### PR TITLE
Improve the capture of unhandled errors from promises

### DIFF
--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -20,7 +20,7 @@ Ember.onerror = function EmberOnError(error) {
 };
 Ember.RSVP.on('error', function (reason) {
     if (reason instanceof Error) {
-        Raven.captureException(reason, {extra: {context: 'Unhandled RSVP error'}});
+        Raven.captureException(reason, {extra: {context: 'Unhandled Promise error detected'}});
     } else {
         Raven.captureMessage('Unhandled Promise error detected', {extra: {reason: reason}});
     }

--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -22,11 +22,7 @@ Ember.RSVP.on('error', function (reason) {
     if (reason instanceof Error) {
         Raven.captureException(reason, {extra: {context: 'Unhandled RSVP error'}});
     } else {
-        try {
-            throw new Error('Unhandled Promise error detected');
-        } catch (err) {
-            Raven.captureException(err, {extra: {reason: reason}});
-        }
+        Raven.captureMessage('Unhandled Promise error detected', {extra: {reason: reason}});
     }
 });
 

--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -20,7 +20,7 @@ Ember.onerror = function EmberOnError(error) {
 };
 Ember.RSVP.on('error', function (reason) {
     if (reason instanceof Error) {
-        Raven.captureException(reason);
+        Raven.captureException(reason, {extra: {context: 'Unhandled RSVP error'}});
     } else {
         try {
             throw new Error('Unhandled Promise error detected');

--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -18,8 +18,16 @@ Ember.onerror = function EmberOnError(error) {
         _oldOnError.call(this, error);
     }
 };
-Ember.RSVP.on('error', function (err) {
-  Raven.captureException(err);
+Ember.RSVP.on('error', function (reason) {
+    if (reason instanceof Error) {
+        Raven.captureException(reason);
+    } else {
+        try {
+            throw new Error('Unhandled Promise error detected');
+        } catch (err) {
+            Raven.captureException(err, {extra: {reason: reason}});
+        }
+    }
 });
 
 }(window, window.Raven, window.Ember));


### PR DESCRIPTION
After using the code behind #319 for about a week, we ran into a little problem.

Even though it's recommended that `Promise.reject` passes in an `Error` instance, not all 3rd-party libraries do. This lead to production errors with `[object Object]` as the error message, which wasn't very helpful.

This fixes the problem by creating a new error (for the stack trace), if one wasn't provided, and passing the `reason` object as `extra` context.
