### PR TITLE
Configuration for the console plugin to choose levels. Fixes #391.

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -3,14 +3,20 @@
  *
  * Monkey patches console.* calls into Sentry messages with
  * their appropriate log levels. (Experimental)
+ *
+ * Options:
+ *
+ *   `levels`: An array of levels (methods on `console`) to report to Sentry.
+ *     Defaults to debug, info, warn, and error.
  */
 'use strict';
 
-function consolePlugin(Raven, console, levels) {
+function consolePlugin(Raven, console, pluginOptions) {
     console = console || window.console || {};
+    pluginOptions = pluginOptions || {};
 
     var originalConsole = console,
-        logLevels = levels || ['debug', 'info', 'warn', 'error'],
+        logLevels = pluginOptions.levels || ['debug', 'info', 'warn', 'error'],
         level = logLevels.pop();
 
     var logForGivenLevel = function(l) {

--- a/plugins/console.js
+++ b/plugins/console.js
@@ -6,11 +6,11 @@
  */
 'use strict';
 
-function consolePlugin(Raven, console) {
+function consolePlugin(Raven, console, levels) {
     console = console || window.console || {};
 
     var originalConsole = console,
-        logLevels = ['debug', 'info', 'warn', 'error'],
+        logLevels = levels || ['debug', 'info', 'warn', 'error'],
         level = logLevels.pop();
 
     var logForGivenLevel = function(l) {
@@ -35,7 +35,6 @@ function consolePlugin(Raven, console) {
             }
         };
     };
-
 
     while(level) {
         console[level] = logForGivenLevel(level);


### PR DESCRIPTION
For example:

```js
Raven.addPlugin(require('raven-js/plugins/console'), console, {levels: ['error']});
```