### PR TITLE
Fix bad level arg in console plugin, other fixes

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -18,18 +18,20 @@ function consolePlugin(Raven, console) {
 
         // warning level is the only level that doesn't map up
         // correctly with what Sentry expects.
-        if (level === 'warn') level = 'warning';
+        if (l === 'warn') l = 'warning';
         return function () {
             var args = [].slice.call(arguments);
-            Raven.captureMessage('' + args[0], {level: level, logger: 'console', extra: { 'arguments': args }});
+            Raven.captureMessage('' + args.join(' '), {level: l, logger: 'console', extra: { 'arguments': args }});
 
             // this fails for some browsers. :(
             if (originalConsoleLevel) {
                 // IE9 doesn't allow calling apply on console functions directly
                 // See: https://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function#answer-5473193
-                Function.prototype.bind
-                    .call(originalConsoleLevel, originalConsole)
-                    .apply(originalConsole, args);
+                Function.prototype.apply.call(
+                    originalConsoleLevel,
+                    originalConsole,
+                    args
+                );
             }
         };
     };

--- a/test/plugins/console.test.js
+++ b/test/plugins/console.test.js
@@ -1,0 +1,48 @@
+var _Raven = require('../../src/raven');
+var consolePlugin = require('../../plugins/console');
+
+var Raven;
+describe('console plugin', function () {
+    beforeEach(function () {
+        Raven = new _Raven();
+        Raven.config('http://abc@example.com:80/2');
+    });
+
+    it('should call Raven.captureMessage', function () {
+        var console = {
+            debug: function () {},
+            info: function () {},
+            warn: function () {},
+            error: function () {}
+        };
+
+        consolePlugin(Raven, console);
+
+        this.sinon.stub(Raven, 'captureMessage');
+        console.error('Raven should capture', 'console.error');
+
+        assert.equal(Raven.captureMessage.callCount, 1);
+        assert.equal(Raven.captureMessage.getCall(0).args[0], 'Raven should capture console.error');
+        assert.deepEqual(Raven.captureMessage.getCall(0).args[1], {
+            level: 'error',
+            logger: 'console',
+            extra: {
+                arguments: ['Raven should capture', 'console.error']
+            }
+        });
+
+        Raven.captureMessage.reset();
+
+        console.warn('Raven should capture console.warn');
+
+        assert.equal(Raven.captureMessage.callCount, 1);
+        assert.equal(Raven.captureMessage.getCall(0).args[0], 'Raven should capture console.warn');
+        assert.deepEqual(Raven.captureMessage.getCall(0).args[1], {
+            level: 'warning', // warn => warning
+            logger: 'console',
+            extra: {
+                arguments: ['Raven should capture console.warn']
+            }
+        });
+    });
+});


### PR DESCRIPTION
Started by applying #473 to plugins/console, then wrote some tests and found some other bugs:

* `level` (passed to Sentry) was always undefined (closure bug)
* Was only taking first argument from console methods to build message string (now joins with space character `' '`)