### PR TITLE
Change logLevel in isSetup from error to warn.  Error stops processin…

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -787,7 +787,7 @@ function isSetup() {
     if (!hasJSON) return false;  // needs JSON support
     if (!globalServer) {
         if (!ravenNotConfiguredError)
-          logDebug('error', 'Error: Raven has not been configured.');
+          logDebug('warn', 'Warning: Raven has not been configured.');
         ravenNotConfiguredError = true;
         return false;
     }

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -308,7 +308,7 @@ describe('globals', function() {
             globalServer = undefined;
             isSetup();
             isSetup();
-            assert.isTrue(window.logDebug.calledWith('error', 'Error: Raven has not been configured.'))
+            assert.isTrue(window.logDebug.calledWith('warn', 'Warning: Raven has not been configured.'))
             assert.isTrue(window.logDebug.calledOnce);
           });
         });


### PR DESCRIPTION
…g, and perhaps should be prohibited by logDebug.  Fixes functional problem with the merge of https://github.com/getsentry/raven-js/pull/364

@benvinegar Can you take a look.  I don't know why console.error stops processing.  It generates a backtrace, maybe that's the reason.  Replacing it with a console.warn everything works fine.