### PR TITLE
Prevent reentrancy in isSetup() when used in log method

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -485,9 +485,10 @@ Raven.prototype = {
     isSetup: function() {
         if (!this._hasJSON) return false;  // needs JSON support
         if (!this._globalServer) {
-            if (!this.ravenNotConfiguredError)
+            if (!this.ravenNotConfiguredError) {
+              this.ravenNotConfiguredError = true;
               this._logDebug('error', 'Error: Raven has not been configured.');
-            this.ravenNotConfiguredError = true;
+            }
             return false;
         }
         return true;


### PR DESCRIPTION
`Raven.isSetup()` logs an error the first time it's called when Raven is not configured. The `logDebug` method assumes the methods cached at initialization time are the built-in methods.

It's possible to send `Raven.isSetup()` into a reentrant loop if a few things happen:

* The console methods cached at initialization are not the the built-in methods.
* The `console.error` method calls `Raven.isSetup()`.
* Raven is in debug mode.

Repro: https://gist.github.com/mseeley/c6243d39a77e54a17ff1

Super edgy but not difficult to trigger if you're holding it a little crooked. Although since avoiding excessive reentrancy is a one liner I figured you all might take the patch.

Thanks!