### PR TITLE
Collect consecutive keypresses on input elems as "input" breadcrumb

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -3,7 +3,7 @@
 <head>
     <title>Scratch Disk</title>
 </head>
-<script src="../dist/raven.js"></script>
+<script src="../build/raven.js"></script>
 <!-- <script src="scratch.min.js"></script> -->
 <script src="scratch.js" crossorigin></script>
 <script src="file.min.js" crossorigin></script>
@@ -39,6 +39,7 @@ Raven.setUserContext({
 <button onclick="throwString()">throw string</button>
 <button onclick="showDialog()">show dialog</button>
 <button onclick="blobExample()">blob example</button>
+<input/>
 
 </body>
 </html>

--- a/src/raven.js
+++ b/src/raven.js
@@ -637,9 +637,20 @@ Raven.prototype = {
 
             self._lastCapturedEvent = evt;
             var elem = evt.target;
+
+            var target;
+
+            // try/catch htmlTreeAsString because it's particularly complicated, and
+            // just accessing the DOM incorrectly can throw an exception in some circumstances.
+            try {
+                target = htmlTreeAsString(elem);
+            } catch (e) {
+                target = '<unknown>';
+            }
+
             self.captureBreadcrumb('ui_event', {
                 type: evtName,
-                target: htmlTreeAsString(elem)
+                target: target
             });
         };
     },

--- a/src/raven.js
+++ b/src/raven.js
@@ -766,7 +766,7 @@ Raven.prototype = {
             var proto = window[global] && window[global].prototype;
             if (proto && proto.hasOwnProperty && proto.hasOwnProperty('addEventListener')) {
                 fill(proto, 'addEventListener', function(orig) {
-                    return function (evt, fn, capture, secure) { // preserve arity
+                    return function (evtName, fn, capture, secure) { // preserve arity
                         try {
                             if (fn && fn.handleEvent) {
                                 fn.handleEvent = self.wrap(fn.handleEvent);
@@ -779,13 +779,13 @@ Raven.prototype = {
                         // TODO: more than just click
                         var before;
                         if (global === 'EventTarget' || global === 'Node') {
-                            if (evt === 'click'){
-                                before = self._breadcrumbEventHandler(evt, fn);
-                            } else if (evt === 'keypress') {
+                            if (evtName === 'click'){
+                                before = self._breadcrumbEventHandler(evtName);
+                            } else if (evtName === 'keypress') {
                                 before = self._keypressEventHandler();
                             }
                         }
-                        return orig.call(this, evt, self.wrap(fn, undefined, before), capture, secure);
+                        return orig.call(this, evtName, self.wrap(fn, undefined, before), capture, secure);
                     };
                 });
                 fill(proto, 'removeEventListener', function (orig) {

--- a/src/utils.js
+++ b/src/utils.js
@@ -153,6 +153,26 @@ function uuid4() {
     }
 }
 
+// Returns a function, that, as long as it continues to be invoked, will not
+// be triggered. The function will be called after it stops being called for
+// N milliseconds. If `immediate` is passed, trigger the function on the
+// leading edge, instead of the trailing.
+// https://davidwalsh.name/javascript-debounce-function
+function debounce(func, wait) {
+    var timeout;
+    return function() {
+        var context = this,
+            args = arguments;
+
+        var later = function() {
+            timeout = null;
+            func.apply(context, args);
+        };
+        clearTimeout(timeout);
+        timeout = setTimeout(later, wait);
+    };
+};
+
 /**
  * Given a child DOM element, returns a query-selector statement describing that
  * and its ancestors
@@ -245,6 +265,7 @@ module.exports = {
     joinRegExp: joinRegExp,
     urlencode: urlencode,
     uuid4: uuid4,
+    debounce: debounce,
     htmlTreeAsString: htmlTreeAsString,
     htmlElementAsString: htmlElementAsString,
     parseUrl: parseUrl

--- a/src/utils.js
+++ b/src/utils.js
@@ -153,26 +153,6 @@ function uuid4() {
     }
 }
 
-// Returns a function, that, as long as it continues to be invoked, will not
-// be triggered. The function will be called after it stops being called for
-// N milliseconds. If `immediate` is passed, trigger the function on the
-// leading edge, instead of the trailing.
-// https://davidwalsh.name/javascript-debounce-function
-function debounce(func, wait) {
-    var timeout;
-    return function() {
-        var context = this,
-            args = arguments;
-
-        var later = function() {
-            timeout = null;
-            func.apply(context, args);
-        };
-        clearTimeout(timeout);
-        timeout = setTimeout(later, wait);
-    };
-};
-
 /**
  * Given a child DOM element, returns a query-selector statement describing that
  * and its ancestors
@@ -265,7 +245,6 @@ module.exports = {
     joinRegExp: joinRegExp,
     urlencode: urlencode,
     uuid4: uuid4,
-    debounce: debounce,
     htmlTreeAsString: htmlTreeAsString,
     htmlElementAsString: htmlElementAsString,
     parseUrl: parseUrl

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -440,7 +440,6 @@ describe('integration', function () {
                     assert.equal(breadcrumbs.length, 1);
 
                     assert.equal(breadcrumbs[0].type, 'ui_event');
-                    // NOTE: attributes re-ordered. should this be expected?
                     assert.equal(breadcrumbs[0].data.target, 'body > form#foo-form > input[name="foo"][placeholder="lol"]');
                     assert.equal(breadcrumbs[0].data.type, 'click');
                 }
@@ -481,7 +480,6 @@ describe('integration', function () {
                     assert.equal(breadcrumbs.length, 1);
 
                     assert.equal(breadcrumbs[0].type, 'ui_event');
-                    // NOTE: attributes re-ordered. should this be expected?
                     assert.equal(breadcrumbs[0].data.target, 'body > form#foo-form > input[name="foo"][placeholder="lol"]');
                     assert.equal(breadcrumbs[0].data.type, 'click');
                 }
@@ -529,7 +527,6 @@ describe('integration', function () {
                     assert.equal(breadcrumbs.length, 1);
 
                     assert.equal(breadcrumbs[0].type, 'ui_event');
-                    // NOTE: attributes re-ordered. should this be expected?
                     assert.equal(breadcrumbs[0].data.target, 'body > div.c > div.b > div.a');
                     assert.equal(breadcrumbs[0].data.type, 'click');
                 }
@@ -541,39 +538,17 @@ describe('integration', function () {
 
             iframeExecute(iframe, done,
                 function () {
-                    // keypress events are debounced 1000ms - wait until
-                    // the debounce finishes
-                    setTimeout(done, 1001);
+                    setTimeout(done);
 
                     // some browsers trigger onpopstate for load / reset breadcrumb state
                     Raven._breadcrumbs = [];
 
                     // keypress <input/> twice
-                    var keypress1 = document.createEvent('MouseEvent');
-                    keypress1.initMouseEvent(
-                        "keypress",
-                        true /* bubble */,
-                        true /* cancelable */,
-                        window,
-                        null,
-                        0, 0, 0, 0, /* coordinates */
-                        false, false, false, false, /* modifier keys */
-                        0 /*left*/,
-                        null
-                    );
+                    var keypress1 = document.createEvent('KeyboardEvent');
+                    keypress1.initKeyboardEvent("keypress", true, true, window, "b", 66, 0, "", false);
 
-                    var keypress2 = document.createEvent('MouseEvent');
-                    keypress2.initMouseEvent(
-                        "keypress",
-                        true /* bubble */,
-                        true /* cancelable */,
-                        window,
-                        null,
-                        0, 0, 0, 0, /* coordinates */
-                        false, false, false, false, /* modifier keys */
-                        0 /*left*/,
-                        null
-                    );
+                    var keypress2 = document.createEvent('KeyboardEvent');
+                    keypress2.initKeyboardEvent("keypress", true, true, window, "a", 65, 0, "", false);
 
                     var input = document.getElementsByTagName('input')[0];
                     input.dispatchEvent(keypress1);
@@ -586,7 +561,6 @@ describe('integration', function () {
                     assert.equal(breadcrumbs.length, 1);
 
                     assert.equal(breadcrumbs[0].type, 'ui_event');
-                    // NOTE: attributes re-ordered. should this be expected?
                     assert.equal(breadcrumbs[0].data.target, 'body > form#foo-form > input[name="foo"][placeholder="lol"]');
                     assert.equal(breadcrumbs[0].data.type, 'input');
                 }
@@ -603,22 +577,12 @@ describe('integration', function () {
                     // some browsers trigger onpopstate for load / reset breadcrumb state
                     Raven._breadcrumbs = [];
 
-                    // click <input/>
-                    var evt = document.createEvent('MouseEvent');
-                    evt.initMouseEvent(
-                        "keypress",
-                        true /* bubble */,
-                        true /* cancelable */,
-                        window,
-                        null,
-                        0, 0, 0, 0, /* coordinates */
-                        false, false, false, false, /* modifier keys */
-                        0 /*left*/,
-                        null
-                    );
+                    // keypress <input/>
+                    var keypress = document.createEvent('KeyboardEvent');
+                    keypress.initKeyboardEvent("keypress", true, true, window, "b", 66, 0, "", false);
 
                     var input = document.getElementsByTagName('input')[0];
-                    input.dispatchEvent(evt);
+                    input.dispatchEvent(keypress);
 
                     foo(); // throw exception
                 },
@@ -630,7 +594,6 @@ describe('integration', function () {
                     assert.equal(breadcrumbs.length, 2);
 
                     assert.equal(breadcrumbs[0].type, 'ui_event');
-                    // NOTE: attributes re-ordered. should this be expected?
                     assert.equal(breadcrumbs[0].data.target, 'body > form#foo-form > input[name="foo"][placeholder="lol"]');
                     assert.equal(breadcrumbs[0].data.type, 'input');
                 }
@@ -647,23 +610,13 @@ describe('integration', function () {
                     // some browsers trigger onpopstate for load / reset breadcrumb state
                     Raven._breadcrumbs = [];
 
-                    // keypress <input/>
-                    var keypressEvent = document.createEvent('MouseEvent');
-                    keypressEvent.initMouseEvent(
-                        "keypress",
-                        true /* bubble */,
-                        true /* cancelable */,
-                        window,
-                        null,
-                        0, 0, 0, 0, /* coordinates */
-                        false, false, false, false, /* modifier keys */
-                        0 /*left*/,
-                        null
-                    );
+                    // 1st keypress <input/>
+                    var keypress1 = document.createEvent('KeyboardEvent');
+                    keypress1.initKeyboardEvent("keypress", true, true, window, "b", 66, 0, "", false);
 
                     // click <input/>
-                    var clickEvent = document.createEvent('MouseEvent');
-                    clickEvent.initMouseEvent(
+                    var click= document.createEvent('MouseEvent');
+                    click.initMouseEvent(
                         "click",
                         true /* bubble */,
                         true /* cancelable */,
@@ -675,26 +628,34 @@ describe('integration', function () {
                         null
                     );
 
+                    // 2nd keypress
+                    var keypress2 = document.createEvent('KeyboardEvent');
+                    keypress2.initKeyboardEvent("keypress", true, true, window, "a", 65, 0, "", false);
+
                     var input = document.getElementsByTagName('input')[0];
-                    input.dispatchEvent(keypressEvent);
-                    input.dispatchEvent(clickEvent);
+                    input.dispatchEvent(keypress1);
+                    input.dispatchEvent(click);
+                    input.dispatchEvent(keypress2);
                 },
                 function () {
                     var Raven = iframe.contentWindow.Raven,
                         breadcrumbs = Raven._breadcrumbs;
 
                     // 2x `ui_event`
-                    assert.equal(breadcrumbs.length, 2);
+                    assert.equal(breadcrumbs.length, 3);
 
                     assert.equal(breadcrumbs[0].type, 'ui_event');
-                    // NOTE: attributes re-ordered. should this be expected?
                     assert.equal(breadcrumbs[0].data.target, 'body > form#foo-form > input[name="foo"][placeholder="lol"]');
                     assert.equal(breadcrumbs[0].data.type, 'input');
 
                     assert.equal(breadcrumbs[1].type, 'ui_event');
-                    // NOTE: attributes re-ordered. should this be expected?
                     assert.equal(breadcrumbs[1].data.target, 'body > form#foo-form > input[name="foo"][placeholder="lol"]');
                     assert.equal(breadcrumbs[1].data.type, 'click');
+
+                    assert.equal(breadcrumbs[2].type, 'ui_event');
+                    assert.equal(breadcrumbs[2].data.target, 'body > form#foo-form > input[name="foo"][placeholder="lol"]');
+                    assert.equal(breadcrumbs[2].data.type, 'input');
+
                 }
             );
         });


### PR DESCRIPTION
* Only considers keypresses on INPUT or TEXTAREA elements
* ~~Keypresses are debounced 1000ms; but a click or error will flush any queued capture~~
* The first keypress in a series is recorded as the start of an "input" event; only > 1000ms without a typing event will cause it to reset