### PR TITLE
Fix console plugin circular dep causing bad CDN build

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -11,46 +11,21 @@
  */
 'use strict';
 
+var wrapConsoleMethod = require('../src/console').wrapMethod;
+
 function consolePlugin(Raven, console, pluginOptions) {
     console = console || window.console || {};
     pluginOptions = pluginOptions || {};
 
-    var originalConsole = console,
-        logLevels = pluginOptions.levels || ['debug', 'info', 'warn', 'error'],
+    var logLevels = pluginOptions.levels || ['debug', 'info', 'warn', 'error'],
         level = logLevels.pop();
 
-    var logForGivenLevel = function(l) {
-        var originalConsoleLevel = console[l];
-
-        // warning level is the only level that doesn't map up
-        // correctly with what Sentry expects.
-        if (l === 'warn') l = 'warning';
-        return function () {
-            var args = [].slice.call(arguments);
-
-            var msg = '' + args.join(' ');
-            var data = {level: l, logger: 'console', extra: { 'arguments': args }};
-            if (pluginOptions.callback) {
-                pluginOptions.callback(msg, data);
-            } else {
-                Raven.captureMessage(msg, data);
-            }
-
-            // this fails for some browsers. :(
-            if (originalConsoleLevel) {
-                // IE9 doesn't allow calling apply on console functions directly
-                // See: https://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function#answer-5473193
-                Function.prototype.apply.call(
-                    originalConsoleLevel,
-                    originalConsole,
-                    args
-                );
-            }
-        };
+    var callback = function (msg, data) {
+        Raven.captureMessage(msg, data);
     };
 
     while(level) {
-        console[level] = logForGivenLevel(level);
+        wrapConsoleMethod(console, level, callback);
         level = logLevels.pop();
     }
 }

--- a/src/console.js
+++ b/src/console.js
@@ -1,0 +1,37 @@
+'use strict';
+
+var wrapMethod = function(console, level, callback) {
+    var originalConsoleLevel = console[level];
+    var originalConsole = console;
+
+    if (!(level in console)) {
+        return;
+    }
+
+    var sentryLevel = level === 'warn'
+        ? 'warning'
+        : level;
+
+    console[level] = function () {
+        var args = [].slice.call(arguments);
+
+        var msg = '' + args.join(' ');
+        var data = {level: sentryLevel, logger: 'console', extra: {'arguments': args}};
+        callback && callback(msg, data);
+
+        // this fails for some browsers. :(
+        if (originalConsoleLevel) {
+            // IE9 doesn't allow calling apply on console functions directly
+            // See: https://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function#answer-5473193
+            Function.prototype.apply.call(
+                originalConsoleLevel,
+                originalConsole,
+                args
+            );
+        }
+    };
+};
+
+module.exports = {
+    wrapMethod: wrapMethod
+};


### PR DESCRIPTION
So ... including plugins/console.js into raven.js was a bad idea. It created a circular dependency where console.js => singleton.js => raven.js => console.js (and so on) ... causing the CDN build to error  because of the way plugins are auto-initialized.

My solution is to create a new file `src/console.js` and utility method `wrapMethod` that is shared by both raven.js and plugins/console.js. No more circular dependency, no more tears, and the CDN version now builds fine.

There were already unit + integration tests for the console plugin and console breadcrumbs, and everything seems green.

Will cut 3.0.1 after this lands.

cc @mitsuhiko @mattrobenolt 