### PR TITLE
Capture breadcrumbs and transmit "breadcrumbs"

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -27,7 +27,14 @@ function consolePlugin(Raven, console, pluginOptions) {
         if (l === 'warn') l = 'warning';
         return function () {
             var args = [].slice.call(arguments);
-            Raven.captureMessage('' + args.join(' '), {level: l, logger: 'console', extra: { 'arguments': args }});
+
+            var msg = '' + args.join(' ');
+            var data = {level: l, logger: 'console', extra: { 'arguments': args }};
+            if (pluginOptions.callback) {
+                pluginOptions.callback(msg, data);
+            } else {
+                Raven.captureMessage(msg, data);
+            }
 
             // this fails for some browsers. :(
             if (originalConsoleLevel) {

--- a/src/raven.js
+++ b/src/raven.js
@@ -613,11 +613,10 @@ Raven.prototype = {
      * @param elem the element addEventListener was called on
      * @param evt the event name (e.g. "click")
      * @param fn the function being wrapped
-     * @param origArgs the original arguments to addEventListener
      * @returns {Function}
      * @private
      */
-    _wrapEventHandlerForBreadcrumbs: function(elem, evt, fn, origArgs) {
+    _wrapEventHandlerForBreadcrumbs: function(elem, evt, fn) {
         var self = this;
         return function () {
             self.captureBreadcrumb({
@@ -627,7 +626,7 @@ Raven.prototype = {
                     target: elem.outerHTML
                 }
             });
-            return fn.apply(this, origArgs);
+            return fn.apply(this, arguments);
         }
     },
 
@@ -682,7 +681,6 @@ Raven.prototype = {
             if (proto && proto.hasOwnProperty && proto.hasOwnProperty('addEventListener')) {
                 fill(proto, 'addEventListener', function(orig) {
                     return function (evt, fn, capture, secure) { // preserve arity
-                        var args = [].slice.apply(arguments);
                         try {
                             if (fn && fn.handleEvent) {
                                 fn.handleEvent = self.wrap(fn.handleEvent);
@@ -693,7 +691,7 @@ Raven.prototype = {
 
                         // TODO: more than just click
                         if (global === 'EventTarget' && evt === 'click') {
-                            fn = self._wrapEventHandlerForBreadcrumbs(this, evt, fn, args);
+                            fn = self._wrapEventHandlerForBreadcrumbs(this, evt, fn);
                         }
                         return orig.call(this, evt, self.wrap(fn), capture, secure);
                     };

--- a/src/raven.js
+++ b/src/raven.js
@@ -17,6 +17,7 @@ var objectMerge = utils.objectMerge;
 var truncate = utils.truncate;
 var urlencode = utils.urlencode;
 var uuid4 = utils.uuid4;
+var htmlElementAsString = utils.htmlElementAsString;
 
 var dsnKeys = 'source protocol user pass host port path'.split(' '),
     dsnPattern = /^(?:(\w+):)?\/\/(?:(\w+)(:\w+)?@)?([\w\.-]+)(?::(\d+))?(\/.*)/;
@@ -623,7 +624,7 @@ Raven.prototype = {
                 type: 'ui_event',
                 data: {
                     type: evt,
-                    target: elem.outerHTML
+                    target: htmlElementAsString(elem)
                 }
             });
             return fn.apply(this, arguments);

--- a/src/raven.js
+++ b/src/raven.js
@@ -620,7 +620,7 @@ Raven.prototype = {
         var self = this;
         return function () {
             self.captureBreadcrumb({
-                type: "ui_event",
+                type: 'ui_event',
                 data: {
                     type: evt,
                     target: elem.outerHTML
@@ -1126,6 +1126,14 @@ Raven.prototype = {
         if (this._globalSecret) {
             auth.sentry_secret = this._globalSecret;
         }
+
+        this.captureBreadcrumb({
+            type: 'sentry',
+            data: {
+                message: data.message,
+                eventId: data.event_id
+            }
+        });
 
         var url = this._globalEndpoint;
         (globalOptions.transport || this._makeRequest).call(this, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -140,6 +140,25 @@ function uuid4() {
     }
 }
 
+/**
+ * Returns a simple, child-less string representation of a DOM element
+ * e.g. [HTMLElement] => <input class="btn" />
+ * @param HTMLElement
+ */
+function htmlElementAsString(elem) {
+    var out = ['<'];
+    out.push(elem.tagName.toLowerCase());
+    var attrWhitelist = ['id', 'type', 'name', 'value', 'class', 'placeholder', 'title', 'alt'];
+    each(attrWhitelist, function(index, key) {
+        var attr = elem.getAttribute(key);
+        if (attr) {
+            out.push(' ' + key + '="' + attr + '"');
+        }
+    });
+    out.push(' />');
+    return out.join('');
+}
+
 module.exports = {
     isUndefined: isUndefined,
     isFunction: isFunction,
@@ -153,5 +172,6 @@ module.exports = {
     hasKey: hasKey,
     joinRegExp: joinRegExp,
     urlencode: urlencode,
-    uuid4: uuid4
+    uuid4: uuid4,
+    htmlElementAsString: htmlElementAsString
 };

--- a/test/integration/frame.html
+++ b/test/integration/frame.html
@@ -73,5 +73,13 @@
   </script>
 </head>
 <body>
+  <!-- test element for breadcrumbs -->
+  <input name="foo" id="bar" placeholder="lol"/>
+
+  <div id="c">
+    <div id="b">
+      <div id="a"/>
+    </div>
+  </div>
 </body>
 </html>

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -298,7 +298,7 @@ describe('integration', function () {
             );
         });
 
-        it('should record pushState changes as navigation breadcrumbs', function (done) {
+        it('should record history.[pushState|back] changes as navigation breadcrumbs', function (done) {
             var iframe = this.iframe;
 
             iframeExecute(iframe, done,

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -309,7 +309,9 @@ describe('integration', function () {
                   history.pushState({}, '', '/bar');
 
                   // can't call history.back() because it will change url of parent document
-                  // (e.g. document running mocha) ... instead just call onpopstate directly
+                  // (e.g. document running mocha) ... instead just "emulate" a back button
+                  // press by calling replaceState + onpopstate manually
+                  history.replaceState({}, '', '/foo');
                   window.onpopstate();
                   done();
               },
@@ -331,8 +333,8 @@ describe('integration', function () {
                   assert.ok(/\/foo$/.test(breadcrumbs[1].data.from), '\'from\' url is incorrect');
                   assert.ok(/\/bar$/.test(breadcrumbs[1].data.to), '\'to\' url is incorrect');
 
-                  assert.ok(/\/bar$/.test(breadcrumbs[2].data.from), '\'from\' url is incorrect');
-                  assert.ok(/\/foo$/.test(breadcrumbs[2].data.to), '\'to\' url is incorrect');
+                  assert.ok(/\/bar/.test(breadcrumbs[2].data.from), '\'from\' url is incorrect');
+                  assert.ok(/\/foo/.test(breadcrumbs[2].data.to), '\'to\' url is incorrect');
               }
             );
         });

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -173,7 +173,6 @@ describe('integration', function () {
             iframeExecute(iframe, done,
               function () {
                   setTimeout(done);
-                  debugger;
 
                   var div = document.createElement('div');
                   document.body.appendChild(div);

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -173,6 +173,7 @@ describe('integration', function () {
             iframeExecute(iframe, done,
               function () {
                   setTimeout(done);
+                  debugger;
 
                   var div = document.createElement('div');
                   document.body.appendChild(div);
@@ -294,6 +295,145 @@ describe('integration', function () {
                     var ravenData = iframe.contentWindow.ravenData[0];
                     // # of frames alter significantly between chrome/firefox & safari
                     assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+                }
+            );
+        });
+    });
+
+    describe('breadcrumbs', function () {
+        it('should record a mouse click on element WITH click handler present', function (done) {
+            var iframe = this.iframe;
+
+            iframeExecute(iframe, done,
+                function () {
+                    setTimeout(done);
+
+                    // some browsers trigger onpopstate for load / reset breadcrumb state
+                    Raven._breadcrumbs = [];
+
+                    // add an event listener to the input. we want to make sure that
+                    // our breadcrumbs still work even if the page has an event listener
+                    // on an element that cancels event bubbling
+                    var input = document.getElementsByTagName('input')[0];
+                    var clickHandler = function (evt) {
+                        evt.stopPropagation(); // don't bubble
+                    };
+                    input.addEventListener('click', clickHandler);
+
+                    // click <input/>
+                    var evt = document.createEvent('MouseEvent');
+                    evt.initMouseEvent(
+                        "click",
+                        true /* bubble */,
+                        true /* cancelable */,
+                        window,
+                        null,
+                        0, 0, 0, 0, /* coordinates */
+                        false, false, false, false, /* modifier keys */
+                        0 /*left*/,
+                        null
+                    );
+                    input.dispatchEvent(evt);
+                },
+                function () {
+                    var Raven = iframe.contentWindow.Raven,
+                        breadcrumbs = Raven._breadcrumbs;
+
+                    assert.equal(breadcrumbs.length, 1);
+
+                    assert.equal(breadcrumbs[0].type, 'ui_event');
+                    // NOTE: attributes re-ordered. should this be expected?
+                    assert.equal(breadcrumbs[0].data.target, '<input id="bar" name="foo" placeholder="lol" />');
+                    assert.equal(breadcrumbs[0].data.type, 'click');
+                }
+            );
+        });
+
+        it('should record a mouse click on element WITHOUT click handler present', function (done) {
+            var iframe = this.iframe;
+
+            iframeExecute(iframe, done,
+                function () {
+                    setTimeout(done);
+
+                    // some browsers trigger onpopstate for load / reset breadcrumb state
+                    Raven._breadcrumbs = [];
+
+                    // click <input/>
+                    var evt = document.createEvent('MouseEvent');
+                    evt.initMouseEvent(
+                        "click",
+                        true /* bubble */,
+                        true /* cancelable */,
+                        window,
+                        null,
+                        0, 0, 0, 0, /* coordinates */
+                        false, false, false, false, /* modifier keys */
+                        0 /*left*/,
+                        null
+                    );
+
+                    var input = document.getElementsByTagName('input')[0];
+                    input.dispatchEvent(evt);
+                },
+                function () {
+                    var Raven = iframe.contentWindow.Raven,
+                        breadcrumbs = Raven._breadcrumbs;
+
+                    assert.equal(breadcrumbs.length, 1);
+
+                    assert.equal(breadcrumbs[0].type, 'ui_event');
+                    // NOTE: attributes re-ordered. should this be expected?
+                    assert.equal(breadcrumbs[0].data.target, '<input id="bar" name="foo" placeholder="lol" />');
+                    assert.equal(breadcrumbs[0].data.type, 'click');
+                }
+            );
+        });
+
+        it('should only record a SINGLE mouse click for a tree of elements with event listeners', function (done) {
+            var iframe = this.iframe;
+
+            iframeExecute(iframe, done,
+                function () {
+                    setTimeout(done);
+
+                    // some browsers trigger onpopstate for load / reset breadcrumb state
+                    Raven._breadcrumbs = [];
+
+                    var clickHandler = function (evt) {
+                        //evt.stopPropagation();
+                    };
+                    document.getElementById('a').addEventListener('click', clickHandler);
+                    document.getElementById('b').addEventListener('click', clickHandler);
+                    document.getElementById('c').addEventListener('click', clickHandler);
+
+                    // click <input/>
+                    var evt = document.createEvent('MouseEvent');
+                    evt.initMouseEvent(
+                        "click",
+                        true /* bubble */,
+                        true /* cancelable */,
+                        window,
+                        null,
+                        0, 0, 0, 0, /* coordinates */
+                        false, false, false, false, /* modifier keys */
+                        0 /*left*/,
+                        null
+                    );
+
+                    var input = document.getElementById('a'); // leaf node
+                    input.dispatchEvent(evt);
+                },
+                function () {
+                    var Raven = iframe.contentWindow.Raven,
+                        breadcrumbs = Raven._breadcrumbs;
+
+                    assert.equal(breadcrumbs.length, 1);
+
+                    assert.equal(breadcrumbs[0].type, 'ui_event');
+                    // NOTE: attributes re-ordered. should this be expected?
+                    assert.equal(breadcrumbs[0].data.target, '<div id="a" />');
+                    assert.equal(breadcrumbs[0].data.type, 'click');
                 }
             );
         });

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -718,6 +718,9 @@ describe('globals', function() {
                 logger: 'javascript',
                 maxMessageLength: 100
             };
+            Raven._breadcrumbs = [
+                { type: 'request', data: { method: 'POST', url: 'http://example.org/api/0/auth/' }}
+            ];
 
             Raven._send({message: 'bar'});
             assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
@@ -732,7 +735,8 @@ describe('globals', function() {
                 },
                 event_id: 'abc123',
                 message: 'bar',
-                extra: {'session:duration': 100}
+                extra: {'session:duration': 100},
+                breadcrumbs: [{ type: 'request', data: { method: 'POST', url: 'http://example.org/api/0/auth/' }}]
             });
         });
 
@@ -767,7 +771,8 @@ describe('globals', function() {
                     name: 'Matt'
                 },
                 message: 'bar',
-                extra: {'session:duration': 100}
+                extra: {'session:duration': 100},
+                breadcrumbs: []
             });
         });
 
@@ -800,7 +805,8 @@ describe('globals', function() {
                 event_id: 'abc123',
                 message: 'bar',
                 tags: {tag1: 'value1', tag2: 'value2'},
-                extra: {'session:duration': 100}
+                extra: {'session:duration': 100},
+                breadcrumbs: []
             });
 
 
@@ -842,7 +848,8 @@ describe('globals', function() {
 
                 event_id: 'abc123',
                 message: 'bar',
-                extra: {key1: 'value1', key2: 'value2', 'session:duration': 100}
+                extra: {key1: 'value1', key2: 'value2', 'session:duration': 100},
+                breadcrumbs: []
             });
 
             assert.deepEqual(Raven._globalOptions, {
@@ -2141,6 +2148,43 @@ describe('Raven (public API)', function() {
             assert.doesNotThrow(function() {
                 Raven.captureException(new Error('err'));
             });
+        });
+    });
+
+    describe('.captureBreadcrumb', function () {
+        it('should store the passed object in _breadcrumbs', function() {
+            var breadcrumb = {
+                type: 'request',
+                timestamp: 100,
+                data: {
+                    url: 'http://example.org/api/0/auth/',
+                    statusCode: 200
+                }
+            };
+
+            Raven.captureBreadcrumb(breadcrumb);
+
+            assert.equal(Raven._breadcrumbs[0], breadcrumb);
+        });
+
+        it('should dequeue the oldest breadcrumb when over limit', function() {
+            Raven._breadcrumbLimit = 5;
+            Raven._breadcrumbs = [
+                { id: 1 },
+                { id: 2 },
+                { id: 3 },
+                { id: 4 },
+                { id: 5 }
+            ];
+
+            Raven.captureBreadcrumb({ id: 6 });
+            assert.deepEqual(Raven._breadcrumbs, [
+                { id: 2 },
+                { id: 3 },
+                { id: 4 },
+                { id: 5 },
+                { id: 6 }
+            ]);
         });
     });
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -771,8 +771,7 @@ describe('globals', function() {
                     name: 'Matt'
                 },
                 message: 'bar',
-                extra: {'session:duration': 100},
-                breadcrumbs: []
+                extra: {'session:duration': 100}
             });
         });
 
@@ -806,7 +805,6 @@ describe('globals', function() {
                 message: 'bar',
                 tags: {tag1: 'value1', tag2: 'value2'},
                 extra: {'session:duration': 100},
-                breadcrumbs: []
             });
 
 
@@ -849,7 +847,6 @@ describe('globals', function() {
                 event_id: 'abc123',
                 message: 'bar',
                 extra: {key1: 'value1', key2: 'value2', 'session:duration': 100},
-                breadcrumbs: []
             });
 
             assert.deepEqual(Raven._globalOptions, {
@@ -2177,13 +2174,13 @@ describe('Raven (public API)', function() {
                 { id: 5 }
             ];
 
-            Raven.captureBreadcrumb({ id: 6 });
+            Raven.captureBreadcrumb({ id: 6, timestamp: 100 });
             assert.deepEqual(Raven._breadcrumbs, [
                 { id: 2 },
                 { id: 3 },
                 { id: 4 },
                 { id: 5 },
-                { id: 6 }
+                { id: 6, timestamp: 100 }
             ]);
         });
     });

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -718,9 +718,7 @@ describe('globals', function() {
                 logger: 'javascript',
                 maxMessageLength: 100
             };
-            Raven._breadcrumbs = [
-                { type: 'request', data: { method: 'POST', url: 'http://example.org/api/0/auth/' }}
-            ];
+            Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: {method: 'POST', url: 'http://example.org/api/0/auth/'}}];
 
             Raven._send({message: 'bar'});
             assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
@@ -736,7 +734,12 @@ describe('globals', function() {
                 event_id: 'abc123',
                 message: 'bar',
                 extra: {'session:duration': 100},
-                breadcrumbs: [{ type: 'request', data: { method: 'POST', url: 'http://example.org/api/0/auth/' }}]
+                breadcrumbs: {
+                    values: [
+                        { type: 'request', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }},
+                        { type: 'sentry', timestamp: 0.1, /* 100ms */ data: { message: 'bar', eventId: 'abc123' }}
+                    ]
+                }
             });
         });
 
@@ -2180,7 +2183,7 @@ describe('Raven (public API)', function() {
                 { id: 3 },
                 { id: 4 },
                 { id: 5 },
-                { id: 6, timestamp: 100 }
+                { id: 6, timestamp: 0.1 }
             ]);
         });
     });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -16,6 +16,7 @@ var joinRegExp = utils.joinRegExp;
 var objectMerge = utils.objectMerge;
 var truncate = utils.truncate;
 var urlencode = utils.urlencode;
+var htmlElementAsString = utils.htmlElementAsString;
 
 describe('utils', function () {
     describe('isUndefined', function() {
@@ -117,5 +118,34 @@ describe('utils', function () {
             assert.equal(urlencode({}), '');
             assert.equal(urlencode({'foo': 'bar', 'baz': '1 2'}), 'foo=bar&baz=1%202');
         });
+    });
+
+    describe('htmlElementAsString', function () {
+        it('should work', function () {
+            assert.equal(htmlElementAsString({
+                tagName: 'INPUT',
+                getAttribute: function (key){
+                    return {
+                        id: 'the-username',
+                        name: 'username',
+                        class: 'form-control',
+                        placeholder: 'Enter your username'
+                    }[key];
+                }
+            }), '<input id="the-username" name="username" class="form-control" placeholder="Enter your username" />');
+
+            assert.equal(htmlElementAsString({
+                tagName: 'IMG',
+                getAttribute: function (key){
+                    return {
+                        id: 'image-3',
+                        title: 'A picture of an apple',
+                        'data-something': 'This should be ignored' // skipping data-* attributes in first implementation
+                    }[key];
+                }
+            }), '<img id="image-3" title="A picture of an apple" />');
+        });
+
+        it
     });
 });


### PR DESCRIPTION
Right now this is just XMLHttpRequest instrumentation, but it will expand to include:

- [x] XMLHttpRequest
- [x] browser UI events (e.g. mouse clicks, keypresses) [technically only implemented mouse clicks, we'll come back to keypresses later]
- [x] console.log calls
- [x] navigation (URL) changes