### PR TITLE
Remove remaining deprecated context/fetchContext code

### DIFF
--- a/test/vendor/tracekit-parser.test.js
+++ b/test/vendor/tracekit-parser.test.js
@@ -10,9 +10,9 @@ describe('TraceKit', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_6);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 4);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 48, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'dumpException3', args: [], line: 52, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'onclick', args: [], line: 82, column: null, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 48, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'dumpException3', args: [], line: 52, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'onclick', args: [], line: 82, column: null });
             assert.deepEqual(stackFrames.stack[3], { url: '[native code]', func: '?', args: [], line: null, column: null });
         });
 
@@ -20,18 +20,18 @@ describe('TraceKit', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_7);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 48, column: 22, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 107, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 48, column: 22 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 107 });
         });
 
         it('should parse Safari 8 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_8);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 47, column: 22, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 23, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 47, column: 22 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 23 });
         });
 
         it('should parse Safari 8 eval error', function () {
@@ -40,62 +40,62 @@ describe('TraceKit', function () {
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
             assert.deepEqual(stackFrames.stack[0], { url: '[native code]', func: 'eval', args: [], line: null, column: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 58, column: 21, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 109, column: 91, context: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 58, column: 21 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 109, column: 91 });
         });
 
         it('should parse Firefox 3 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_3);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://127.0.0.1:8000/js/stacktrace.js', func: '?', args: [], line: 44, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://127.0.0.1:8000/js/stacktrace.js', func: '?', args: ['null'], line: 31, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://127.0.0.1:8000/js/stacktrace.js', func: 'printStackTrace', args: [], line: 18, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://127.0.0.1:8000/js/file.js', func: 'bar', args: ['1'], line: 13, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://127.0.0.1:8000/js/file.js', func: 'bar', args: ['2'], line: 16, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[5], { url: 'http://127.0.0.1:8000/js/file.js', func: 'foo', args: [], line: 20, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[6], { url: 'http://127.0.0.1:8000/js/file.js', func: '?', args: [], line: 24, column: null, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://127.0.0.1:8000/js/stacktrace.js', func: '?', args: [], line: 44, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://127.0.0.1:8000/js/stacktrace.js', func: '?', args: ['null'], line: 31, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://127.0.0.1:8000/js/stacktrace.js', func: 'printStackTrace', args: [], line: 18, column: null });
+            assert.deepEqual(stackFrames.stack[3], { url: 'http://127.0.0.1:8000/js/file.js', func: 'bar', args: ['1'], line: 13, column: null });
+            assert.deepEqual(stackFrames.stack[4], { url: 'http://127.0.0.1:8000/js/file.js', func: 'bar', args: ['2'], line: 16, column: null });
+            assert.deepEqual(stackFrames.stack[5], { url: 'http://127.0.0.1:8000/js/file.js', func: 'foo', args: [], line: 20, column: null });
+            assert.deepEqual(stackFrames.stack[6], { url: 'http://127.0.0.1:8000/js/file.js', func: '?', args: [], line: 24, column: null });
         });
 
         it('should parse Firefox 7 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_7);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[0], { url: 'file:///G:/js/stacktrace.js', func: '?', args: [], line: 44, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'file:///G:/js/stacktrace.js', func: '?', args: ['null'], line: 31, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'file:///G:/js/stacktrace.js', func: 'printStackTrace', args: [], line: 18, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[3], { url: 'file:///G:/js/file.js', func: 'bar', args: ['1'], line: 13, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[4], { url: 'file:///G:/js/file.js', func: 'bar', args: ['2'], line: 16, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[5], { url: 'file:///G:/js/file.js', func: 'foo', args: [], line: 20, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[6], { url: 'file:///G:/js/file.js', func: '?', args: [], line: 24, column: null, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'file:///G:/js/stacktrace.js', func: '?', args: [], line: 44, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'file:///G:/js/stacktrace.js', func: '?', args: ['null'], line: 31, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'file:///G:/js/stacktrace.js', func: 'printStackTrace', args: [], line: 18, column: null });
+            assert.deepEqual(stackFrames.stack[3], { url: 'file:///G:/js/file.js', func: 'bar', args: ['1'], line: 13, column: null });
+            assert.deepEqual(stackFrames.stack[4], { url: 'file:///G:/js/file.js', func: 'bar', args: ['2'], line: 16, column: null });
+            assert.deepEqual(stackFrames.stack[5], { url: 'file:///G:/js/file.js', func: 'foo', args: [], line: 20, column: null });
+            assert.deepEqual(stackFrames.stack[6], { url: 'file:///G:/js/file.js', func: '?', args: [], line: 24, column: null });
         });
 
         it('should parse Firefox 14 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_14);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 48, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'dumpException3', args: [], line: 52, column: null, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'onclick', args: [], line: 1, column: null, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 48, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'dumpException3', args: [], line: 52, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'onclick', args: [], line: 1, column: null });
         });
 
         it('should parse Firefox 31 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_31);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 41, column: 13, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 1, column: 1, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '.plugin/e.fn[c]/<', args: [], line: 1, column: 1, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 41, column: 13 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 1, column: 1 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '.plugin/e.fn[c]/<', args: [], line: 1, column: 1 });
         });
 
         it('should parse Firefox 44 ns exceptions', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_44_NS_EXCEPTION);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 4);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '[2]</Bar.prototype._baz/</<', args: [], line: 703, column: 28, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'file:///path/to/file.js', func: 'App.prototype.foo', args: [], line: 15, column: 2, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'file:///path/to/file.js', func: 'bar', args: [], line: 20, column: 3, context: null });
-            assert.deepEqual(stackFrames.stack[3], { url: 'file:///path/to/index.html', func: '?', args: [], line: 23, column: 1, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '[2]</Bar.prototype._baz/</<', args: [], line: 703, column: 28 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'file:///path/to/file.js', func: 'App.prototype.foo', args: [], line: 15, column: 2 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'file:///path/to/file.js', func: 'bar', args: [], line: 20, column: 3 });
+            assert.deepEqual(stackFrames.stack[3], { url: 'file:///path/to/index.html', func: '?', args: [], line: 23, column: 1 });
         });
 
         it('should parse Chrome error with no location', function () {
@@ -108,31 +108,31 @@ describe('TraceKit', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_15);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 4);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 13, column: 17, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 16, column: 5, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 20, column: 5, context: null });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: '?', args: [], line: 24, column: 4, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 13, column: 17 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 16, column: 5 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 20, column: 5 });
+            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: '?', args: [], line: 24, column: 4 });
         });
 
         it('should parse Chrome 36 error with port numbers', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_36);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8080/file.js', func: 'dumpExceptionError', args: [], line: 41, column: 27, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8080/file.js', func: 'HTMLButtonElement.onclick', args: [], line: 107, column: 146, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8080/file.js', func: 'I.e.fn.(anonymous function) [as index]', args: [], line: 10, column: 3651, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8080/file.js', func: 'dumpExceptionError', args: [], line: 41, column: 27 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8080/file.js', func: 'HTMLButtonElement.onclick', args: [], line: 107, column: 146 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8080/file.js', func: 'I.e.fn.(anonymous function) [as index]', args: [], line: 10, column: 3651 });
         });
 
         it('should parse Chrome error with blob URLs', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_48_BLOB);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[1], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 's', args: [], line: 31, column: 29146, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 'Object.d [as add]', args: [  ], line: 31, column: 30039, context: null });
-            assert.deepEqual(stackFrames.stack[3], { url: 'blob:http%3A//localhost%3A8080/d4eefe0f-361a-4682-b217-76587d9f712a', func: '?', args: [], line: 15, column: 10978, context: null });
-            assert.deepEqual(stackFrames.stack[4], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: '?', args: [], line: 1, column: 6911, context: null });
-            assert.deepEqual(stackFrames.stack[5], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 'n.fire', args: [], line: 7, column: 3019, context: null });
-            assert.deepEqual(stackFrames.stack[6], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 'n.handle', args: [], line: 7, column: 2863, context: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 's', args: [], line: 31, column: 29146 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 'Object.d [as add]', args: [  ], line: 31, column: 30039 });
+            assert.deepEqual(stackFrames.stack[3], { url: 'blob:http%3A//localhost%3A8080/d4eefe0f-361a-4682-b217-76587d9f712a', func: '?', args: [], line: 15, column: 10978 });
+            assert.deepEqual(stackFrames.stack[4], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: '?', args: [], line: 1, column: 6911 });
+            assert.deepEqual(stackFrames.stack[5], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 'n.fire', args: [], line: 7, column: 3019 });
+            assert.deepEqual(stackFrames.stack[6], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 'n.handle', args: [], line: 7, column: 2863 });
         });
 
         it('should parse empty IE 9 error', function() {
@@ -146,9 +146,9 @@ describe('TraceKit', function () {
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
             // TODO: func should be normalized
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'Anonymous function', args: [], line: 48, column: 13, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 46, column: 9, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 82, column: 1, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'Anonymous function', args: [], line: 48, column: 13 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 46, column: 9 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 82, column: 1 });
         });
 
         it('should parse IE 11 error', function () {
@@ -156,9 +156,9 @@ describe('TraceKit', function () {
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
             // TODO: func should be normalized
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'Anonymous function', args: [], line: 47, column: 21, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 45, column: 13, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 1, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'Anonymous function', args: [], line: 47, column: 21 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 45, column: 13 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 1 });
         });
 
 
@@ -166,82 +166,82 @@ describe('TraceKit', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.IE_11_EVAL);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'eval code', func: 'eval code', args: [], line: 1, column: 1, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 58, column: 17, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 109, column: 1, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'eval code', func: 'eval code', args: [], line: 1, column: 1 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 58, column: 17 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 109, column: 1 });
         });
 
         it('should parse Opera 8.54 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_854);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 44, column: null, context: [ '    this.undef();' ] });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: '?', args: [], line: 31, column: null, context: [ '    ex = ex || this.createException();' ] });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '?', args: [], line: 18, column: null, context: [ '    var p = new printStackTrace.implementation(), result = p.run(ex);' ] });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: '?', args: [], line: 4, column: null, context: [ '    printTrace(printStackTrace());' ] });
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: '?', args: [], line: 7, column: null, context: [ '    bar(n - 1);' ] });
-            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: '?', args: [], line: 11, column: null, context: [ '    bar(2);' ] });
-            assert.deepEqual(stackFrames.stack[6], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: null, context: [ '    foo();' ] });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 44, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: '?', args: [], line: 31, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '?', args: [], line: 18, column: null });
+            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: '?', args: [], line: 4, column: null });
+            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: '?', args: [], line: 7, column: null });
+            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: '?', args: [], line: 11, column: null });
+            assert.deepEqual(stackFrames.stack[6], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: null });
         });
 
         it('should parse Opera 9.02 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_902);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 44, column: null, context: [ '    this.undef();' ] });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: '?', args: [], line: 31, column: null, context: [ '    ex = ex || this.createException();' ] });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '?', args: [], line: 18, column: null, context: [ '    var p = new printStackTrace.implementation(), result = p.run(ex);' ] });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: '?', args: [], line: 4, column: null, context: [ '    printTrace(printStackTrace());' ] });
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: '?', args: [], line: 7, column: null, context: [ '    bar(n - 1);' ] });
-            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: '?', args: [], line: 11, column: null, context: [ '    bar(2);' ] });
-            assert.deepEqual(stackFrames.stack[6], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: null, context: [ '    foo();' ] });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 44, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: '?', args: [], line: 31, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '?', args: [], line: 18, column: null });
+            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: '?', args: [], line: 4, column: null });
+            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: '?', args: [], line: 7, column: null });
+            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: '?', args: [], line: 11, column: null });
+            assert.deepEqual(stackFrames.stack[6], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: null });
         });
 
         it('should parse Opera 9.27 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_927);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 43, column: null, context: [ '    bar(n - 1);' ] });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: '?', args: [], line: 31, column: null, context: [ '    bar(2);' ] });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '?', args: [], line: 18, column: null, context: [ '    foo();' ] });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 43, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: '?', args: [], line: 31, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '?', args: [], line: 18, column: null });
         });
 
         it('should parse Opera 9.64 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_964);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 6);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 27, column: null, context: [ '            ex = ex || this.createException();' ] });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'printStackTrace', args: [], line: 18, column: null, context: [ '        var p = new printStackTrace.implementation(), result = p.run(ex);' ] });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 4, column: null, context: [ '             printTrace(printStackTrace());' ] });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 7, column: null, context: [ '           bar(n - 1);' ] });
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 11, column: null, context: [ '           bar(2);' ] });
-            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: null, context: [ '         foo();' ] });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 27, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'printStackTrace', args: [], line: 18, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 4, column: null });
+            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 7, column: null });
+            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 11, column: null });
+            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: null });
         });
 
         it('should parse Opera 10 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_10);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 42, column: null, context: [ '                this.undef();' ] });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: '?', args: [], line: 27, column: null, context: [ '            ex = ex || this.createException();' ] });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'printStackTrace', args: [], line: 18, column: null, context: [ '        var p = new printStackTrace.implementation(), result = p.run(ex);' ] });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 4, column: null, context: [ '             printTrace(printStackTrace());' ] });
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 7, column: null, context: [ '           bar(n - 1);' ] });
-            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 11, column: null, context: [ '           bar(2);' ] });
-            assert.deepEqual(stackFrames.stack[6], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: null, context: [ '         foo();' ] });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 42, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: '?', args: [], line: 27, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'printStackTrace', args: [], line: 18, column: null });
+            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 4, column: null });
+            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 7, column: null });
+            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 11, column: null });
+            assert.deepEqual(stackFrames.stack[6], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: null });
         });
 
         it('should parse Opera 11 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_11);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'createException', args: [], line: 42, column: 12, context: [ '    this.undef();' ] });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'run', args: ['ex'], line: 27, column: 8, context: [ '    ex = ex || this.createException();' ] });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'printStackTrace', args: ['options'], line: 18, column: 4, context: [ '    var p = new printStackTrace.implementation(), result = p.run(ex);' ] });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: 'bar', args: ['n'], line: 4, column: 5, context: [ '    printTrace(printStackTrace());' ] });
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: 'bar', args: ['n'], line: 7, column: 4, context: [ '    bar(n - 1);' ] });
-            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 11, column: 4, context: [ '    bar(2);' ] });
-            assert.deepEqual(stackFrames.stack[6], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: 3, context: [ '    foo();' ] });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'createException', args: [], line: 42, column: 12 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'run', args: ['ex'], line: 27, column: 8 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'printStackTrace', args: ['options'], line: 18, column: 4 });
+            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: 'bar', args: ['n'], line: 4, column: 5 });
+            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: 'bar', args: ['n'], line: 7, column: 4 });
+            assert.deepEqual(stackFrames.stack[5], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 11, column: 4 });
+            assert.deepEqual(stackFrames.stack[6], { url: 'http://path/to/file.js', func: '?', args: [], line: 15, column: 3 });
         });
 
         it('should parse Opera 12 error', function () {
@@ -249,18 +249,18 @@ describe('TraceKit', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_12);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8000/ExceptionLab.html', func: '<anonymous function>', args: ['x'], line: 48, column: 12, context: [ '    x.undef();' ] });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8000/ExceptionLab.html', func: 'dumpException3', args: [], line: 46, column: 8, context: [ '    dumpException((function(x) {' ] });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8000/ExceptionLab.html', func: '<anonymous function>', args: ['event'], line: 1, column: 0, context: [ '    dumpException3();' ] });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8000/ExceptionLab.html', func: '<anonymous function>', args: ['x'], line: 48, column: 12 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8000/ExceptionLab.html', func: 'dumpException3', args: [], line: 46, column: 8 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8000/ExceptionLab.html', func: '<anonymous function>', args: ['event'], line: 1, column: 0 });
         });
 
         it('should parse Opera 25 error', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_25);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 47, column: 22, context: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15, context: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 168, context: null });
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 47, column: 22 });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15 });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 168 });
         });
     });
 });

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -175,7 +175,6 @@ TraceKit.report = (function reportModuleWrapper() {
             }
 
             location.func = UNKNOWN_FUNCTION;
-            location.context = null;
 
             stack = {
                 'name': name,
@@ -278,7 +277,6 @@ TraceKit.report = (function reportModuleWrapper() {
  *   s.stack[i].args     - arguments passed to the function, if known
  *   s.stack[i].line     - line number, if known
  *   s.stack[i].column   - column number, if known
- *   s.stack[i].context  - an array of source code lines; the middle element corresponds to the correct line#
  *
  * Supports:
  *   - Firefox:  full stack trace with line numbers and unreliable column
@@ -428,10 +426,6 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
                 element.func = UNKNOWN_FUNCTION;
             }
 
-            if (element.line) {
-                element.context = null;
-            }
-
             stack.push(element);
         }
 
@@ -497,7 +491,6 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
                 if (!element.func && element.line) {
                     element.func = UNKNOWN_FUNCTION;
                 }
-                element.context = [lines[line + 1]];
 
                 stack.push(element);
             }
@@ -585,7 +578,6 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
                 if (!item.func) {
                     item.func = UNKNOWN_FUNCTION;
                 }
-                item.context = [lines[line + 1]];
 
                 stack.push(item);
             }
@@ -635,7 +627,6 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
                         return false; // already in stack trace
                     } else if (!stackInfo.stack[0].line && stackInfo.stack[0].func === initial.func) {
                         stackInfo.stack[0].line = initial.line;
-                        stackInfo.stack[0].context = initial.context;
                         return false;
                     }
                 }


### PR DESCRIPTION
In #542 we removed most of TraceKit's source fetching code (everything except TraceKit's context parsing of old Opera error messages).

This finishes the job by killing the remaining TraceKit code, and also removing `_extractContextFromFrame` from src/raven.js.

_To clarify once again, this only removes client-side context/source fetching. Sentry server will still fetch source/context from 1) your publicly-accessible JavaScript sources, and 2) release artifacts uploaded directly to Sentry._