### PR TITLE
Update integration docs to 2.0.5

### DIFF
--- a/docs/integrations/angular.rst
+++ b/docs/integrations/angular.rst
@@ -13,7 +13,7 @@ Example:
 
 .. sourcecode:: html
 
-    <script src="https://cdn.ravenjs.com/2.0.0/angular/raven.min.js"></script>
+    <script src="https://cdn.ravenjs.com/2.0.5/angular/raven.min.js"></script>
 
     <!-- your application code below -->
     <script src="static/app.js"></script>
@@ -38,7 +38,7 @@ to wire up the SDK just as if you weren't using Angular. This should happen imme
 
 .. code-block:: html
 
-    <script src="https://cdn.ravenjs.com/2.0.0/angular/raven.min.js"></script>
+    <script src="https://cdn.ravenjs.com/2.0.5/angular/raven.min.js"></script>
     <script>
       Raven.config('___PUBLIC_DSN___').install();
     </script>

--- a/docs/integrations/ember.rst
+++ b/docs/integrations/ember.rst
@@ -9,7 +9,7 @@ after you load all other external libraries (like jQuery), but before your code.
 
 .. sourcecode:: html
 
-    <script src="https://cdn.ravenjs.com/2.0.0/ember/raven.min.js"></script>
+    <script src="https://cdn.ravenjs.com/2.0.5/ember/raven.min.js"></script>
 
 Configuring the Client
 ----------------------


### PR DESCRIPTION
Noticed integrations/angular.rst and integrations/ember.rst pointing to 2.0.0 instead of 2.0.5