### PR TITLE
fix possible ie8 trailing comma problem

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -684,7 +684,7 @@ function send(data) {
 
     // Send along our own collected metadata with extra
     data.extra = objectMerge({
-        'session:duration': now() - startTime,
+        'session:duration': now() - startTime
     }, data.extra);
 
     // If there are no tags/extra, strip the key from the payload alltogther.


### PR DESCRIPTION
I faced with exception on 678 string of raven.js with IE versions less than 8 and below. Google Closure Compiler thrown errors too...

This fixes the issue. All tests passed, full build successful too.

Thanks.