### PR TITLE
Log arguments in extra so that they do not need to be stringified

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -23,7 +23,7 @@ var logForGivenLevel = function(level) {
     if (level === 'warn') level = 'warning';
     return function () {
         var args = [].slice.call(arguments);
-        Raven.captureMessage('' + args[0], {level: level, logger: 'console', extra: { args: args }});
+        Raven.captureMessage('' + args[0], {level: level, logger: 'console', extra: { arguments: args }});
 
         // this fails for some browsers. :(
         if (originalConsoleLevel) {

--- a/plugins/console.js
+++ b/plugins/console.js
@@ -23,7 +23,7 @@ var logForGivenLevel = function(level) {
     if (level === 'warn') level = 'warning';
     return function () {
         var args = [].slice.call(arguments);
-        Raven.captureMessage(args[0], {level: level, logger: 'console', extra: { args: args }});
+        Raven.captureMessage('' + args[0], {level: level, logger: 'console', extra: { args: args }});
 
         // this fails for some browsers. :(
         if (originalConsoleLevel) {

--- a/plugins/console.js
+++ b/plugins/console.js
@@ -23,7 +23,7 @@ var logForGivenLevel = function(level) {
     if (level === 'warn') level = 'warning';
     return function () {
         var args = [].slice.call(arguments);
-        Raven.captureMessage('' + args, {level: level, logger: 'console'});
+        Raven.captureMessage(args[0], {level: level, logger: 'console', extra: { args: args }});
 
         // this fails for some browsers. :(
         if (originalConsoleLevel) {


### PR DESCRIPTION
Log arguments in extra so that they do not need to be stringified. This provides more context for use when debugging errors.