### PR TITLE
'sentry' breadcrumb is for subsequent errors, not same error

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1082,8 +1082,10 @@ Raven.prototype = {
         data.extra['session:duration'] = now() - this._startTime;
 
         if (this._breadcrumbs && this._breadcrumbs.length > 0) {
+            // intentionally make shallow copy so that additions
+            // to breadcrumbs aren't accidentally sent in this request
             data.breadcrumbs = {
-                values: this._breadcrumbs
+                values: [].slice.call(this._breadcrumbs, 0)
             };
         }
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -736,11 +736,34 @@ describe('globals', function() {
                 extra: {'session:duration': 100},
                 breadcrumbs: {
                     values: [
-                        { type: 'request', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }},
-                        { type: 'sentry', timestamp: 0.1, /* 100ms */ data: { message: 'bar', eventId: 'abc123' }}
+                        { type: 'request', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }}
                     ]
                 }
             });
+
+        });
+
+        it('should create and append \'sentry\' breadcrumb', function () {
+            this.sinon.stub(Raven, 'isSetup').returns(true);
+            this.sinon.stub(Raven, '_makeRequest');
+            this.sinon.stub(Raven, '_getHttpData').returns({
+                url: 'http://localhost/?a=b',
+                headers: {'User-Agent': 'lolbrowser'}
+            });
+
+            Raven._globalProject = '2';
+            Raven._globalOptions = {
+                logger: 'javascript',
+                maxMessageLength: 100
+            };
+            Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: {method: 'POST', url: 'http://example.org/api/0/auth/'}}];
+
+            Raven._send({message: 'bar'});
+
+            assert.deepEqual(Raven._breadcrumbs, [
+                { type: 'request', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }},
+                { type: 'sentry', timestamp: 0.1, /* 100ms */ data: { message: 'bar', eventId: 'abc123' }}
+            ])
         });
 
         it('should build a good data payload with a User', function() {


### PR DESCRIPTION
Because of reference passing, we were sending out the 'sentry' breadcrumb early (with outbound, matching error).