### PR TITLE
Add crossOrigin option

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -17,6 +17,7 @@ var _Raven = window.Raven,
         ignoreUrls: [],
         whitelistUrls: [],
         includePaths: [],
+        crossOrigin: 'anonymous',
         collectWindowErrors: true,
         tags: {},
         maxMessageLength: 100,
@@ -759,7 +760,10 @@ function makeRequest(data) {
     var img = newImage(),
         src = globalServer + authQueryString + '&sentry_data=' + encodeURIComponent(JSON.stringify(data));
 
-    img.crossOrigin = 'anonymous';
+    if (globalOptions.crossOrigin) {
+        img.crossOrigin = globalOptions.crossOrigin;
+    }
+
     img.onload = function success() {
         triggerEvent('success', {
             data: data,

--- a/src/raven.js
+++ b/src/raven.js
@@ -760,7 +760,7 @@ function makeRequest(data) {
     var img = newImage(),
         src = globalServer + authQueryString + '&sentry_data=' + encodeURIComponent(JSON.stringify(data));
 
-    if (globalOptions.crossOrigin) {
+    if (globalOptions.crossOrigin || globalOptions.crossOrigin === '') {
         img.crossOrigin = globalOptions.crossOrigin;
     }
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1081,15 +1081,38 @@ describe('globals', function() {
     });
 
     describe('makeRequest', function() {
+        var imageCache;
+
+        beforeEach(function () {
+            imageCache = [];
+            this.sinon.stub(window, 'newImage', function(){ var img = {}; imageCache.push(img); return img; });
+        })
+
         it('should load an Image', function() {
             authQueryString = '?lol';
             globalServer = 'http://localhost/';
-            var imageCache = [];
-            this.sinon.stub(window, 'newImage', function(){ var img = {}; imageCache.push(img); return img; });
 
             makeRequest({foo: 'bar'});
             assert.equal(imageCache.length, 1);
             assert.equal(imageCache[0].src, 'http://localhost/?lol&sentry_data=%7B%22foo%22%3A%22bar%22%7D');
+        });
+
+        it('should populate crossOrigin based on globalOptions', function() {
+            globalOptions = {
+                crossOrigin: 'something'
+            };
+            makeRequest({foo: 'bar'});
+            assert.equal(imageCache.length, 1);
+            assert.equal(imageCache[0].crossOrigin, 'something');
+        });
+
+        it('should not populate crossOrigin if falsey', function() {
+            globalOptions = {
+                crossOrigin: false
+            };
+            makeRequest({foo: 'bar'});
+            assert.equal(imageCache.length, 1);
+            assert.isUndefined(imageCache[0].crossOrigin);
         });
     });
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1106,6 +1106,15 @@ describe('globals', function() {
             assert.equal(imageCache[0].crossOrigin, 'something');
         });
 
+        it('should populate crossOrigin if empty string', function() {
+            globalOptions = {
+                crossOrigin: ''
+            };
+            makeRequest({foo: 'bar'});
+            assert.equal(imageCache.length, 1);
+            assert.equal(imageCache[0].crossOrigin, '');
+        });
+
         it('should not populate crossOrigin if falsey', function() {
             globalOptions = {
                 crossOrigin: false


### PR DESCRIPTION
Automatically detecting whether the crossOrigin option is needed is unreliable
as outlined in this SO answer: http://stackoverflow.com/a/9569822/315562

- Lets user workaround [issue in Chrome](https://code.google.com/p/chromium/issues/detail?id=412163) where requests with `crossOrigin` attribute aren't sent with expected cookies when making request to same origin
- Allows usage `use-credentials` for internal configurations where Sentry is behind a reverse proxy which requires credentials

Resolves #344