### PR TITLE
Fix version not available via CommonJS (fixes #459) ...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -6,6 +6,7 @@ module.exports = function(grunt) {
     var through = require('through2');
     var proxyquire = require('proxyquireify');
     var versionify = require('browserify-versionify');
+    var derequire = require('derequire/plugin');
 
     var excludedPlugins = [
         'react-native'
@@ -98,7 +99,14 @@ module.exports = function(grunt) {
             },
             core: {
                 src: 'src/singleton.js',
-                dest: 'build/raven.js'
+                dest: 'build/raven.js',
+                options: {
+                    plugin: [ derequire ],
+                    transform: [
+                        [ versionify ],
+                        [ new AddPluginBrowserifyTransformer() ]
+                    ]
+                }
             },
             plugins: {
                 files: pluginConcatFiles,

--- a/package.json
+++ b/package.json
@@ -11,10 +11,11 @@
     "type": "git",
     "url": "git://github.com/getsentry/raven-js.git"
   },
-  "main": "src/singleton.js",
+  "main": "dist/raven.js",
   "devDependencies": {
     "browserify-versionify": "^1.0.6",
     "chai": "2.3.0",
+    "derequire": "2.0.3",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-cli": "^0.1.13",


### PR DESCRIPTION
* package.json now points to dist/raven.js
* dist/raven.js is built with derequire plugin (removes require statements)
* derequire plugin added as dev dep