### PR TITLE
Remove intentional throw on native XHR ...

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1293,9 +1293,6 @@ Raven.prototype = {
     _makeRequest: function(opts) {
         var request = new XMLHttpRequest();
 
-        if (request.send.toString() === 'function send() { [native code] }') {
-            throw new Error('shouldnt get here');
-        }
         // if browser doesn't support CORS (e.g. IE7), we are out of luck
         var hasCORS =
             'withCredentials' in request ||


### PR DESCRIPTION
This was for debugging purposes (to track down errant XHRs in test code), and will always throw unless `install()` was called (most users).

*facepalm*

cc @mattrobenolt @tkaemming 