### PR TITLE
Don't require a user in the DSN

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -423,7 +423,7 @@ function triggerEvent(eventType, options) {
 }
 
 var dsnKeys = 'source protocol user pass host port path'.split(' '),
-    dsnPattern = /^(?:(\w+):)?\/\/(\w+)(:\w+)?@([\w\.-]+)(?::(\d+))?(\/.*)/;
+    dsnPattern = /^(?:(\w+):)?\/\/(?:(\w+)(:\w+)?@)?([\w\.-]+)(?::(\d+))?(\/.*)/;
 
 function RavenConfigError(message) {
     this.name = 'RavenConfigError';

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -359,6 +359,15 @@ describe('globals', function() {
             assert.strictEqual(pieces.host, 'matt-robenolt.com');
         });
 
+        it('should parse domain without user', function() {
+            var pieces = parseDSN('http://matt-robenolt.com/1');
+            assert.strictEqual(pieces.protocol, 'http');
+            assert.strictEqual(pieces.user, '');
+            assert.strictEqual(pieces.port, '');
+            assert.strictEqual(pieces.path, '/1');
+            assert.strictEqual(pieces.host, 'matt-robenolt.com');
+        });
+
         it('should raise a RavenConfigError when setting a password', function() {
             try {
                 parseDSN('http://user:pass@example.com/2');


### PR DESCRIPTION
`raven-js` requires a user part in the DSN passed to `Raven.config`, but in some scenarios this isn't desired. This PR makes `user` and optional part.

In our configuration, our sentry instance isn't publicly available, and we proxy requests from our frontend application through our backend app for reporting; because of this, we use our already authenticated users (and sentry auth is handled via the backend). We were on a very old version of `raven-js` which did not have this restriction. This restriction blocks us from being able to upgrade.

Let me know if you have any questions/requests, and thanks for your time!