### PR TITLE
Always expose window.Raven no matter what the loader is

### DIFF
--- a/template/_footer.js
+++ b/template/_footer.js
@@ -1,7 +1,10 @@
+// This is being exposed no matter what because there are too many weird
+// usecases for how people use Raven. If this is really a problem, I'm sorry.
+window.Raven = Raven;
+
 // Expose Raven to the world
 if (typeof define === 'function' && define.amd) {
     // AMD
-    window.Raven = Raven;
     define('raven', [], function() {
       return Raven;
     });
@@ -11,9 +14,6 @@ if (typeof define === 'function' && define.amd) {
 } else if (typeof exports === 'object') {
     // CommonJS
     exports = Raven;
-} else {
-    // Everything else
-    window.Raven = Raven;
 }
 
 })(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
This is problematic for many use cases, but the primary case is when
window.module exists already, and someone loads raven.js from a <script>
tag, the global window.Raven never exists any causes things to break and
is a bit confusing.