### PR TITLE
monkey patch react native default error handling without overwriting it

### DIFF
--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -69,7 +69,12 @@ function reactNativePlugin(Raven) {
         }
     });
 
-    ErrorUtils.setGlobalHandler(Raven.captureException.bind(Raven));
+    var defaultHandler = (ErrorUtils.getGlobalHandler && ErrorUtils.getGlobalHandler())
+     || ErrorUtils._globalHandler;
+    ErrorUtils.setGlobalHandler(function(...args){
+      defaultHandler(...args);
+      Raven.captureException(...args);
+    });
 }
 
 module.exports = reactNativePlugin;

--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -71,9 +71,10 @@ function reactNativePlugin(Raven) {
 
     var defaultHandler = (ErrorUtils.getGlobalHandler && ErrorUtils.getGlobalHandler())
      || ErrorUtils._globalHandler;
-    ErrorUtils.setGlobalHandler(function(...args){
-      defaultHandler(...args);
-      Raven.captureException(...args);
+    ErrorUtils.setGlobalHandler(function(){
+      var error = arguments[0];
+      defaultHandler.apply(this, arguments)
+      Raven.captureException(error);
     });
 }
 


### PR DESCRIPTION
'setGlobalHandler' would overwrite the default error handler for React Native. This code keeps the default  handler by wrapping it the new handler. More about the global error handler for React Native could be found from this discussion: https://github.com/facebook/react-native/issues/1194  