### PR TITLE
captureMessage can attach stack trace via `stacktrace: true` option

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -132,7 +132,7 @@ module.exports = function(grunt) {
             dest: 'build/raven.test.js',
             options: {
                 browserifyOptions: {
-                    debug: true // source maps
+                    debug: false// source maps
                 },
                 ignore: ['react-native'],
                 plugin: [proxyquire.plugin]

--- a/example/index.html
+++ b/example/index.html
@@ -36,6 +36,7 @@ Raven.setUserContext({
 <button onclick="divide(1, 0)">Sourcemap breakage</button>
 <button onclick="derp()">window.onerror</button>
 <button onclick="testOptions()">test options</button>
+<button onclick="testSynthetic()">test synthetic</button>
 <button onclick="throwString()">throw string</button>
 <button onclick="showDialog()">show dialog</button>
 <button onclick="blobExample()">blob example</button>

--- a/example/scratch.js
+++ b/example/scratch.js
@@ -46,6 +46,12 @@ function showDialog() {
     Raven.showReportDialog();
 }
 
+function testSynthetic() {
+    Raven.captureMessage('synthetic', {
+        stacktrace: true
+    });
+}
+
 function blobExample() {
     var xhr = new XMLHttpRequest();
     xhr.open('GET', 'stack.js');

--- a/src/raven.js
+++ b/src/raven.js
@@ -1129,7 +1129,7 @@ Raven.prototype = {
 
             // e.g. frames captured via captureMessage throw
             if (options && options.trimHeadFrames) {
-                for (var j = frames.length - options.trimHeadFrames; j < frames.length; j++) {
+                for (var j = 0; j < options.trimHeadFrames && j < frames.length; j++) {
                     frames[j].in_app = false;
                 }
                 // ... delete to prevent from appearing in outbound payload

--- a/src/raven.js
+++ b/src/raven.js
@@ -386,9 +386,8 @@ Raven.prototype = {
             ex.name = null;
 
             options = objectMerge({
-                // fingerprint on msg, not stack trace
-                // NOTE: need also to do this because stack could include Raven.wrap,
-                //       which may create inconsistent traces if only using window.onerror
+                // fingerprint on msg, not stack trace (legacy behavior, could be
+                // revisited)
                 fingerprint: msg,
                 trimHeadFrames: (options.trimHeadFrames || 0) + 1
             }, options);

--- a/src/raven.js
+++ b/src/raven.js
@@ -384,8 +384,6 @@ Raven.prototype = {
                 ex = ex1;
             }
 
-            console.log(ex.stack);
-
             // null exception name so `Error` isn't prefixed to msg
             ex.name = null;
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -396,7 +396,7 @@ Raven.prototype = {
             }, options);
 
             var stack = TraceKit.computeStackTrace(ex);
-            var frames = this._buildNormalizedFrames(stack, options);
+            var frames = this._prepareFrames(stack, options);
             data.stacktrace = {
                 // Sentry expects frames oldest to newest
                 frames: frames.reverse()
@@ -1134,14 +1134,14 @@ Raven.prototype = {
             var j;
             if (options && options.trimHeadFrames) {
                 for (j = 0; j < options.trimHeadFrames && j < frames.length; j++) {
-                    frames[j].in_app = true;
+                    frames[j].in_app = false;
                 }
             }
 
             // e.g. try/catch (wrapper) frames
             if (options && options.trimTailFrames) {
                 for (j = options.trimTailFrames; j < frames.length; j++) {
-                    frames[j].in_app = true;
+                    frames[j].in_app = false;
                 }
             }
         }

--- a/src/raven.js
+++ b/src/raven.js
@@ -384,6 +384,8 @@ Raven.prototype = {
                 ex = ex1;
             }
 
+            console.log(ex.stack);
+
             // null exception name so `Error` isn't prefixed to msg
             ex.name = null;
 
@@ -1132,15 +1134,15 @@ Raven.prototype = {
 
             // e.g. frames captured via captureMessage throw
             var j;
-            if (options && options.trimHeadFrames) {
-                for (j = 0; j < options.trimHeadFrames && j < frames.length; j++) {
+            if (options && options.trimTailFrames) {
+                for (j = 0; j < options.trimTailFrames && j < frames.length; j++) {
                     frames[j].in_app = false;
                 }
             }
 
             // e.g. try/catch (wrapper) frames
-            if (options && options.trimTailFrames) {
-                for (j = options.trimTailFrames; j < frames.length; j++) {
+            if (options && options.trimHeadFrames) {
+                for (j = frames.length - options.trimHeadFrames; j < frames.length; j++) {
                     frames[j].in_app = false;
                 }
             }

--- a/src/raven.js
+++ b/src/raven.js
@@ -278,7 +278,9 @@ Raven.prototype = {
                 return func.apply(this, args);
             } catch(e) {
                 self._ignoreNextOnError();
-                self.captureException(e, options, 1);
+                self.captureException(e, objectMerge({
+                    trimTailFrames: 1
+                }, options));
                 throw e;
             }
         }
@@ -323,11 +325,14 @@ Raven.prototype = {
      * @param {object} options A specific set of options for this error [optional]
      * @return {Raven}
      */
-    captureException: function(ex, options, skipframes) {
-        skipframes = skipframes || 0;
-
+    captureException: function(ex, options) {
         // If not an Error is passed through, recall as a message instead
-        if (!isError(ex)) return this.captureMessage(ex, options, skipframes + 1);
+        if (!isError(ex)) {
+            return this.captureMessage(ex, objectMerge({
+                trimHeadFrames: 1,
+                stacktrace: true // if we fall back to captureMessage, default to attempting a new trace
+            }, options));
+        }
 
         // Store the raw exception object for potential debugging and introspection
         this._lastCapturedException = ex;
@@ -339,7 +344,7 @@ Raven.prototype = {
         // report on.
         try {
             var stack = TraceKit.computeStackTrace(ex);
-            this._handleStackInfo(stack, options, skipframes);
+            this._handleStackInfo(stack, options);
         } catch(ex1) {
             if(ex !== ex1) {
                 throw ex1;
@@ -356,7 +361,36 @@ Raven.prototype = {
      * @param {object} options A specific set of options for this message [optional]
      * @return {Raven}
      */
-    captureMessage: function(msg, options, skipframes) {
+    captureMessage: function(msg, options) {
+        if (options.stacktrace) {
+            var ex;
+            // create a stack trace from this point; just trim
+            // off extra frames so they don't include this function call (or
+            // earlier Raven.js library fn calls)
+            try {
+                throw new Error(msg);
+            } catch (ex1) {
+                ex = ex1;
+            }
+
+            // null exception name so `Error` isn't prefixed to msg
+            ex.name = null;
+
+            options = objectMerge({
+                // fingerprint on msg, not stack trace
+                // NOTE: need also to do this because stack could include Raven.wrap,
+                //       which may create inconsistent traces if only using window.onerror
+                fingerprint: msg,
+                trimTailFrames: (options.trimHeadFrames || 0) + 1
+            }, options);
+
+            // infinite loop if ex *somehow* returns false for isError
+            // is that possible when it is result of try/catch?
+            this.captureException(ex, options);
+
+            return this;
+        }
+
         // config() automagically converts ignoreErrors from a list to a RegExp so we need to test for an
         // early call; we'll error on the side of logging anything called before configuration since it's
         // probably something you should see:
@@ -1066,7 +1100,7 @@ Raven.prototype = {
         }
     },
 
-    _handleStackInfo: function(stackInfo, options, skipframes) {
+    _handleStackInfo: function(stackInfo, options) {
         var self = this;
         var frames = [];
 
@@ -1078,8 +1112,13 @@ Raven.prototype = {
                 }
             });
 
-            if (skipframes) {
-                frames = frames.slice(0, skipframes);
+            // e.g. frames captured via captureMessage throw
+            if (options.trimHeadFrames) {
+                frames = frames.slice(options.trimHeadFrames);
+            }
+            // e.g. try/catch (wrapper) frames
+            if (options.trimTailFrames) {
+                frames = frames.slice(0, options.trimTailFrames);
             }
         }
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -278,7 +278,7 @@ Raven.prototype = {
                 return func.apply(this, args);
             } catch(e) {
                 self._ignoreNextOnError();
-                self.captureException(e, options);
+                self.captureException(e, options, 1);
                 throw e;
             }
         }
@@ -323,9 +323,11 @@ Raven.prototype = {
      * @param {object} options A specific set of options for this error [optional]
      * @return {Raven}
      */
-    captureException: function(ex, options) {
+    captureException: function(ex, options, skipframes) {
+        skipframes = skipframes || 0;
+
         // If not an Error is passed through, recall as a message instead
-        if (!isError(ex)) return this.captureMessage(ex, options);
+        if (!isError(ex)) return this.captureMessage(ex, options, skipframes + 1);
 
         // Store the raw exception object for potential debugging and introspection
         this._lastCapturedException = ex;
@@ -337,7 +339,7 @@ Raven.prototype = {
         // report on.
         try {
             var stack = TraceKit.computeStackTrace(ex);
-            this._handleStackInfo(stack, options);
+            this._handleStackInfo(stack, options, skipframes);
         } catch(ex1) {
             if(ex !== ex1) {
                 throw ex1;
@@ -354,7 +356,7 @@ Raven.prototype = {
      * @param {object} options A specific set of options for this message [optional]
      * @return {Raven}
      */
-    captureMessage: function(msg, options) {
+    captureMessage: function(msg, options, skipframes) {
         // config() automagically converts ignoreErrors from a list to a RegExp so we need to test for an
         // early call; we'll error on the side of logging anything called before configuration since it's
         // probably something you should see:
@@ -1064,7 +1066,7 @@ Raven.prototype = {
         }
     },
 
-    _handleStackInfo: function(stackInfo, options) {
+    _handleStackInfo: function(stackInfo, options, skipframes) {
         var self = this;
         var frames = [];
 
@@ -1075,6 +1077,10 @@ Raven.prototype = {
                     frames.push(frame);
                 }
             });
+
+            if (skipframes) {
+                frames = frames.slice(0, skipframes);
+            }
         }
 
         this._triggerEvent('handle', {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2027,6 +2027,29 @@ describe('Raven (public API)', function() {
             });
         });
 
+        it('should include a synthetic stacktrace if stacktrace:true is passed', function () {
+            this.sinon.stub(Raven, 'isSetup').returns(true);
+            this.sinon.stub(Raven, '_send');
+
+            function foo() {
+                Raven.captureMessage('foo', {
+                    stacktrace: true
+                });
+            }
+
+            foo();
+            var frames = Raven._send.lastCall.args[0].stacktrace.frames;
+
+            // Raven.captureMessage
+            var last = frames[frames.length - 1];
+            console.log(last.function);
+            assert.isTrue(/captureMessage/.test(last.function)); // loose equality check because differs per-browser
+            assert.equal(last.in_app, false);
+
+            var secondLast = frames[frames.length - 2];
+            assert.equal(secondLast.function, 'foo');
+            assert.equal(secondLast.in_app, true);
+        });
     });
 
     describe('.captureException', function() {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1757,7 +1757,10 @@ describe('Raven (public API)', function() {
                 Raven.context({foo: 'bar'}, broken);
             }, error);
             assert.isTrue(Raven.captureException.called);
-            assert.deepEqual(Raven.captureException.lastCall.args, [error, {'foo': 'bar'}]);
+            assert.deepEqual(Raven.captureException.lastCall.args, [error, {
+                'foo': 'bar',
+                trimTailFrames: 1 // because wrap
+            }]);
         });
 
         it('should capture the exception without options', function() {
@@ -1768,7 +1771,9 @@ describe('Raven (public API)', function() {
                 Raven.context(broken);
             }, error);
             assert.isTrue(Raven.captureException.called);
-            assert.deepEqual(Raven.captureException.lastCall.args, [error, undefined]);
+            assert.deepEqual(Raven.captureException.lastCall.args, [error, {
+                trimTailFrames: 1 // because wrap
+            }]);
         });
 
         it('should execute the callback without arguments', function() {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1758,8 +1758,7 @@ describe('Raven (public API)', function() {
             }, error);
             assert.isTrue(Raven.captureException.called);
             assert.deepEqual(Raven.captureException.lastCall.args, [error, {
-                'foo': 'bar',
-                trimTailFrames: 1 // because wrap
+                'foo': 'bar'
             }]);
         });
 
@@ -1771,9 +1770,7 @@ describe('Raven (public API)', function() {
                 Raven.context(broken);
             }, error);
             assert.isTrue(Raven.captureException.called);
-            assert.deepEqual(Raven.captureException.lastCall.args, [error, {
-                trimTailFrames: 1 // because wrap
-            }]);
+            assert.deepEqual(Raven.captureException.lastCall.args, [error, undefined]);
         });
 
         it('should execute the callback without arguments', function() {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2042,10 +2042,10 @@ describe('Raven (public API)', function() {
 
             // Raven.captureMessage
             var last = frames[frames.length - 1];
-            console.log(last.function);
-            assert.isTrue(/captureMessage/.test(last.function)); // loose equality check because differs per-browser
+            assert.isTrue(/(captureMessage|^\?)$/.test(last.function)); // loose equality check because differs per-browser
             assert.equal(last.in_app, false);
 
+            // foo
             var secondLast = frames[frames.length - 2];
             assert.equal(secondLast.function, 'foo');
             assert.equal(secondLast.in_app, true);


### PR DESCRIPTION
See also #581

- not by default, must specify new option: `{ stacktrace: true }`
- this can be passed directly to individual `captureMessage` calls, or set globally during `config`
- overrides grouping/fingerprint so that stack trace doesn't change existing behavior
  - good idea? makes sense when user intentionally calls `captureMessage`, but maybe not if `captureMessage` was the result of a failed `captureException` call (e.g. bad error object)
- fixes #544
- fixes #503 (since attached stack trace will include URLs that filters can/will reject)

cc @mattrobenolt @mitsuhiko @dcramer @bradvogel

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/582)
<!-- Reviewable:end -->
