### PR TITLE
Strip Raven's `wrapped` try/catch call from frames [WIP]

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -265,7 +265,7 @@ Raven.prototype = {
                 return func.apply(this, args);
             } catch(e) {
                 self._ignoreNextOnError();
-                self.captureException(e, options);
+                self.captureException(e, options, 1);
                 throw e;
             }
         }
@@ -310,9 +310,11 @@ Raven.prototype = {
      * @param {object} options A specific set of options for this error [optional]
      * @return {Raven}
      */
-    captureException: function(ex, options) {
+    captureException: function(ex, options, skipframes) {
+        skipframes = skipframes || 0;
+
         // If not an Error is passed through, recall as a message instead
-        if (!isError(ex)) return this.captureMessage(ex, options);
+        if (!isError(ex)) return this.captureMessage(ex, options, skipframes + 1);
 
         // Store the raw exception object for potential debugging and introspection
         this._lastCapturedException = ex;
@@ -324,7 +326,7 @@ Raven.prototype = {
         // report on.
         try {
             var stack = TraceKit.computeStackTrace(ex);
-            this._handleStackInfo(stack, options);
+            this._handleStackInfo(stack, options, skipframes);
         } catch(ex1) {
             if(ex !== ex1) {
                 throw ex1;
@@ -341,7 +343,7 @@ Raven.prototype = {
      * @param {object} options A specific set of options for this message [optional]
      * @return {Raven}
      */
-    captureMessage: function(msg, options) {
+    captureMessage: function(msg, options, skipframes) {
         // config() automagically converts ignoreErrors from a list to a RegExp so we need to test for an
         // early call; we'll error on the side of logging anything called before configuration since it's
         // probably something you should see:
@@ -1005,7 +1007,7 @@ Raven.prototype = {
         }
     },
 
-    _handleStackInfo: function(stackInfo, options) {
+    _handleStackInfo: function(stackInfo, options, skipframes) {
         var self = this;
         var frames = [];
 
@@ -1016,6 +1018,10 @@ Raven.prototype = {
                     frames.push(frame);
                 }
             });
+
+            if (skipframes) {
+                frames = frames.slice(0, skipframes);
+            }
         }
 
         this._triggerEvent('handle', {


### PR DESCRIPTION
When users see try/catch in their stack traces, they believe the bug is Raven's fault (read: ours).

This patch makes it so that the correct number of frames are sliced from the top of the frames array before being sent to Sentry.

This also means that wrapped functions should now produce the same results as strictly doing `window.onerror`. This makes it possible for us to remove function instrumentation from modern browsers that support a fully-functioning `window.onerror` (which we can feature detect).

cc @mattrobenolt @mitsuhiko 
