### PR TITLE
Show ancestor query selectors in click target breadcrumbs

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -17,7 +17,7 @@ var objectMerge = utils.objectMerge;
 var truncate = utils.truncate;
 var urlencode = utils.urlencode;
 var uuid4 = utils.uuid4;
-var htmlElementAsString = utils.htmlElementAsString;
+var htmlTreeAsString = utils.htmlTreeAsString;
 var parseUrl = utils.parseUrl;
 
 var dsnKeys = 'source protocol user pass host port path'.split(' '),
@@ -639,7 +639,7 @@ Raven.prototype = {
             var elem = evt.target;
             self.captureBreadcrumb('ui_event', {
                 type: evtName,
-                target: htmlElementAsString(elem)
+                target: htmlTreeAsString(elem)
             });
         };
     },

--- a/test/integration/frame.html
+++ b/test/integration/frame.html
@@ -74,11 +74,13 @@
 </head>
 <body>
   <!-- test element for breadcrumbs -->
-  <input name="foo" id="bar" placeholder="lol"/>
+  <form id="foo-form">
+    <input name="foo" placeholder="lol"/>
+  </form>
 
-  <div id="c">
-    <div id="b">
-      <div id="a"/>
+  <div class="c">
+    <div class="b">
+      <div class="a"/>
     </div>
   </div>
 </body>

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -441,7 +441,7 @@ describe('integration', function () {
 
                     assert.equal(breadcrumbs[0].type, 'ui_event');
                     // NOTE: attributes re-ordered. should this be expected?
-                    assert.equal(breadcrumbs[0].data.target, 'input#bar[name="foo"][placeholder="lol"]');
+                    assert.equal(breadcrumbs[0].data.target, 'body > form#foo-form > input[name="foo"][placeholder="lol"]');
                     assert.equal(breadcrumbs[0].data.type, 'click');
                 }
             );
@@ -482,7 +482,7 @@ describe('integration', function () {
 
                     assert.equal(breadcrumbs[0].type, 'ui_event');
                     // NOTE: attributes re-ordered. should this be expected?
-                    assert.equal(breadcrumbs[0].data.target, 'input#bar[name="foo"][placeholder="lol"]');
+                    assert.equal(breadcrumbs[0].data.target, 'body > form#foo-form > input[name="foo"][placeholder="lol"]');
                     assert.equal(breadcrumbs[0].data.type, 'click');
                 }
             );
@@ -501,9 +501,9 @@ describe('integration', function () {
                     var clickHandler = function (evt) {
                         //evt.stopPropagation();
                     };
-                    document.getElementById('a').addEventListener('click', clickHandler);
-                    document.getElementById('b').addEventListener('click', clickHandler);
-                    document.getElementById('c').addEventListener('click', clickHandler);
+                    document.querySelector('.a').addEventListener('click', clickHandler);
+                    document.querySelector('.b').addEventListener('click', clickHandler);
+                    document.querySelector('.c').addEventListener('click', clickHandler);
 
                     // click <input/>
                     var evt = document.createEvent('MouseEvent');
@@ -519,7 +519,7 @@ describe('integration', function () {
                         null
                     );
 
-                    var input = document.getElementById('a'); // leaf node
+                    var input = document.querySelector('.a'); // leaf node
                     input.dispatchEvent(evt);
                 },
                 function () {
@@ -530,7 +530,7 @@ describe('integration', function () {
 
                     assert.equal(breadcrumbs[0].type, 'ui_event');
                     // NOTE: attributes re-ordered. should this be expected?
-                    assert.equal(breadcrumbs[0].data.target, 'div#a');
+                    assert.equal(breadcrumbs[0].data.target, 'body > div.c > div.b > div.a');
                     assert.equal(breadcrumbs[0].data.type, 'click');
                 }
             );

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -16,6 +16,7 @@ var joinRegExp = utils.joinRegExp;
 var objectMerge = utils.objectMerge;
 var truncate = utils.truncate;
 var urlencode = utils.urlencode;
+var htmlTreeAsString = utils.htmlTreeAsString;
 var htmlElementAsString = utils.htmlElementAsString;
 var parseUrl = utils.parseUrl;
 
@@ -118,6 +119,60 @@ describe('utils', function () {
         it('should work', function() {
             assert.equal(urlencode({}), '');
             assert.equal(urlencode({'foo': 'bar', 'baz': '1 2'}), 'foo=bar&baz=1%202');
+        });
+    });
+
+    describe('htmlTreeAsString', function () {
+        it('should work', function () {
+            var tree = {
+                tagName: 'INPUT',
+                id: 'the-username',
+                className: 'form-control',
+                getAttribute: function (key){
+                    return {
+                        name: 'username'
+                    }[key];
+                },
+                parentNode: {
+                    tagName: 'span',
+                    getAttribute: function () {},
+                    parentNode: {
+                        tagName: 'div',
+                        getAttribute: function () {},
+                    }
+                }
+            };
+
+            assert.equal(htmlTreeAsString(tree), 'div > span > input#the-username.form-control[name="username"]');
+        });
+
+
+        it('should not create strings that are too big', function () {
+            var tree = {
+                tagName: 'INPUT',
+                id: 'the-username',
+                className: 'form-control',
+                getAttribute: function (key){
+                    return {
+                        name: 'username'
+                    }[key];
+                },
+                parentNode: {
+                    tagName: 'span',
+                    getAttribute: function () {},
+                    parentNode: {
+                        tagName: 'div',
+                        getAttribute: function (key) {
+                            return {
+                                name: 'super long input name that nobody would really ever have i mean come on look at this'
+                            }[key];
+                        }
+                    }
+                }
+            };
+
+            // NOTE: <div/> omitted because crazy long name
+            assert.equal(htmlTreeAsString(tree), 'span > input#the-username.form-control[name="username"]');
         });
     });
 


### PR DESCRIPTION
So instead of just:

```
input[name="password"]
```

We get:

```
form[name="login"] > div > input[name="password"]
```

cc @mitsuhiko @mattrobenolt