### PR TITLE
Move project config to "Preventing Abuse" in usage

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -1,29 +1,26 @@
 Configuration
 =============
 
-We must first configure the client to allow certain hosts to report
-errors.  This prevents abuse so somebody else couldn't start sending
-errors to your account from their site.
+To get started, you need to configure Raven.js to use your Sentry DSN:
 
-**Note**: Without setting this, all messages will be rejected!
-
-This can be found under the *Project Details* page in Sentry.
-
-Now need to set up Raven.js to use your Sentry DSN.
-
-.. code-block:: javascript
+.. sourcecode:: javascript
 
     Raven.config('___PUBLIC_DSN___').install()
 
 At this point, Raven is ready to capture any uncaught exception.
 
-Although, this technically works, this is not going to yield the greatest
-results. It's highly recommended to next check out :doc:`usage`.
-
 Optional settings
 -----------------
 
-``Raven.config()`` can be passed an optional object for extra configuration.
+``Raven.config()`` can optionally be passed an additional argument for extra configuration:
+
+.. sourcecode:: javascript
+
+    Raven.config('___PUBLIC_DSN___', {
+        release: '1.3.0'
+    }).install()
+
+Those configuration options are documented below:
 
 .. describe:: logger
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,17 +28,6 @@ scripts.  For all details see :doc:`install`.
 
     <script src="https://cdn.ravenjs.com/2.0.4/raven.min.js"></script>
 
-Configuring the Project
------------------------
-
-We must first configure Sentry to allow certain hosts to report errors.
-This prevents abuse so somebody else couldn't start sending errors to your
-account from their site.
-
-This can be found under the **Project Settings** page in Sentry. You'll need
-to add each domain that you plan to report from into the **Allowed Domains**
-box. Alternatively if you're not worried about CORS security, you can simply
-enter ``*`` to whitelist all domains.
 
 Configuring the Client
 ----------------------

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -289,3 +289,16 @@ deduplicate by taking into account the URL:
 .. sentry:edition:: hosted, on-premise
 
     For more information, see :ref:`custom-grouping`.
+
+Preventing Abuse
+----------------
+
+By default, the Sentry server accepts errors from any host. This can lead to an abuse
+scenario where a malicious party triggers JavaScript errors from a different website that are
+accepted by your Sentry Project. To prevent this, it is recommended to whitelist known hosts where your
+JavaScript code is operating.
+
+This setting can be found under the **Project Settings** page in Sentry. You'll need
+to add each domain that you plan to report from into the **Allowed Domains**
+box. When an error is collected by Raven.js and transmitted to Sentry, Sentry will verify the ``Origin`` and/or
+``Referer`` headers of the HTTP request to verify that it matches one of your allowed hosts.


### PR DESCRIPTION
Removes references where configuring the project is required before errors can be accepted.