### PR TITLE
Use a more thorough check when exporting.

### DIFF
--- a/template/_footer.js
+++ b/template/_footer.js
@@ -8,12 +8,9 @@ if (typeof define === 'function' && define.amd) {
     define('raven', [], function() {
       return Raven;
     });
-} else if (typeof module === 'object') {
+} else if (typeof module === 'object' && module.exports) {
     // browserify
     module.exports = Raven;
-} else if (typeof exports === 'object') {
-    // CommonJS
-    exports = Raven;
 }
 
 })(typeof window !== 'undefined' ? window : this);


### PR DESCRIPTION
If an element with ID of `module` is in the document, `module.exports` could be defined wrongly. This adds a check to ensure `module.exports` exists first. This commit also removes the `exports` branch which wasn't doing anything, and also is only used in old environments without `module.exports` support, such as Narwhal and older versions of Ringo, which are no longer in use.