### PR TITLE
Avoid recursion when using the console plugin

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -25,9 +25,9 @@ var logForGivenLevel = function(level) {
         if (originalConsoleLevel) {
             // IE9 doesn't allow calling apply on console functions directly
             // See: https://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function#answer-5473193
-             Function.prototype.bind
-                 .call(originalConsoleLevel, originalConsole)
-                 .apply(originalConsole, args);
+            Function.prototype.bind
+                .call(originalConsoleLevel, originalConsole)
+                .apply(originalConsole, args);
         }
     };
 };

--- a/src/raven.js
+++ b/src/raven.js
@@ -25,8 +25,10 @@ var _Raven = window.Raven,
     },
     authQueryString,
     isRavenInstalled = false,
-
     objectPrototype = Object.prototype,
+    // capture a reference to window.console first before
+    // the console plugin has a chance to monkey patch
+    originalConsole = window.console || {},
     startTime = now();
 
 /*
@@ -850,10 +852,10 @@ function uuid4() {
 }
 
 function logDebug(level) {
-    if (window.console && console[level] && Raven.debug) {
+    if (originalConsole[level] && Raven.debug) {
         // _slice is coming from vendor/TraceKit/tracekit.js
         // so it's accessible globally
-        console[level].apply(console, _slice.call(arguments, 1));
+        originalConsole[level].apply(originalConsole, _slice.call(arguments, 1));
     }
 }
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -21,6 +21,7 @@ function flushRavenState() {
     },
     startTime = 0;
     ravenNotConfiguredError = undefined;
+    originalConsole = window.console || {};
 
     Raven.uninstall();
 }
@@ -325,21 +326,21 @@ describe('globals', function() {
 
         it('should not write to console when Raven.debug is false', function() {
             Raven.debug = false;
-            this.sinon.stub(console, level);
+            this.sinon.stub(originalConsole, level);
             logDebug(level, message);
-            assert.isFalse(console[level].called);
+            assert.isFalse(originalConsole[level].called);
         });
 
         it('should write to console when Raven.debug is true', function() {
             Raven.debug = true;
-            this.sinon.stub(console, level);
+            this.sinon.stub(originalConsole, level);
             logDebug(level, message);
-            assert.isTrue(console[level].calledOnce);
+            assert.isTrue(originalConsole[level].calledOnce);
         });
 
         it('should handle variadic arguments', function() {
             Raven.debug = true;
-            this.sinon.stub(console, level);
+            this.sinon.stub(originalConsole, level);
             logDebug(level, message, {}, 'foo');
         });
     });


### PR DESCRIPTION
Store a global reference to `window.console` before the `console` plugin gets a chance to monkey patch, avoiding it recursing on itself.

Fixes #320 #364 #369