### PR TITLE
captureMessage() uses global ignoreErrors config

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -261,6 +261,13 @@ var Raven = {
      * @return {Raven}
      */
     captureMessage: function(msg, options) {
+        // config() automagically converts ignoreErrors from a list to a RegExp so we need to test for an
+        // early call; we'll error on the side of logging anything called before configuration since it's
+        // probably something you should see:
+        if (!!globalOptions.ignoreErrors.test && globalOptions.ignoreErrors.test(msg)) {
+            return;
+        }
+
         // Fire away!
         send(
             objectMerge({

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1594,6 +1594,18 @@ describe('Raven (public API)', function() {
             Raven.captureMessage('lol');
             assert.equal(Raven.lastEventId(), 'abc123');
         });
+
+        it('should respect `ignoreErrors`', function() {
+            this.sinon.stub(window, 'send');
+
+            globalOptions.ignoreErrors = joinRegExp(['e1', 'e2']);
+            Raven.captureMessage('e1');
+            assert.isFalse(window.send.called);
+            Raven.captureMessage('e2');
+            assert.isFalse(window.send.called);
+            Raven.captureMessage('Non-ignored error');
+            assert.isTrue(window.send.calledOnce);
+        });
     });
 
     describe('.captureException', function() {


### PR DESCRIPTION
Previously, only errors recorded using captureException were checked against the ignoreErrors regexp. captureMessage will now silently discard messages which match ignoreErrors.

The backstory is that I have code to collect errors which occur before Raven.JS has loaded:

```html
        <script>
            var _raven_queue = [], Raven = {context: function (i) { return i(); }};
            window.onerror = function(message, file, line) {
               var msg = line ? message + " at " + line : message;
               _raven_queue.push([msg, {culprit: file}]);
            }
        </script>
```

and my page uses `<script async>` to load Raven without blocking and logs any errors which happened in the interim:

```js
/* global RAVEN_PUBLIC_DSN, Raven, _raven_queue */

(function() {
    'use strict';

    if (!!RAVEN_PUBLIC_DSN && !!Raven && !!Raven.config) {
        Raven.config(RAVEN_PUBLIC_DSN, {
            ignoreErrors: [
                'bmi_SafeAddOnload',
                'EBCallBackMessageReceived',
                'conduitPage'
            ],
            ignoreUrls: [
                /^extensions\//i,
                /^chrome:\/\//i,
                /.*(twitter|readspeaker).*/i,
                /.*widgets[.]js/
            ]
        }).install();

        for (var i = 0; i < _raven_queue.length; i++) {
            Raven.captureMessage.apply(this, _raven_queue[i]);
        }
    }
}());
```