### PR TITLE
Hardcode version string in src/raven.js (fixes GH-465)

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -258,9 +258,16 @@ module.exports = function(grunt) {
     // Custom Grunt tasks
     grunt.registerTask('version', function() {
         var pkg = grunt.config.get('pkg');
+
+        // Verify version string in source code matches what's in package.json
+        var Raven = require('./src/raven');
+        if (Raven.prototype.VERSION !== pkg.version) {
+            return grunt.util.error('Mismatched version in src/raven.js: ' + Raven.prototype.VERSION +
+                ' (should be ' + pkg.version + ')');
+        }
+
         if (grunt.option('dev')) {
             pkg.release = 'dev';
-            pkg.version = grunt.config.get('gitinfo').local.branch.current.shortSHA;
         } else {
             pkg.release = pkg.version;
         }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "type": "git",
     "url": "git://github.com/getsentry/raven-js.git"
   },
-  "main": "dist/raven.js",
+  "main": "src/singleton.js",
   "devDependencies": {
     "browserify-versionify": "^1.0.6",
     "chai": "2.3.0",

--- a/src/raven.js
+++ b/src/raven.js
@@ -71,7 +71,11 @@ function Raven() {
  */
 
 Raven.prototype = {
-    VERSION: '__VERSION__',
+    // Hardcode version string so that raven source can be loaded directly via
+    // webpack (using a build step causes webpack #1617). Grunt verifies that
+    // this value matches package.json during build.
+    //   See: https://github.com/getsentry/raven-js/issues/465
+    VERSION: '2.0.0',
 
     debug: false,
 


### PR DESCRIPTION
Note `src/raven.js` specifies 2.0.0 because this is the current value of version in package.json on master.

When I cherry-pick this into stable/2.0.x, I will update the version string.

---

Grunt output when attempting to run `grunt dist` or `grunt build` when version mismatches:

```bash
➜  raven-js git:(master) ✗ grunt dist
Running "clean:0" (clean) task
>> 1 path cleaned.

Running "gitinfo" task

Running "version" task
Warning: Mismatched version in src/raven.js: 2.1.0 (should be 2.0.0) Use --force to continue.

Aborted due to warnings.
```

```bash
➜  raven-js git:(master) ✗ grunt build
Running "clean:0" (clean) task
>> 0 paths cleaned.

Running "gitinfo" task

Hardcode version string in src/raven.js (fixes GH-465)
Running "version" task
Warning: Mismatched version in src/raven.js: 2.1.0 (should be 2.0.0) Use --force to continue.

Aborted due to warnings.
```