### PR TITLE
Configure Uglify to mangle prop names beginning with _

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -172,8 +172,22 @@ module.exports = function(grunt) {
 
                 // Only preserve comments that start with (!)
                 preserveComments: /^!/,
+
+                // Minify object properties that begin with _ ("private"
+                // methods and values)
+                mangleProperties: {
+                    regex: /^_/
+                },
+
                 compress: {
+                    booleans: true,
+                    conditionals: true,
                     dead_code: true,
+                    join_vars: true,
+                    pure_getters: true,
+                    sequences: true,
+                    unused: true,
+
                     global_defs: {
                         'TEST': false
                     }


### PR DESCRIPTION
Saves > 500 bytes after minification, gzip.

Note that if anyone is using private, internal methods (e.g. `Raven._send`), those properties will be renamed and this will almost certainly cause their code to break.

However ...

* Those methods are intentionally not documented
* Most of them were not accessible until Raven 2.0.0 (released in December) when they changed from being private functions into "instance methods"
* There's a reason we prefixed them with `_`