### PR TITLE
Workaround for nodeunit

### DIFF
--- a/template/_footer.js
+++ b/template/_footer.js
@@ -16,4 +16,12 @@ if (typeof define === 'function' && define.amd) {
     window.Raven = Raven;
 }
 
-})(window);
+})(
+  (function() {
+    if (typeof window !== 'undefined') {
+      return window;
+    } else {
+      return this;
+    }
+  })()
+);


### PR DESCRIPTION
Using nodeunit on a project which use browserify, return an error like
```
/home/bud/my_secret_project/node_modules/raven-js/dist/raven.js:1871
 })((function() { if (window) { return window; } else { return this;} })());
                      ^
 ReferenceError: window is not defined
```

Obviously in a node context the window is not defined, passing `this` arguments is fine to run the tests.

I have tested (with internal tests) this patch and the result was:
```
./node_modules/.bin/grunt test dist
Running "jshint:all" (jshint) task
>> 9 files lint free.

Running "mocha:all" (mocha) task
Testing: test/index.html

  
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․Error: Raven has not been configured.
․․․․․․․․․․․․․․
  ․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․․

  124 passing (8s)

>> 124 passed! (8.31s)

Running "clean:0" (clean) task
Cleaning "build"...OK

Running "gitinfo" task

Running "version" task

Running "concat:core" (concat) task
File "build/raven.js" created.

Running "uglify:dist" (uglify) task
Source Map "build/raven.min.map" created.
File "build/raven.min.js" created.

Running "fixSourceMaps:all" (fixSourceMaps) task
File "build/raven.min.map" fixed.

Running "copy:dist" (copy) task
Created 1 directories, copied 3 files

Done, without errors.
```