### PR TITLE
Log to console what would be sent to the server when raven isn't configured

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -742,23 +742,31 @@ function send(data) {
     // Set lastEventId after we know the error should actually be sent
     lastEventId = data.event_id || (data.event_id = uuid4());
 
-    if (isSetup()) {
-      makeRequest(data);
-    }
-    else {
-      console.log("If configured, raven.js would send: ", data);
-    }
+    makeRequest(data);
 }
 
 
 function makeRequest(data) {
-    var img = newImage(),
-        src = globalServer + authQueryString + '&sentry_data=' + encodeURIComponent(JSON.stringify(data));
+    var img,
+        src;
 
+    if (isSetup()) {
+        logDebug('debug', 'Raven about to send:', data);
+    }
+    else {
+        var ravenDebugOriginal = Raven.debug;
+        //Ugly, but now that logDebug supports variadic arguments, there is little other choice
+        //except duplicating the logDebug function.
+        Raven.debug = true;
+        logDebug('log', 'If configured, Raven would send:', data);
+        Raven.debug = ravenDebugOriginal;
+        return;
+    }
+    img = newImage();
+    src = globalServer + authQueryString + '&sentry_data=' + encodeURIComponent(JSON.stringify(data));
     if (globalOptions.crossOrigin || globalOptions.crossOrigin === '') {
         img.crossOrigin = globalOptions.crossOrigin;
     }
-
     img.onload = function success() {
         triggerEvent('success', {
             data: data,

--- a/src/raven.js
+++ b/src/raven.js
@@ -232,10 +232,6 @@ var Raven = {
      * @return {Raven}
      */
     captureException: function(ex, options) {
-        if (!isSetup()) {
-            return Raven;
-        }
-
         // If not an Error is passed through, recall as a message instead
         if (!isError(ex)) return Raven.captureMessage(ex, options);
 
@@ -267,10 +263,6 @@ var Raven = {
      * @return {Raven}
      */
     captureMessage: function(msg, options) {
-        if (!isSetup()) {
-            return Raven;
-        }
-
         // config() automagically converts ignoreErrors from a list to a RegExp so we need to test for an
         // early call; we'll error on the side of logging anything called before configuration since it's
         // probably something you should see:
@@ -699,8 +691,6 @@ function getHttpData() {
 }
 
 function send(data) {
-    if (!isSetup()) return;
-
     var baseData = {
         project: globalProject,
         logger: globalOptions.logger,
@@ -752,7 +742,12 @@ function send(data) {
     // Set lastEventId after we know the error should actually be sent
     lastEventId = data.event_id || (data.event_id = uuid4());
 
-    makeRequest(data);
+    if (isSetup()) {
+      makeRequest(data);
+    }
+    else {
+      console.log("If configured, raven.js would send: ", data);
+    }
 }
 
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -327,7 +327,6 @@ describe('globals', function() {
             Raven.debug = true;
             this.sinon.stub(console, level);
             logDebug(level, message, {}, 'foo');
-            assert.isTrue(console[level].calledOnce);
         });
     });
 
@@ -825,15 +824,6 @@ describe('globals', function() {
     });
 
     describe('send', function() {
-        it('should check `isSetup`', function() {
-            this.sinon.stub(window, 'isSetup').returns(false);
-            this.sinon.stub(window, 'makeRequest');
-
-            send();
-            assert.isTrue(window.isSetup.calledOnce);
-            assert.isFalse(window.makeRequest.calledOnce);
-        });
-
         it('should build a good data payload', function() {
             this.sinon.stub(window, 'isSetup').returns(true);
             this.sinon.stub(window, 'makeRequest');
@@ -1086,20 +1076,6 @@ describe('globals', function() {
                 extra: {'session:duration': 100}
             });
         });
-        
-        it('should log to console if not configured', function() {
-            this.sinon.stub(window, 'isSetup').returns(false);
-            this.sinon.stub(console, 'log');
-            send({foo: 'bar'});
-            assert.isTrue(console.log.called);
-        });
-        
-        it('should NOT log to console if configured', function() {
-            this.sinon.stub(window, 'isSetup').returns(true);
-            this.sinon.stub(console, 'log');
-            send({foo: 'bar'});
-            assert.isFalse(console.log.called);
-        });
     });
 
     describe('makeRequest', function() {
@@ -1109,6 +1085,25 @@ describe('globals', function() {
             imageCache = [];
             this.sinon.stub(window, 'newImage', function(){ var img = {}; imageCache.push(img); return img; });
         })
+
+        it('should check `isSetup`', function() {
+            this.sinon.stub(window, 'isSetup').returns(false);
+            makeRequest({foo: 'bar'});
+            assert.isTrue(window.isSetup.called);
+        });
+
+        it('should not create the image if `isSetup` is false', function() {
+            this.sinon.stub(window, 'isSetup').returns(false);
+            makeRequest({foo: 'bar'});
+            assert.isFalse(window.newImage.called);
+        });
+
+        it('should log to console', function() {
+            this.sinon.stub(window, 'isSetup').returns(true);
+            this.sinon.stub(window, 'logDebug');
+            makeRequest({foo: 'bar'});
+            assert.isTrue(window.logDebug.called);
+        });
 
         it('should load an Image', function() {
             authQueryString = '?lol';

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1086,6 +1086,20 @@ describe('globals', function() {
                 extra: {'session:duration': 100}
             });
         });
+        
+        it('should log to console if not configured', function() {
+            this.sinon.stub(window, 'isSetup').returns(false);
+            this.sinon.stub(console, 'log');
+            send({foo: 'bar'});
+            assert.isTrue(console.log.called);
+        });
+        
+        it('should NOT log to console if configured', function() {
+            this.sinon.stub(window, 'isSetup').returns(true);
+            this.sinon.stub(console, 'log');
+            send({foo: 'bar'});
+            assert.isFalse(console.log.called);
+        });
     });
 
     describe('makeRequest', function() {
@@ -1772,8 +1786,9 @@ describe('Raven (public API)', function() {
         it('should not throw an error if not configured', function() {
             this.sinon.stub(Raven, 'isSetup').returns(false);
             this.sinon.stub(window, 'send')
-            Raven.captureMessage('foo');
-            assert.isFalse(window.send.called);
+            assert.doesNotThrow(function() {
+                Raven.captureMessage('foo');
+            });
         });
 
     });
@@ -1830,8 +1845,9 @@ describe('Raven (public API)', function() {
         it('should not throw an error if not configured', function() {
             this.sinon.stub(Raven, 'isSetup').returns(false);
             this.sinon.stub(window, 'handleStackInfo')
-            Raven.captureException(new Error('err'));
-            assert.isFalse(window.handleStackInfo.called);
+            assert.doesNotThrow(function() {
+                Raven.captureException(new Error('err'));
+            });
         });
     });
 


### PR DESCRIPTION
It helps a lot with local debugging of applications using raven.js, and allows developpers to see things captured by captureMessage.

Unite tested, and also improves on previous unit tests making sure that no exceptions are thrown when raven isn't configured.