### PR TITLE
Introduce an optional configurable request timeout

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -215,6 +215,12 @@ Those configuration options are documented below:
     onFailure
         Callback to be invoked upon a failed request.
 
+.. describe:: timeout
+
+    By default, Raven.js requests do not time out. By setting this options, you can enforce that the request
+    is aborted after a number of milliseconds, e.g. set ``timeout: 500`` to abort after half a second during
+    configuration. Once the timeout occurs, the ``ravenTimeout`` event is triggered.
+
 .. describe:: allowSecretKey
 
     By default, Raven.js will throw an error if configured with a Sentry DSN that contains a secret key.

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1249,6 +1249,50 @@ describe('globals', function() {
             assert.equal(lastXhr.requestBody, '{"foo":"bar"}');
             assert.equal(lastXhr.url, 'http://localhost/?a=1&b=2');
         });
+
+        it('should set the request timeout if configured', function() {
+            var optionsWithTimeout = JSON.parse(JSON.stringify(Raven._globalOptions)),
+                expectedTimeout = 500;
+
+            optionsWithTimeout.timeout = expectedTimeout;
+            Raven._makeXhrRequest({
+                url: 'http://localhost/',
+                auth: {a: '1', b: '2'},
+                data: {foo: 'bar'},
+                options: optionsWithTimeout
+            });
+
+            var lastXhr = this.requests[this.requests.length - 1];
+            assert.equal(lastXhr.timeout, expectedTimeout);
+        });
+
+        it('should trigger a timeout event once timeout occurs', function () {
+            Raven._makeXhrRequest({
+                url: 'http://localhost/',
+                auth: {a: '1', b: '2'},
+                data: {foo: 'bar'},
+                options: Raven._globalOptions
+            });
+            this.sinon.stub(Raven, '_triggerEvent');
+
+            var lastXhr = this.requests[this.requests.length - 1];
+            assert.typeOf(lastXhr.ontimeout, 'function');
+
+            lastXhr.ontimeout();
+            assert.isTrue(Raven._triggerEvent.calledWith('timeout'));
+        });
+
+        it('should use an infinite request timeout by default', function() {
+            Raven._makeXhrRequest({
+                url: 'http://localhost/',
+                auth: {a: '1', b: '2'},
+                data: {foo: 'bar'},
+                options: Raven._globalOptions
+            });
+
+            var lastXhr = this.requests[this.requests.length - 1];
+            assert.equal(lastXhr.timeout, 0);
+        });
     });
 
     describe('makeImageRequest', function() {


### PR DESCRIPTION
By default, XMLHttpRequests do not time out. A developer might want to react to
errors by redirecting to an error page, which was only possible by listening
for ravenSuccess and ravenFailure events.

In case of network issues or Sentry being overloaded, error reporting requests
may take a very long time. The newly introduced ravenTimeout event is triggered
once a user-defined timeout has aborted the request.
