### PR TITLE
Bugfix for IE8 compatibility

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -813,8 +813,15 @@ Raven.prototype = {
         // Capture breadcrubms from any click that is unhandled / bubbled up all the way
         // to the document. Do this before we instrument addEventListener.
         if (this._hasDocument) {
-            document.addEventListener('click', self._breadcrumbEventHandler('click'));
-            document.addEventListener('keypress', self._keypressEventHandler());
+            if (document.addEventListener) {
+                document.addEventListener('click', self._breadcrumbEventHandler('click'));
+                document.addEventListener('keypress', self._keypressEventHandler());
+            }
+            else {
+                // IE8 Compatibility
+                document.attachEvent('onclick', self._breadcrumbEventHandler('click'));
+                document.attachEvent('onkeypress', self._keypressEventHandler());
+            }
         }
 
         // event targets borrowed from bugsnag-js:

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2130,6 +2130,23 @@ describe('install/uninstall', function () {
             Raven.install();
             assert.isTrue(TraceKit.report.subscribe.calledOnce);
         });
+
+        it('should use attachEvent instead of addEventListener in IE8', function () {
+            // Maintain a ref to the old function so we can restore it later.
+            var temp = document.addEventListener;
+
+            // Test setup.
+            this.sinon.stub(Raven, 'isSetup').returns(true);
+            document.addEventListener = false;
+            document.attachEvent = this.sinon.stub();
+
+            // Invoke and assert.
+            Raven.install();
+            assert.isTrue(document.attachEvent.called);
+
+            // Cleanup.
+            document.addEventListener = temp;
+        });
     });
 
     describe('.uninstall', function() {


### PR DESCRIPTION
## Problem

#594 -- addEventListener doesn't work in IE8

## Solution

If `addEventListener` exists, use it, otherwise use `attachEvent`.

## Tests

I noticed you have to run `grunt run:test` _after_ `grunt test`. `run:test` seems to only serve, not build. Could be worth investigating :)

1. `grunt test`
2. `grunt run:test`
3. [http://localhost:8000/test/?grep=install%2Funinstall](http://localhost:8000/test/?grep=install%2Funinstall)

