### PR TITLE
Register angular module on plugin load

### DIFF
--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -32,31 +32,31 @@ function exceptionHandler(Raven, $delegate) {
     };
 }
 
-// See https://github.com/angular/angular.js/blob/v1.4.7/src/minErr.js
-var angularPattern = /^\[((?:[$a-zA-Z0-9]+:)?(?:[$a-zA-Z0-9]+))\] (.+?)\n(\S+)$/;
+angular.module('ngRaven', [])
+    .provider('Raven',  RavenProvider)
+    .config(['$provide', ExceptionHandlerProvider]);
 
 Raven.addPlugin(function () {
-    angular.module('ngRaven', [])
-        .provider('Raven',  RavenProvider)
-        .config(['$provide', ExceptionHandlerProvider]);
-});
+    // See https://github.com/angular/angular.js/blob/v1.4.7/src/minErr.js
+    var angularPattern = /^\[((?:[$a-zA-Z0-9]+:)?(?:[$a-zA-Z0-9]+))\] (.+?)\n(\S+)$/;
 
-Raven.setDataCallback(function(data) {
-    // We only care about mutating an exception
-    var exception = data.exception;
-    if (exception) {
-        exception = exception.values[0];
-        var matches = angularPattern.exec(exception.value);
-
-        if (matches) {
-            // This type now becomes something like: $rootScope:inprog
-            exception.type = matches[1];
-            exception.value = matches[2];
-            data.message = exception.type + ': ' + exception.value;
-            // auto set a new tag specifically for the angular error url
-            data.extra.angularDocs = matches[3].substr(0, 250);
+    Raven.setDataCallback(function(data) {
+        // We only care about mutating an exception
+        var exception = data.exception;
+        if (exception) {
+            exception = exception.values[0];
+            var matches = angularPattern.exec(exception.value);
+    
+            if (matches) {
+                // This type now becomes something like: $rootScope:inprog
+                exception.type = matches[1];
+                exception.value = matches[2];
+                data.message = exception.type + ': ' + exception.value;
+                // auto set a new tag specifically for the angular error url
+                data.extra.angularDocs = matches[3].substr(0, 250);
+            }
         }
-    }
+    });
 });
 
 }(typeof window !== 'undefined' ? window : this));


### PR DESCRIPTION
With this change we're able to reference `ngRaven` module even before `Raven.install()` call.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/413)

<!-- Reviewable:end -->
