### PR TITLE
Handle stacks from internal exceptions sometimes thrown by Firefox

### DIFF
--- a/test/vendor/fixtures/captured-errors.js
+++ b/test/vendor/fixtures/captured-errors.js
@@ -223,6 +223,24 @@ CapturedExceptions.FIREFOX_31 = {
     columnNumber: 12
 };
 
+// Internal errors sometimes thrown by Firefox
+// More here: https://developer.mozilla.org/en-US/docs/Mozilla/Errors
+//
+// Note that such errors are instanceof "Exception", not "Error"
+CapturedExceptions.FIREFOX_44_NS_EXCEPTION = {
+    message: "",
+    name: "NS_ERROR_FAILURE",
+    stack: "[2]</Bar.prototype._baz/</<@http://path/to/file.js:703:28\n" +
+    "App.prototype.foo@file:///path/to/file.js:15:2\n" +
+    "bar@file:///path/to/file.js:20:3\n" +
+    "@file:///path/to/index.html:23:1\n" + // inside <script> tag
+    "",
+    fileName: "http://path/to/file.js",
+    columnNumber: 0,
+    lineNumber: 703,
+    result: 2147500037
+};
+
 CapturedExceptions.SAFARI_6 = {
     message: "'null' is not an object (evaluating 'x.undef')",
     stack: "@http://path/to/file.js:48\n" +

--- a/test/vendor/tracekit-parser.test.js
+++ b/test/vendor/tracekit-parser.test.js
@@ -108,6 +108,16 @@ describe('TraceKit', function () {
             expect(stackFrames.stack[2]).toEqual({ url: 'http://path/to/file.js', func: '.plugin/e.fn[c]/<', args: [], line: 1, column: 1, context: null });
         });
 
+        it('should parse Firefox 44 ns exceptions', function () {
+            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_44_NS_EXCEPTION);
+            expect(stackFrames).toBeTruthy();
+            expect(stackFrames.stack.length).toBe(4);
+            expect(stackFrames.stack[0]).toEqual({ url: 'http://path/to/file.js', func: '[2]</Bar.prototype._baz/</<', args: [], line: 703, column: 28, context: null });
+            expect(stackFrames.stack[1]).toEqual({ url: 'file:///path/to/file.js', func: 'App.prototype.foo', args: [], line: 15, column: 2, context: null });
+            expect(stackFrames.stack[2]).toEqual({ url: 'file:///path/to/file.js', func: 'bar', args: [], line: 20, column: 3, context: null });
+            expect(stackFrames.stack[3]).toEqual({ url: 'file:///path/to/index.html', func: '?', args: [], line: 23, column: 1, context: null });
+        });
+
         it('should parse Chrome error with no location', function () {
             var stackFrames = TraceKit.computeStackTrace({stack: "error\n at Array.forEach (native)"});
             expect(stackFrames.stack.length).toBe(1);

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -616,7 +616,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
         if (isUndefined(ex.stack) || !ex.stack) return;
 
         var chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|<anonymous>).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
-            gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|\[).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
+            gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|\[native).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
             winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:ms-appx|https?|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
             lines = ex.stack.split('\n'),
             stack = [],


### PR DESCRIPTION
Discussed in csnover/tracekit#49
Upstream fix in csnover/tracekit#50