### PR TITLE
Capture unhandled errors from promises

### DIFF
--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -18,6 +18,8 @@ Ember.onerror = function EmberOnError(error) {
         _oldOnError.call(this, error);
     }
 };
-
+Ember.RSVP.on('error', function (err) {
+  Raven.captureException(err);
+});
 
 }(window, window.Raven, window.Ember));


### PR DESCRIPTION
Based on [this](https://github.com/tildeio/rsvp.js#error-handling) to help detect swallowed errors.
