### PR TITLE
Disable maxMessageLength truncation by default

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -166,7 +166,7 @@ Optional settings
 
 .. describe:: maxMessageLength
 
-    By default, raven truncates messages to a max length of 100
+    By default, raven truncates messages to a max length of 1000
     characters. You can customize the max length with this parameter.
 
 .. describe:: transport

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -166,8 +166,8 @@ Optional settings
 
 .. describe:: maxMessageLength
 
-    By default, raven truncates messages to a max length of 1000
-    characters. You can customize the max length with this parameter.
+    By default, Raven does not truncate messages. If you need to truncate
+    characters for whatever reason, you may set this to limit the length.
 
 .. describe:: transport
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -45,7 +45,7 @@ function Raven() {
         includePaths: [],
         crossOrigin: 'anonymous',
         collectWindowErrors: true,
-        maxMessageLength: 100
+        maxMessageLength: 1000
     };
     this._ignoreOnError = 0;
     this._isRavenInstalled = false;

--- a/src/raven.js
+++ b/src/raven.js
@@ -45,7 +45,7 @@ function Raven() {
         includePaths: [],
         crossOrigin: 'anonymous',
         collectWindowErrors: true,
-        maxMessageLength: 1000
+        maxMessageLength: 0
     };
     this._ignoreOnError = 0;
     this._isRavenInstalled = false;

--- a/src/utils.js
+++ b/src/utils.js
@@ -61,7 +61,7 @@ function objectMerge(obj1, obj2) {
 }
 
 function truncate(str, max) {
-    return str.length <= max ? str : str.substr(0, max) + '\u2026';
+    return !max || str.length <= max ? str : str.substr(0, max) + '\u2026';
 }
 
 /**

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -86,6 +86,7 @@ describe('utils', function () {
             assert.equal(truncate('lolol', 3), 'lol\u2026');
             assert.equal(truncate('lolol', 10), 'lolol');
             assert.equal(truncate('lol', 3), 'lol');
+            assert.equal(truncate(new Array(1000).join('f'), 0), new Array(1000).join('f'));
         });
     });
 


### PR DESCRIPTION
We can now send lots more data since we send via POST, so remove this restriction.

Alternatively, we can either remove this entirely, or handle a `0` value to disable truncation entirely. I can't see any other client that does this type of truncation. iirc, I added this originally to limit the packet size being sent, which isn't really needed anymore.