### PR TITLE
Add support for options.via

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -88,13 +88,20 @@ var Raven = {
         globalKey = uri.user;
         globalProject = uri.path.substr(lastSlash + 1);
 
-        // assemble the endpoint from the uri pieces
-        globalServer = '//' + uri.host +
-                      (uri.port ? ':' + uri.port : '') +
-                      '/' + path + 'api/' + globalProject + '/store/';
+        if (globalOptions.via) {
+            // Support proxying through another endpoint
+            globalServer = globalOptions.via;
+            setAuthQueryString(dsn);
+        } else {
+            // assemble the endpoint from the uri pieces
+            globalServer = '//' + uri.host +
+                          (uri.port ? ':' + uri.port : '') +
+                          '/' + path + 'api/' + globalProject + '/store/';
 
-        if (uri.protocol) {
-            globalServer = uri.protocol + ':' + globalServer;
+            if (uri.protocol) {
+                globalServer = uri.protocol + ':' + globalServer;
+            }
+            setAuthQueryString();
         }
 
         if (globalOptions.fetchContext) {
@@ -106,8 +113,6 @@ var Raven = {
         }
 
         TraceKit.collectWindowErrors = !!globalOptions.collectWindowErrors;
-
-        setAuthQueryString();
 
         // return for chaining
         return Raven;
@@ -501,11 +506,12 @@ function each(obj, callback) {
 }
 
 
-function setAuthQueryString() {
+function setAuthQueryString(dsn) {
+    // If we pass a DSN, we want to send sentry_dsn, else send sentry_key
     authQueryString =
         '?sentry_version=4' +
         '&sentry_client=raven-js/' + Raven.VERSION +
-        '&sentry_key=' + globalKey;
+        (isUndefined(dsn) ? '&sentry_key=' + globalKey : '&sentry_dsn=' + encodeURIComponent(dsn));
 }
 
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -304,6 +304,12 @@ describe('globals', function() {
             setAuthQueryString();
             assert.strictEqual(authQueryString, expected);
         });
+
+        it('should set sentry_dsn if set', function() {
+            var expected = '?sentry_version=4&sentry_client=raven-js/<%= pkg.version %>&sentry_dsn=http%3A%2F%2Fexample.com%2F2';
+            setAuthQueryString('http://example.com/2');
+            assert.strictEqual(authQueryString, expected);
+        });
     });
 
     describe('parseDSN', function() {
@@ -1343,6 +1349,12 @@ describe('Raven (public API)', function() {
 
         it('should return Raven for a falsey dsn', function() {
             assert.equal(Raven.config(''), Raven);
+        });
+
+        it('should accept via as a proxy', function() {
+            Raven.config('http://a@example.com/2', {via: 'http://example.com/via'});
+            assert.equal(globalServer, 'http://example.com/via');
+            assert.equal(authQueryString, '?sentry_version=4&sentry_client=raven-js/<%= pkg.version %>&sentry_dsn=http%3A%2F%2Fa%40example.com%2F2')
         });
 
         it('should not set global options more than once', function() {


### PR DESCRIPTION
options.via allows the use of a proxy endpoint, which will
forward along the request, and pass ``sentry_dsn`` in
the querystring instead of ``sentry_key``.

Fixes #346