### PR TITLE
Switched to using callback for determining if error should be sent

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -687,17 +687,23 @@ function send(data) {
         data = globalOptions.dataCallback(data);
     }
 
-    // Check if the request should be filtered or not
-    if (isFunction(globalOptions.shouldSendCallback) && !globalOptions.shouldSendCallback(data)) {
-        return;
+    var shouldSend = function (should) {
+      if (should) {
+        // Send along an event_id if not explicitly passed.
+        // This event_id can be used to reference the error within Sentry itself.
+        // Set lastEventId after we know the error should actually be sent
+        lastEventId = data.event_id || (data.event_id = uuid4());
+
+        makeRequest(data);
+      }
     }
 
-    // Send along an event_id if not explicitly passed.
-    // This event_id can be used to reference the error within Sentry itself.
-    // Set lastEventId after we know the error should actually be sent
-    lastEventId = data.event_id || (data.event_id = uuid4());
-
-    makeRequest(data);
+    // Check if the request should be filtered or not
+    if (isFunction(globalOptions.shouldSendCallback)) {
+      globalOptions.shouldSendCallback(data, shouldSend);
+    } else {
+      shouldSend(true);
+    }
 }
 
 


### PR DESCRIPTION
Not sure if this would be useful to anyone else, but I required the use of a callback function after determining if I'd like an error to be sent to the Sentry platform.

I've just implemented this a basic as possible, as I didn't have much time to look around and see how this project tends to implement similar patterns. So some guidance would be appreciated.
