### PR TITLE
Add ravenPresend and ravenMessage events

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -334,10 +334,17 @@ Raven.prototype = {
             return;
         }
 
+        var data = {
+            message: msg,
+            options: options
+        };
+
+        this._triggerEvent('message', data);
+
         // Fire away!
         this._send(
             objectMerge({
-                message: msg + ''  // Make sure it's actually a string
+                message: data.message + ''  // Make sure it's actually a string
             }, options)
         );
 
@@ -557,7 +564,7 @@ Raven.prototype = {
     },
 
     _triggerEvent: function(eventType, options) {
-        // NOTE: `event` is a native browser thing, so let's avoid conflicting wiht it
+        // NOTE: `event` is a native browser thing, so let's avoid conflicting with it
         var evt, key;
 
         if (!this._hasDocument)
@@ -985,6 +992,11 @@ Raven.prototype = {
 
         // Try and clean up the packet before sending by truncating long values
         data = this._trimPacket(data);
+
+        this._triggerEvent('presend', {
+            options: globalOptions,
+            data: data
+        });
 
         this._logDebug('debug', 'Raven about to send:', data);
 


### PR DESCRIPTION
Hello,

As we already have `ravenHandle` event when handling an exception, `ravenSuccess` and `ravenFailure` events for post-submitting data, I propose to add 
 - `ravenMessage` when capturing a message
 - `ravenPresend` just before sending data to Sentry server.

This improves raven flexibility for the developer as it allows him to tweak the data.