### PR TITLE
Capture NS_ERROR_FAILURE errors from Firefox

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -26,8 +26,10 @@ function isEmptyObject(what) {
 // Sorta yanked from https://github.com/joyent/node/blob/aa3b4b4/lib/util.js#L560
 // with some tiny modifications
 function isError(what) {
+    var toString = objectPrototype.toString.call(what);
     return isObject(what) &&
-        objectPrototype.toString.call(what) === '[object Error]' ||
+        toString === '[object Error]' ||
+        toString === '[object Exception]' || // Firefox NS_ERROR_FAILURE Exceptions
         what instanceof Error;
 }
 


### PR DESCRIPTION
I've managed to reproduce these failures by trying to do a POST from an html page that is served from the local filesystem (e.g. `file:///`)

```javascript
var request = new XMLHttpRequest();
request.open("POST", 'http://example.com', false);
request.setRequestHeader("Content-type", "application/x-www-form-urlencoded");
request.send('');
```

Unfortunately I cannot write a test for this without overwriting `Object.prototype.toString.call`. Maybe that's worthwhile anyways.

Example of a stack captured after this change:

```json
{
    "project": "1",
    "logger": "javascript",
    "platform": "javascript",
    "request": {
        "headers": {
            "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.11; rv:44.0) Gecko/20100101 Firefox/44.0"
        },
        "url": "file:///Users/xxx/Projects/sentry/index.html"
    },
    "exception": {
        "values": [{
            "type": "NS_ERROR_FAILURE",
            "value": "",
            "stacktrace": {
                "frames": [{
                    "filename": "file:///Users/xxx/Projects/sentry/index.html",
                    "lineno": 12,
                    "colno": 1,
                    "function": "?",
                    "in_app": true
                }, {
                    "filename": "[2]</Raven.prototype._wrapBuiltIns/</<@http://127.0.0.1:8002/dist/raven.js",
                    "lineno": 703,
                    "colno": 28,
                    "function": "?",
                    "in_app": false
                }]
            }
        }]
    },
    "culprit": "[2]</Raven.prototype._wrapBuiltIns/</<@http://127.0.0.1:8002/dist/raven.js",
    "message": "NS_ERROR_FAILURE: ",
    "extra": {
        "session:duration": 83
    },
    "event_id": "7784426458894fe4bd595d44505f3ec2"
}
```