### PR TITLE
Lazy load plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@
 * NEW: Add `Raven.clearContext()` to empty all of the context.
 * NEW: Add `Raven.getContext()` to get a copy of the current context.
 * NEW: `Raven.set{Extra,Tags}Context(ctx)` now merges with existing values instead of overwriting.
+* NEW: Add `Raven.addPlugin()` to register a plugin to be initialized when installed.
+* NEW: Plugins are now initialized and loaded when calling `Raven.install()`. This avoid some race conditions with load order.
 
 ## 1.1.22
 

--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -3,13 +3,17 @@
  *
  * Provides an $exceptionHandler for Angular.js
  */
-;(function(Raven, angular) {
+;(function(window) {
 'use strict';
 
+var angular = window.angular,
+    Raven = window.Raven;
+
 // quit if angular isn't on the page
-if (!angular) {
-    return;
-}
+if (!(angular && Raven)) return;
+
+// Angular plugin doesn't go through the normal `Raven.addPlugin`
+// since this bootstraps the `install()` automatically.
 
 function ngRavenProvider($provide) {
     $provide.decorator('$exceptionHandler', [
@@ -37,4 +41,4 @@ angular.module('ngRaven', [])
     .config(['$provide', ngRavenProvider])
     .value('Raven', Raven);
 
-})(window.Raven, window.angular);
+}(typeof window !== 'undefined' ? window : this));

--- a/plugins/backbone.js
+++ b/plugins/backbone.js
@@ -3,13 +3,15 @@
  *
  * Patches Backbone.Events callbacks.
  */
-;(function(window, Raven, Backbone) {
+;(function(window) {
 'use strict';
 
+if (window.Raven) Raven.addPlugin(function backbonePlugin() {
+
+var Backbone = window.Backbone;
+
 // quit if Backbone isn't on the page
-if (!Backbone) {
-    return;
-}
+if (!Backbone) return;
 
 function makeBackboneEventsOn(oldOn) {
   return function BackboneEventsOn(name, callback, context) {
@@ -52,4 +54,6 @@ for (; i < l; i++) {
   affected.bind = affected.on;
 }
 
-}(window, window.Raven, window.Backbone));
+});
+
+}(typeof window !== 'undefined' ? window : this));

--- a/plugins/console.js
+++ b/plugins/console.js
@@ -4,8 +4,12 @@
  * Monkey patches console.* calls into Sentry messages with
  * their appropriate log levels. (Experimental)
  */
-;(function(window, Raven, console) {
+;(function(window) {
 'use strict';
+
+if (window.Raven) Raven.addPlugin(function ConsolePlugin() {
+
+var console = window.console || {};
 
 var originalConsole = console,
     logLevels = ['debug', 'info', 'warn', 'error'],
@@ -37,7 +41,12 @@ while(level) {
     console[level] = logForGivenLevel(level);
     level = logLevels.pop();
 }
+
 // export
 window.console = console;
 
-}(window, window.Raven, window.console || {}));
+// End of plugin factory
+});
+
+// console would require `window`, so we don't allow it to be optional
+}(window));

--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -3,13 +3,15 @@
  *
  * Patches event handler callbacks and ajax callbacks.
  */
-;(function(window, Raven, Ember) {
+;(function(window) {
 'use strict';
 
+if (window.Raven) Raven.addPlugin(function EmberPlugin() {
+
+var Ember = window.Ember;
+
 // quit if Ember isn't on the page
-if (!Ember) {
-    return;
-}
+if (!Ember) return;
 
 var _oldOnError = Ember.onerror;
 Ember.onerror = function EmberOnError(error) {
@@ -26,4 +28,7 @@ Ember.RSVP.on('error', function (reason) {
     }
 });
 
-}(window, window.Raven, window.Ember));
+// End of plugin factory
+});
+
+}(typeof window !== 'undefined' ? window : this));

--- a/plugins/jquery.js
+++ b/plugins/jquery.js
@@ -3,13 +3,15 @@
  *
  * Patches event handler callbacks and ajax callbacks.
  */
-;(function(window, Raven, $) {
+;(function(window) {
 'use strict';
 
+if (window.Raven) Raven.addPlugin(function jQueryPlugin() {
+
+var $ = window.jQuery;
+
 // quit if jQuery isn't on the page
-if (!$) {
-    return;
-}
+if (!$) return;
 
 var _oldEventAdd = $.event.add;
 $.event.add = function ravenEventAdd(elem, types, handler, data, selector) {
@@ -100,4 +102,7 @@ $.Deferred = function ravenDeferredWrapper(func) {
     });
 };
 
-}(window, window.Raven, window.jQuery));
+// End of plugin factory
+});
+
+}(typeof window !== 'undefined' ? window : this));

--- a/plugins/native.js
+++ b/plugins/native.js
@@ -4,8 +4,10 @@
  * Extends support for global error handling for asynchronous browser
  * functions. Adopted from Closure Library's errorhandler.js.
  */
-;(function extendToAsynchronousCallbacks(window, Raven) {
-"use strict";
+;(function(window) {
+'use strict';
+
+if (window.Raven) Raven.addPlugin(function nativePlugin() {
 
 var _helper = function _helper(fnName) {
     var originalFn = window[fnName];
@@ -30,4 +32,7 @@ var _helper = function _helper(fnName) {
 _helper('setTimeout');
 _helper('setInterval');
 
-}(window, window.Raven));
+// End of plugin factory
+});
+
+}(typeof window !== 'undefined' ? window : this));

--- a/plugins/require.js
+++ b/plugins/require.js
@@ -3,12 +3,17 @@
  *
  * Automatically wrap define/require callbacks. (Experimental)
  */
-;(function(window, Raven) {
+;(function(window) {
 'use strict';
+
+if (window.Raven) Raven.addPlugin(function RequirePlugin() {
 
 if (typeof define === 'function' && define.amd) {
     window.define = Raven.wrap({deep: false}, define);
     window.require = Raven.wrap({deep: false}, require);
 }
 
-}(window, window.Raven));
+// End of plugin factory
+});
+
+}(window));

--- a/src/raven.js
+++ b/src/raven.js
@@ -29,6 +29,7 @@ var _Raven = window.Raven,
     // before the console plugin has a chance to monkey patch
     originalConsole = window.console || {},
     originalConsoleMethods = {},
+    plugins = [],
     startTime = now();
 
 for (var method in originalConsole) {
@@ -133,6 +134,12 @@ var Raven = {
     install: function() {
         if (isSetup() && !isRavenInstalled) {
             TraceKit.report.subscribe(handleStackInfo);
+
+            // Install all of the plugins
+            each(plugins, function(_, plugin) {
+                plugin();
+            });
+
             isRavenInstalled = true;
         }
 
@@ -285,6 +292,12 @@ var Raven = {
             }, options)
         );
 
+        return Raven;
+    },
+
+    addPlugin: function(plugin) {
+        plugins.push(plugin);
+        if (isRavenInstalled) plugin();
         return Raven;
     },
 


### PR DESCRIPTION
This defers the installation and loading of plugins until
`Raven.install()` is called.

Should fix up issues around #384 I believe, since it'll be less important.