### PR TITLE
Ignore level in logDebug. 

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -855,7 +855,12 @@ function logDebug(level) {
     if (originalConsole[level] && Raven.debug) {
         // _slice is coming from vendor/TraceKit/tracekit.js
         // so it's accessible globally
-        originalConsole[level].apply(originalConsole, _slice.call(arguments, 1));
+        //The console plugin cause infinite recursion if logDebug is called
+        //See https://github.com/getsentry/raven-js/issues/373
+        //originalConsole[level].apply(originalConsole, _slice.call(arguments, 1));
+        //As a temporary workaround, we ignore the level and call 'log', which
+        //is ignored by the console plugin
+        originalConsole.log.apply(originalConsole, _slice.call(arguments, 1));
     }
 }
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -327,15 +327,21 @@ describe('globals', function() {
         it('should not write to console when Raven.debug is false', function() {
             Raven.debug = false;
             this.sinon.stub(originalConsole, level);
+            this.sinon.stub(originalConsole, 'log');
             logDebug(level, message);
-            assert.isFalse(originalConsole[level].called);
+            //Temporary fix, see https://github.com/getsentry/raven-js/issues/373
+            //assert.isFalse(originalConsole[level].called);
+            assert.isFalse(originalConsole.log.called);
         });
 
         it('should write to console when Raven.debug is true', function() {
             Raven.debug = true;
             this.sinon.stub(originalConsole, level);
+            this.sinon.stub(originalConsole, 'log');
             logDebug(level, message);
-            assert.isTrue(originalConsole[level].calledOnce);
+            //Temporary fix, see https://github.com/getsentry/raven-js/issues/373
+            //assert.isTrue(originalConsole[level].calledOnce);
+            assert.isTrue(originalConsole.log.calledOnce);
         });
 
         it('should handle variadic arguments', function() {


### PR DESCRIPTION
 Workaround for https://github.com/getsentry/raven-js/issues/373, avoids crashing raven-js when both the console plugin is loaded and Raven.debug===true.