### PR TITLE
Fix `normalized.function` call in IE8

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
     "dot-notation": [
       2,
       {
-        "allowKeywords": true
+        "allowKeywords": false
       }
     ],
     "eqeqeq": [

--- a/src/raven.js
+++ b/src/raven.js
@@ -791,7 +791,7 @@ Raven.prototype = {
             // first we check the global includePaths list.
             !!this._globalOptions.includePaths.test && !this._globalOptions.includePaths.test(normalized.filename) ||
             // Now we check for fun, if the function name is Raven or TraceKit
-            /(Raven|TraceKit)\./.test(normalized.function) ||
+            /(Raven|TraceKit)\./.test(normalized['function']) ||
             // finally, we do a last ditch effort and check for raven.min.js
             /raven\.(min\.)?js$/.test(normalized.filename)
         );


### PR DESCRIPTION
eslint by default wanted to change this to `.function` instead of the
correct `['function']`, so this also changes the rule.

Fixes GH-498