### PR TITLE
Replace DOM events w/ new global Raven events

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -1,0 +1,57 @@
+'use strict';
+
+var isFunction = require('./utils').isFunction;
+
+/**
+ * Events mixin, inspired by Backbone events.
+ *
+ * Usage:
+ *
+ *  objectMerge(TargetObject.prototype, Events);
+ *
+ *  var obj = new TargetObject();
+ *  obj.on('foo', function () { ... }); // add listener to 'foo' event
+ *  obj.trigger('foo'); // calls all listeners bound to 'foo' event
+ *  obj.off('foo'); // removes all listeners bound to 'foo'
+ */
+var Events = {
+    on: function on(eventName, listener) {
+        this._listeners = this._listeners || {};
+        this._listeners[eventName] = this._listeners[eventName] || [];
+        this._listeners[eventName].push(listener);
+        return this;
+    },
+
+    off: function off(eventName, listener) {
+        var _listeners = this._listeners && this._listeners[eventName];
+        if (!_listeners)
+            return this;
+
+        if (listener) {
+            for (var i = 0; i < _listeners.length; i++) {
+                if (_listeners[i] === listener) {
+                    this._listeners[eventName] = _listeners.slice(0, i).concat(_listeners.slice(i + 1));
+                    break;
+                }
+            }
+        } else {
+            this._listeners[eventName] = [];
+        }
+        return this;
+    },
+
+    trigger: function trigger(eventName, arg1, arg2 /* , ... argN */) {
+        var _listeners = this._listeners && this._listeners[eventName];
+        if (!_listeners)
+            return this;
+
+        var listenerArgs = [].slice.call(arguments, 1);
+        for (var i = 0; i < _listeners.length; i++) {
+            if (isFunction(_listeners[i]))
+                _listeners[i].apply(this, listenerArgs);
+        }
+        return this;
+    }
+};
+
+module.exports = Events;

--- a/test/events.test.js
+++ b/test/events.test.js
@@ -1,0 +1,68 @@
+/*jshint mocha:true*/
+/*global assert:false, console:true*/
+'use strict';
+
+var Events = require('../src/events');
+
+describe('events', function () {
+    describe('on', function () {
+        it('should create a listeners property and assign the listener to the event name', function () {
+            var self = {};
+            var listener = function () {};
+            Events.on.call(self, 'thinghappened', listener);
+
+            assert.equal(self._listeners.thinghappened[0], listener);
+        });
+    });
+
+    describe('off', function () {
+        it('should remove all listeners bound to the given event name', function () {
+            var self = {
+                _listeners: {
+                    thinghappened: [
+                        function () {},
+                        function () {}
+                    ]
+                }
+            };
+            Events.off.call(self, 'thinghappened');
+            assert.equal(self._listeners.thinghappened.length, 0);
+        });
+
+        it('should remove only the given listener bound the given event name', function () {
+            var foo = function () {};
+            var bar = function () {};
+            var baz = function () {};
+            var self = {
+                _listeners: {
+                    thinghappened: [foo, bar, baz]
+                }
+            };
+            Events.off.call(self, 'thinghappened', bar);
+            assert.deepEqual(self._listeners.thinghappened, [foo, baz]); // 'bar' removed
+        });
+    });
+
+    describe('trigger', function () {
+        it('should trigger any matching listeners bound to the given event name', function () {
+            var foo = this.sinon.stub();
+            var bar = this.sinon.stub();
+            var baz = this.sinon.stub();
+            var self = {
+                _listeners: {
+                    thinghappened: [foo, baz],
+                    somethingelsehappened: [bar]
+                }
+            };
+            Events.trigger.call(self, 'thinghappened', { 'a': 123 }, 1337);
+
+            assert.isTrue(foo.calledOnce);
+            assert.deepEqual(foo.getCall(0).args, [{ 'a': 123 }, 1337]);
+
+            assert.isTrue(baz.calledOnce);
+            assert.deepEqual(baz.getCall(0).args, [{ 'a': 123 }, 1337]);
+
+            assert.isFalse(bar.called);
+        });
+    });
+});


### PR DESCRIPTION
The DOM events weren't compatible w/ React Native (no document).

This PR is against 3.x since this is a breaking API change.
