### PR TITLE
Added a way to filter values out of the transmitted data.

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -631,7 +631,7 @@ function filterData(data) {
         if (data.request.url) {
             var splitByQuery = data.request.url.split('?');
             each(splitByQuery, function(index, value) {
-                if (index >= 0) {
+                if (index !== 0) {
                     splitByQuery[index] = filterString(splitByQuery[index]);
                 }
             });

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -91,6 +91,16 @@ describe('globals', function() {
         });
     });
 
+    describe('isRegExp', function() {
+        it('should do as advertised', function() {
+            assert.isTrue(isRegExp(new RegExp("asdf")));
+            assert.isTrue(isRegExp(/(somethingcool)/gi));
+            assert.isFalse(isRegExp({}));
+            assert.isFalse(isRegExp(undefined));
+            assert.isFalse(isRegExp(function(){}));
+        });
+    });
+
     describe('isString', function() {
         it('should do as advertised', function() {
             assert.isTrue(isString(''));
@@ -196,6 +206,23 @@ describe('globals', function() {
             // shouldn't hit this
             assert.isTrue(false);
         });
+    });
+    
+    describe('filterString', function() {
+      it('should filter correctly', function() {
+          var filters = [/(\w+\@\w+)\.com/, /(\d{3}-?\d{2}-?\d{4})/, 'SECRET'];
+          
+          assert.strictEqual(filterString('secret', filters), '******');
+          assert.strictEqual(filterString('123-45-6789', filters), '***********');
+          assert.strictEqual(
+              filterString('my email is 1234@5678.com', filters),
+              'my email is *********.com');
+          assert.strictEqual(
+              filterString('some SECRET sentence with multiple SEcREts inside', filters),
+              'some ****** sentence with multiple ******s inside');
+          assert.deepEqual(filterString({'ignore': 'anything that isnt a string (secret)'}, filters),
+              {'ignore': 'anything that isnt a string (secret)'});
+      });
     });
 
     describe('normalizeFrame', function() {
@@ -664,6 +691,39 @@ describe('globals', function() {
                 event_id: 'abc123',
                 extra: {key1: 'value1', key2: 'value2'}
             }]);
+        });
+        
+        it('should filter data sent', function() {
+            this.sinon.stub(window, 'isSetup').returns(true);
+            this.sinon.stub(window, 'makeRequest');
+            this.sinon.stub(window, 'getHttpData').returns({
+                url: 'http://localhost/?email=jeanluc@picard.com&myssn=123-45-6789&another=true',
+                headers: {'User-Agent': 'lolbrowser', 'Extra': 'secret-goes-here'}
+            });
+        
+            globalOptions = {
+                filterValues: [/(\w+\@\w+)\.com/, /(\d{3}-?\d{2}-?\d{4})/, 'SECRET'],
+                projectId: 2,
+                logger: 'javascript',
+                site: 'THE BEST',
+                request: {
+                    url: 'http://localhost/?email=jeanluc@picard.com&myssn=123-45-6789',
+                    headers: {
+                        'User-Agent': 'Chrome'
+                    }
+                }
+            };
+        
+            send({
+                exception: 'some secret exception',
+                message: 'my SSN is 123-45-6789'
+            });
+            var sendObj = window.makeRequest.lastCall.args[0];
+
+            assert.equal(sendObj.request.headers['Extra'], "******-goes-here");
+            assert.equal(sendObj.exception, "some ****** exception");
+            assert.equal(sendObj.message, "my SSN is ***********");
+            assert.equal(sendObj.request.url, "http://localhost/?email=**************.com&myssn=***********&another=true");
         });
 
         it('should let dataCallback override everything', function() {


### PR DESCRIPTION
Added a filterValues option that people can configure with strings or regexes. The transmitted data will filter out those strings and regexes.  In the case of a regex, only the matching group will get filtered, e.g.

/(\w+\@\w+).com/ig

will filter jeanluc@picard.com to **************.com
