### PR TITLE
Improve Angular plugin + add docs

### DIFF
--- a/docs/integrations/angular.rst
+++ b/docs/integrations/angular.rst
@@ -1,0 +1,44 @@
+AngularJS
+=========
+
+Installation
+------------
+
+Start by adding the ``raven.js`` script tag to your page. It should go **before** your application code.
+
+Example:
+
+.. sourcecode:: html
+
+    <script src="https://cdn.ravenjs.com/1.2.0/angular,native/raven.min.js"></script>
+
+    <!-- your application code below -->
+    <script src="static/app.js"></script>
+
+Additionally, inside your main Angular application module, you need to declare ``ngRaven`` as a
+module dependency:
+
+.. code-block:: javascript
+
+    var myApp = angular.module('myApp', [
+      'ngRaven',
+      'ngRoute',
+      'myAppControllers',
+      'myAppFilters'
+    ]);
+
+Configuring the Client
+----------------------
+
+You need to configure raven.js to use your Sentry DSN. This should happen immediately after
+your raven.js script include:
+
+.. code-block:: html
+
+    <script src="https://cdn.ravenjs.com/1.2.0/angular,native/raven.min.js"></script>
+    <script>
+      Raven.config('___PUBLIC_DSN___').install();
+    </script>
+
+At this point, Raven is ready to capture any uncaught exception via standard hooks
+in addition to Backbone specific hooks.

--- a/docs/sentry-doc-config.json
+++ b/docs/sentry-doc-config.json
@@ -10,6 +10,15 @@
         "index#reporting-errors"
       ]
     },
+    "javascript.angular": {
+      "name": "Angular",
+      "type": "framework",
+      "doc_link": "integrations/angular/",
+      "wizard": [
+        "integrations/angular#installation",
+        "integrations/angular#configuring-the-client"
+      ]
+    },
     "javascript.backbone": {
       "name": "Backbone",
       "type": "framework",

--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -12,33 +12,30 @@ var angular = window.angular,
 // quit if angular isn't on the page
 if (!(angular && Raven)) return;
 
-// Angular plugin doesn't go through the normal `Raven.addPlugin`
-// since this bootstraps the `install()` automatically.
-
-function ngRavenProvider($provide) {
-    $provide.decorator('$exceptionHandler', [
-        'RavenConfig', '$delegate',
-        ngRavenExceptionHandler
-    ]);
+function RavenProvider() {
+    this.$get = ['$window', function($window, $log) {
+        return $window.Raven;
+    }];
 }
 
-function ngRavenExceptionHandler(RavenConfig, $delegate) {
-    if (!RavenConfig)
-        throw new Error('RavenConfig must be set before using this');
+function ExceptionHandlerProvider($provide) {
+    $provide.decorator('$exceptionHandler',
+        ['Raven', '$delegate', exceptionHandler]);
+}
 
-    if (RavenConfig.debug !== void 0) {
-      Raven.debug = RavenConfig.debug;
-    }
-
-    Raven.config(RavenConfig.dsn, RavenConfig.config).install();
-    return function angularExceptionHandler(ex, cause) {
+function exceptionHandler(Raven, $delegate) {
+    return function (ex, cause)     {
+        Raven.captureException(ex, {
+            extra: { cause: cause }
+        });
         $delegate(ex, cause);
-        Raven.captureException(ex, {extra: {cause: cause}});
     };
 }
 
-angular.module('ngRaven', [])
-    .config(['$provide', ngRavenProvider])
-    .value('Raven', Raven);
+Raven.addPlugin(function () {
+    angular.module('ngRaven', [])
+        .provider('Raven',  RavenProvider)
+        .config(['$provide', ExceptionHandlerProvider]);
+});
 
 }(typeof window !== 'undefined' ? window : this));


### PR DESCRIPTION
This patch does the following:

* Plugin now actually works (had module dependency problem before)
* Uses `Raven.addPlugins` (like all other plugins)
* Adds angular.rst documentation page; adds new page to .json index