### PR TITLE
Angular raven provider configuration

### DIFF
--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -13,6 +13,9 @@ var angular = window.angular,
 if (!(angular && Raven)) return;
 
 function RavenProvider() {
+    this.config = function (configuration) {
+      Raven.config(configuration).install();
+    };
     this.$get = ['$window', function($window, $log) {
         return $window.Raven;
     }];


### PR DESCRIPTION
Great to see the [angular support added](https://docs.getsentry.com/hosted/clients/javascript/integrations/angular/)!

I've opened this PR to introduce a more angular friendly/traditional way of providing configuration -- through the provider.

Currently the proposed approach is

``` html
<script src="https://cdn.ravenjs.com/1.3.0/angular,native/raven.min.js"></script>
<script>
  Raven.config('https://abc@app.getsentry.com/123').install();
</script>
```

While this works, it makes it very hard to configure for multiple environments. For instance, in some environments we choose to report errors to a different project than our production environments.

For example, with [gulp-ng-config](https://github.com/ajwhite/gulp-ng-config) we will define a raven configuration for `staging` and `production` separately. This will generate an angular constant, say `EnvironmentConfig`, containing properties such as `{raven: 'token'}`, which we'd like to use to perform `Raven.config('..').install()`. 

With the current approach, we unfortunately can't access that very easily. This PR introduces the idea of configuring at the provider level during `app.config` where many configuration routines take place.

Example:

``` js
angular.module('app.config', [])
.constant('EnvironmentConfig', {
  raven: 'https://abc@app.getsentry.com/123',
  other: 'configurations'
});

// configuring Raven during the `config()` phase
angular.module('app', ['app.config', 'ngRaven'])
.config(function (RavenProvider, EnvironmentConfig) {
  RavenProvider.config(EnvironmentConfig.raven);
});
```

With this I can simply configure your service without having to leave the angular context. This is a similar approach as used by other third party angular modules, such as:
- [angular-facebook](https://github.com/Ciul/angular-facebook)
- [angular-github-adapter](https://github.com/PascalPrecht/angular-github-adapter)
- [angular-intercom](https://github.com/gdi2290/angular-intercom)
- and many more

This is actually how we're currently using Raven before the new integration became relased
