### PR TITLE
Don't include error name as part of msg if it is falsy

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -855,7 +855,7 @@ Raven.prototype = {
         message += '';
         message = truncate(message, this._globalOptions.maxMessageLength);
 
-        fullMessage = type + ': ' + message;
+        fullMessage = (type ? type + ': ' : '') + message;
         fullMessage = truncate(fullMessage, this._globalOptions.maxMessageLength);
 
         if (frames && frames.length) {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -695,6 +695,13 @@ describe('globals', function() {
             Raven._processException('TypeError', undefined, 'http://example.com', []);
             assert.isTrue(Raven._send.called);
         });
+
+        it('should omit error name as part of message if error name is undefined/falsy', function () {
+            this.sinon.stub(Raven, '_send');
+
+            Raven._processException(undefined, '\'foo\' is undefined', 'http://example.com', 10); // IE9 ReferenceError
+            assert.deepEqual(Raven._send.lastCall.args[0].message, '\'foo\' is undefined');
+        });
     });
 
     describe('send', function() {


### PR DESCRIPTION
IE8 and IE9 (and surely other browsers) produce error strings that *don't* have an error name (e.g. ReferenceError). We end up producing strings like below, which end up in the Sentry UI:

```
undefined: 'foo' is not defined // IE9
undefined: Object expected // IE8
```

Screenshot:

![image](https://cloud.githubusercontent.com/assets/2153/13940058/7e91ea82-ef97-11e5-8dfd-38232cbb561b.png)

This patch omits error name if it is falsy, so that the messages above now become:

```
'foo' is not defined // IE9
Object expected // IE8
```