### PR TITLE
Improved image creation

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -717,7 +717,7 @@ function send(data) {
 
 
 function makeRequest(data) {
-    var img = new Image(),
+    var img = document.createElement('img'),
         src = globalServer + authQueryString + '&sentry_data=' + encodeURIComponent(JSON.stringify(data));
 
     img.crossOrigin = 'anonymous';


### PR DESCRIPTION
`new Image()` creation can trigger a bug into an older version of Chrome.
I suggest the 'more compliant' way to create a node into the dom.

http://stackoverflow.com/questions/15469763/an-attempt-was-made-to-reference-a-node-in-a-context-where-it-does-not-exist