### PR TITLE
Set Raven.debug using angular RavenConfig

### DIFF
--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -22,6 +22,10 @@ function ngRavenExceptionHandler(RavenConfig, $delegate) {
     if (!RavenConfig)
         throw new Error('RavenConfig must be set before using this');
 
+    if (RavenConfig.debug !== void 0) {
+      Raven.debug = RavenConfig.debug;
+    }
+
     Raven.config(RavenConfig.dsn, RavenConfig.config).install();
     return function angularExceptionHandler(ex, cause) {
         $delegate(ex, cause);


### PR DESCRIPTION
Raven must be loaded after Angular. We concatenate all our angular code, so if Angular loads first, our `RavenConfig` block is loaded before `Raven`, making it difficult to closurize `window.Raven` when `RavenConfig` is loaded. Might as well just stick `debug` onto `RavenConfig` since `dsn` is on there too, and initialize `debug` the angular way.