### PR TITLE
Support setting Error.stackTraceLimit automatically

### DIFF
--- a/example/scratch.js
+++ b/example/scratch.js
@@ -45,3 +45,19 @@ function showDialog() {
     broken();
     Raven.showReportDialog();
 }
+
+function a() { b(); }
+function b() { c(); }
+function c() { d(); }
+function d() { e(); }
+function e() { f(); }
+function f() { g(); }
+function g() { h(); }
+function h() { i(); }
+function i() { j(); }
+function j() { k(); }
+function k() { l(); }
+function l() { m(); }
+function m() { n(); }
+function n() { o(); }
+function o() { throw new Error('dang'); }

--- a/src/raven.js
+++ b/src/raven.js
@@ -46,7 +46,7 @@ function Raven() {
         crossOrigin: 'anonymous',
         collectWindowErrors: true,
         maxMessageLength: 0,
-        stackTraceLimit: Infinity
+        stackTraceLimit: 50
     };
     this._ignoreOnError = 0;
     this._isRavenInstalled = false;

--- a/src/raven.js
+++ b/src/raven.js
@@ -45,10 +45,12 @@ function Raven() {
         includePaths: [],
         crossOrigin: 'anonymous',
         collectWindowErrors: true,
-        maxMessageLength: 0
+        maxMessageLength: 0,
+        stackTraceLimit: Infinity
     };
     this._ignoreOnError = 0;
     this._isRavenInstalled = false;
+    this._originalErrorStackTraceLimit = Error.stackTraceLimit;
     // capture references to window.console *and* all its methods first
     // before the console plugin has a chance to monkey patch
     this._originalConsole = window.console || {};
@@ -164,6 +166,7 @@ Raven.prototype = {
             this._isRavenInstalled = true;
         }
 
+        Error.stackTraceLimit = this._globalOptions.stackTraceLimit;
         return this;
     },
 
@@ -269,6 +272,7 @@ Raven.prototype = {
 
         this._restoreBuiltIns();
 
+        Error.stackTraceLimit = this._originalErrorStackTraceLimit;
         this._isRavenInstalled = false;
 
         return this;
@@ -757,7 +761,7 @@ Raven.prototype = {
             stackInfo.message,
             stackInfo.url,
             stackInfo.lineno,
-            frames,
+            frames.slice(0, this._globalOptions.stackTraceLimit),
             options
         );
     },

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1449,6 +1449,29 @@ describe('globals', function() {
                 'new <anonymous>', 'hey', 'http://example.com', 10, [], undefined
             ]);
         });
+
+        it('should trim number of frames based on stackTraceLimit', function() {
+            var frame = {url: 'http://example.com'};
+            this.sinon.stub(Raven, '_normalizeFrame').returns(frame);
+            this.sinon.stub(Raven, '_processException');
+
+            var stackInfo = {
+                name: 'Matt',
+                message: 'hey',
+                url: 'http://example.com',
+                lineno: 10,
+                stack: [
+                  frame, frame
+                ]
+            };
+
+            Raven._globalOptions.stackTraceLimit = 1;
+
+            Raven._handleStackInfo(stackInfo);
+            assert.deepEqual(Raven._processException.lastCall.args, [
+                'Matt', 'hey', 'http://example.com', 10, [frame], undefined
+            ]);
+        });
     });
 });
 


### PR DESCRIPTION
In V8, `Error.stack` is truncated with a default `Error.stackTraceLimit`
of 10. So we want to expose this and set it to 50 to capture more.

/cc @dcramer 

Also worth noting, that this is probably useless without XHR being the default transport, since this will very easily push us over our querystring limitations.