### PR TITLE
Config flag for disabling automatically wrapping built ins

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -215,6 +215,18 @@ Those configuration options are documented below:
     onFailure
         Callback to be invoked upon a failed request.
 
+.. describe:: wrapBuiltIns
+
+    By default, Raven will automatically wrap built-ins such as ``setTimeout``, ``setInterval``, and ``addEventListener``
+    on most EventTargets. Any errors that are thrown by the functions these invoke will now be automatically be
+    reported to Sentry. This can be disabled by setting ``wrapBuiltIns`` to ``false``.
+
+    .. code-block:: javascript
+
+        {
+          wrapBuiltIns: false
+        }
+
 Putting it all together
 -----------------------
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -165,7 +165,7 @@ Raven.prototype = {
             });
 
             if (this._globalOptions.wrapBuiltIns) {
-              this._wrapBuiltIns();
+                this._wrapBuiltIns();
             }
 
             // Install all of the plugins

--- a/src/raven.js
+++ b/src/raven.js
@@ -45,6 +45,7 @@ function Raven() {
         includePaths: [],
         crossOrigin: 'anonymous',
         collectWindowErrors: true,
+        wrapBuiltIns: true,
         maxMessageLength: 0,
         stackTraceLimit: 50
     };
@@ -162,7 +163,10 @@ Raven.prototype = {
             TraceKit.report.subscribe(function () {
                 self._handleOnErrorStackInfo.apply(self, arguments);
             });
-            this._wrapBuiltIns();
+
+            if (this._globalOptions.wrapBuiltIns) {
+              this._wrapBuiltIns();
+            }
 
             // Install all of the plugins
             this._drainPlugins();


### PR DESCRIPTION
We explicitly capture all errors we want to push to Sentry. Our code also occasionally runs alongside other's where it's considered bad etiquette to auto patch built-ins they may be using. So I wanted to add a easy way to disable the auto capturing errors from built-ins which was recently added.

The code change itself is pretty straight forward, although perhaps could use some thinking around naming. I've defaulted the option to `true` so it retains the existing behavior by default, but can now be turned off.

Please let me know if this is suitable. Thanks!