### PR TITLE
Remove remaining references to fetchContext/remoteFetching/linesOfContext

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -146,14 +146,6 @@ Raven.prototype = {
         this._globalEndpoint = this._globalServer +
             '/' + path + 'api/' + this._globalProject + '/store/';
 
-        if (this._globalOptions.fetchContext) {
-            TraceKit.remoteFetching = true;
-        }
-
-        if (this._globalOptions.linesOfContext) {
-            TraceKit.linesOfContext = this._globalOptions.linesOfContext;
-        }
-
         TraceKit.collectWindowErrors = !!this._globalOptions.collectWindowErrors;
 
         // return for chaining

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -30,8 +30,6 @@ var SENTRY_DSN = 'http://abc@example.com:80/2';
 
 function setupRaven() {
     Raven.config(SENTRY_DSN);
-
-    Raven._globalOptions.fetchContext = true;
 }
 
 
@@ -254,8 +252,6 @@ describe('globals', function() {
                 // context: []    context is stubbed
             };
 
-            Raven._globalOptions.fetchContext = true;
-
             assert.deepEqual(Raven._normalizeFrame(frame), {
                 filename: 'http://example.com/path/file.js',
                 lineno: 10,
@@ -290,7 +286,6 @@ describe('globals', function() {
                 func: 'lol'
             };
 
-            Raven._globalOptions.fetchContext = true;
             Raven._globalOptions.includePaths = /^http:\/\/example\.com/;
 
             assert.deepEqual(Raven._normalizeFrame(frame), {
@@ -310,7 +305,6 @@ describe('globals', function() {
                 func: 'lol'
             };
 
-            Raven._globalOptions.fetchContext = true;
             Raven._globalOptions.includePaths = /^http:\/\/example\.com/;
 
             assert.deepEqual(Raven._normalizeFrame(frame), {

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -12,10 +12,7 @@ var isUndefined = utils.isUndefined;
 */
 
 var TraceKit = {
-    remoteFetching: false,
     collectWindowErrors: true,
-    // 3 lines before, the offending line, 3 lines after
-    linesOfContext: 7,
     debug: false
 };
 


### PR DESCRIPTION
Apparently we didn't even document these options.