### PR TITLE
Optional support of secret_key

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -100,7 +100,7 @@ Raven.prototype = {
         var uri = this._parseDSN(dsn),
             lastSlash = uri.path.lastIndexOf('/'),
             path = uri.path.substr(1, lastSlash);
-        this._secret = uri.pass;
+        this._secret = uri.pass.substr(1);
 
 
         // merge in options
@@ -994,15 +994,20 @@ Raven.prototype = {
 
         if (!this.isSetup()) return;
 
+        var header_data = {
+            sentry_version: '7',
+            sentry_client: 'raven-js/' + this.VERSION,
+            sentry_key: this._globalKey
+        };
+
+        if(this._secret) {
+            header_data.sentry_secret = this._secret;
+        }
+
         var url = this._globalEndpoint;
         (globalOptions.transport || this._makeRequest).call(this, {
             url: url,
-            auth: {
-                sentry_version: '7',
-                sentry_client: 'raven-js/' + this.VERSION,
-                sentry_key: this._globalKey,
-                sentry_secret: this._secret
-            },
+            auth: header_data,
             data: data,
             options: globalOptions,
             onSuccess: function success() {

--- a/src/raven.js
+++ b/src/raven.js
@@ -100,7 +100,10 @@ Raven.prototype = {
         var uri = this._parseDSN(dsn),
             lastSlash = uri.path.lastIndexOf('/'),
             path = uri.path.substr(1, lastSlash);
-        this._secret = uri.pass.substr(1);
+
+        var secret = uri.pass;
+        if(secret && secret.length)
+            this._secret = secret.substr(1);
 
 
         // merge in options

--- a/src/raven.js
+++ b/src/raven.js
@@ -100,6 +100,8 @@ Raven.prototype = {
         var uri = this._parseDSN(dsn),
             lastSlash = uri.path.lastIndexOf('/'),
             path = uri.path.substr(1, lastSlash);
+        this._secret = uri.pass;
+
 
         // merge in options
         if (options) {
@@ -725,8 +727,8 @@ Raven.prototype = {
             throw new RavenConfigError('Invalid DSN: ' + str);
         }
 
-        if (dsn.pass)
-            throw new RavenConfigError('Do not specify your private key in the DSN!');
+        //if (dsn.pass)
+        //    throw new RavenConfigError('Do not specify your private key in the DSN!');
 
         return dsn;
     },
@@ -998,7 +1000,8 @@ Raven.prototype = {
             auth: {
                 sentry_version: '7',
                 sentry_client: 'raven-js/' + this.VERSION,
-                sentry_key: this._globalKey
+                sentry_key: this._globalKey,
+                sentry_secret: this._secret
             },
             data: data,
             options: globalOptions,


### PR DESCRIPTION
We are using the Firefox JS engine to run the game on the iOS (cocos2d-js). The game is written in JavaScript and 100% share code with WEB version. The game runs in Spidermonkey which is much in common as Firefox is with some differences (for example we have an own implementation of XMLHTTPRequest).

The raven-js works well but I receive the error ```Missing required attribute in authentication header: sentry_secret```. 

I have read some discussions and the validation on the sentry server is done via Origin header. But in such case the JavaScript is running outside browser and URL means nothing in such environment. 

I added a feature to set the sentry_secret as an option. In such environment, it is safe as the secret will be bundled inside the application.

As a bonus, Cordova and Phonegap application has same issues, after this pull request they will also support raven-js.