### PR TITLE
Add getters for global contexts

### DIFF
--- a/docs/usage/index.rst
+++ b/docs/usage/index.rst
@@ -63,6 +63,12 @@ While a user is logged in, you can tell Sentry to associate errors with user dat
         id: '123'
     })
 
+You can get the current UserContext with ``getUserContext``.
+
+.. code-block:: javascript
+
+    Raven.getUserContext()
+
 If at any point, the user becomes unauthenticated, you can call ``Raven.setUserContext()`` with no arguments to remove their data. *This would only really be useful in a large web app where the user logs in/out without a page reload.*
 
 Capturing a specific message
@@ -96,6 +102,12 @@ You can also set context variables globally to be merged in with future exceptio
     Raven.setExtraContext({ foo: "bar" })
     Raven.setTagsContext({ key: "value" })
 
+You can get current context variables with ``getExtraContext`` and ``getTagsContext``.
+
+.. code-block:: javascript
+
+    Raven.getExtraContext()
+    Raven.getTagsContext()
 
 Getting back an event id
 ~~~~~~~~~~~~~~~~~~~~~~~~

--- a/src/raven.js
+++ b/src/raven.js
@@ -288,6 +288,15 @@ var Raven = {
     },
 
     /*
+     * Get user to be sent along with the payload.
+     *
+     * @return {object}
+     */
+    getUserContext: function() {
+      return globalUser;
+    },
+
+    /*
      * Set extra attributes to be sent along with the payload.
      *
      * @param {object} extra An object representing extra data [optional]
@@ -300,6 +309,15 @@ var Raven = {
     },
 
     /*
+     * Get extra attributes to be sent along with the payload.
+     *
+     * @return {object}
+     */
+    getExtraContext: function() {
+      return globalOptions.extra;
+    },
+
+    /*
      * Set tags to be sent along with the payload.
      *
      * @param {object} tags An object representing tags [optional]
@@ -309,6 +327,15 @@ var Raven = {
        globalOptions.tags = tags || {};
 
        return Raven;
+    },
+
+    /*
+     * Get tags to be sent along with the payload.
+     *
+     * @return {object}
+     */
+    getTagsContext: function() {
+      return globalOptions.tags;
     },
 
     /*

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -16,9 +16,8 @@ function flushRavenState() {
         maxMessageLength: 100,
         tags: {},
         extra: {}
-    },
-    startTime = 0
-    ;
+    };
+    startTime = 0;
 
     Raven.uninstall();
 }
@@ -1522,6 +1521,13 @@ describe('Raven (public API)', function() {
         });
     });
 
+    describe('.getUserContext', function() {
+        it('should get the globalUser object', function() {
+            Raven.setUserContext({name: 'Matt'});
+            assert.deepEqual(Raven.getUserContext(), {name: 'Matt'});
+        });
+    });
+
     describe('.setExtraContext', function() {
         it('should set the globalOptions.extra object', function() {
             Raven.setExtraContext({name: 'Matt'});
@@ -1535,6 +1541,13 @@ describe('Raven (public API)', function() {
         });
     });
 
+    describe('.getExtraContext', function() {
+        it('should get the globalOptions.extra object', function() {
+            Raven.setExtraContext({name: 'Matt'});
+            assert.deepEqual(Raven.getExtraContext(), {name: 'Matt'});
+        });
+    });
+
     describe('.setTagsContext', function() {
         it('should set the globalOptions.tags object', function() {
             Raven.setTagsContext({name: 'Matt'});
@@ -1545,6 +1558,13 @@ describe('Raven (public API)', function() {
             globalOptions = {name: 'Matt'};
             Raven.setTagsContext();
             assert.deepEqual(globalOptions.tags, {});
+        });
+    });
+
+    describe('.getTagsContext', function() {
+        it('should get the globalOptions.tags object', function() {
+            Raven.setTagsContext({name: 'Matt'});
+            assert.deepEqual(Raven.getTagsContext(), {name: 'Matt'});
         });
     });
 


### PR DESCRIPTION
Proposed solution for #285 
- Adds get methods to get usercontext, extracontext, and tagscontext.
- Adds tests for these methods
- Adds docs for these methods in Usage