### PR TITLE
Fix parameters to TraceKit.rethrow

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -237,18 +237,7 @@ var Raven = {
         // Store the raw exception object for potential debugging and introspection
         lastCapturedException = ex;
 
-        // TraceKit.report will re-raise any exception passed to it,
-        // which means you have to wrap it in try/catch. Instead, we
-        // can wrap it here and only re-raise if TraceKit.report
-        // raises an exception different from the one we asked to
-        // report on.
-        try {
-            TraceKit.report(ex, options);
-        } catch(ex1) {
-            if(ex !== ex1) {
-                throw ex1;
-            }
-        }
+        TraceKit.report(ex, options);
 
         return Raven;
     },

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -212,11 +212,9 @@ TraceKit.report = (function reportModuleWrapper() {
     /**
      * Reports an unhandled Error to TraceKit.
      * @param {Error} ex
-     * @param {?boolean} rethrow If false, do not re-throw the exception.
-     * Only used for window.onerror to not cause an infinite loop of
-     * rethrowing.
+     * @param {...*} extraArgs Any arguments to pass to the registered handlers.
      */
-    function report(ex, rethrow) {
+    function report(ex, extraArgs) {
         var args = _slice.call(arguments, 1);
         if (lastExceptionStack) {
             if (lastException === ex) {
@@ -240,10 +238,6 @@ TraceKit.report = (function reportModuleWrapper() {
                 processLastException();
             }
         }, (stack.incomplete ? 2000 : 0));
-
-        if (rethrow !== false) {
-            throw ex; // re-throw to propagate to the top level (and cause window.onerror)
-        }
     }
 
     report.subscribe = subscribe;


### PR DESCRIPTION
* Do not pass options array. TraceKit expects a boolean so it
  doesn't do anything useful.
* Pass false to disable rethrowing errors. Raven would catch them
  again so it is pointless, and it can pollute the stack trace
  (since TraceKit doesn't extract information from it unnecessarily).
* Remove the try-catch that was made unnecessary by the change.

This should fix #300.