### PR TITLE
Don't call out to the default handler in production mode

### DIFF
--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -58,7 +58,12 @@ function reactNativePlugin(Raven, options) {
 
     ErrorUtils.setGlobalHandler(function() {
         var error = arguments[0];
-        defaultHandler.apply(this, arguments)
+        // We only call the default handler in development mode so that you are
+        // presented with the redbox.  Calling the default handler in production
+        // will trigger an Objective-C exception and crash the app.
+        if ('__DEV__' in global && global.__DEV__) {
+            defaultHandler.apply(this, arguments)
+        }
         Raven.captureException(error);
     });
 }

--- a/test/plugins/react-native.test.js
+++ b/test/plugins/react-native.test.js
@@ -135,7 +135,8 @@ describe('React Native plugin', function () {
             }
         });
 
-        it('should call the default React Native handler and Raven.captureException', function () {
+        it('should call the default React Native handler and Raven.captureException in development mode', function () {
+            global.__DEV__ = true;
             reactNativePlugin(Raven);
             var err = new Error();
             this.sinon.stub(Raven, 'captureException');
@@ -145,6 +146,18 @@ describe('React Native plugin', function () {
             assert.isTrue(this.defaultErrorHandler.calledOnce);
             assert.isTrue(Raven.captureException.calledOnce);
             assert.equal(Raven.captureException.getCall(0).args[0], err);
+        });
+
+        it('should not call the default React Native handler and Raven.captureException in production mode', function () {
+            global.__DEV__ = false;
+            reactNativePlugin(Raven);
+            var err = new Error();
+            this.sinon.stub(Raven, 'captureException');
+
+            this.globalErrorHandler(err);
+
+            assert.equal(this.defaultErrorHandler.callCount, 0);
+            assert.equal(Raven.captureException.callCount, 1);
         });
     });
 });


### PR DESCRIPTION
A continuation of the discussion in #515 and _one way_ to fix #468 - however, this is a controversial change!

---

There are a few options as I see it (when in react native's production mode):

1. Don't call the native handler, ever (this PR).
  * Upside is that Raven can always send exceptions (assuming connectivity; also see https://github.com/getsentry/raven-js/issues/489#issuecomment-188419708)
  * Downside is that you lose the benefit of aggressively crashing: The app could now be in an inconsistent state

2. Call the native handler after sending the exception, or timing out
  * Upside is that this behaves more closely to how RN behaves out of the box
  * Downside is that the app could be in an inconsistent state (a few seconds is a long time!)

3. Capture JS exceptions on the native (Obj-C/Java) side of the fence (and not using raven-js at all)
  * Upsides:
    * Behaves just like RN does today
    * The same plugin could capture both native and JS exceptions; no need to set up both
  * Downside is that this approach is complicated

IMO the 3rd approach is ideal, but I have no idea how much work it would be