### PR TITLE
Refactor slice call

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -20,7 +20,7 @@ function consolePlugin(Raven, console) {
         // correctly with what Sentry expects.
         if (l === 'warn') l = 'warning';
         return function () {
-            var args = [].slice.call(arguments);
+            var args = Array.prototype.slice.call(arguments);
             Raven.captureMessage('' + args.join(' '), {level: l, logger: 'console', extra: { 'arguments': args }});
 
             // this fails for some browsers. :(


### PR DESCRIPTION
[].slice.call creates needless array, slower and has lots of other problems.
Full list is here: https://toddmotto.com/ditch-the-array-foreach-call-nodelist-hack