### PR TITLE
[react-native] Support for a custom URI normalization function

### DIFF
--- a/test/plugins/react-native.test.js
+++ b/test/plugins/react-native.test.js
@@ -39,12 +39,14 @@ describe('React Native plugin', function () {
                     }],
                 }
             };
-            reactNativePlugin._normalizeData(data);
+            reactNativePlugin._normalizeData(data, function(uri) {
+                return uri.replace(/^.*\//, '');
+            });
 
-            assert.equal(data.culprit, '/app.js');
+            assert.equal(data.culprit, 'app.js');
             var frames = data.exception.values[0].stacktrace.frames;
-            assert.equal(frames[0].filename, '/file1.js');
-            assert.equal(frames[1].filename, '/file2.js');
+            assert.equal(frames[0].filename, 'file1.js');
+            assert.equal(frames[1].filename, 'file2.js');
         });
     });
 


### PR DESCRIPTION
You can now pass `normalizeUrl` as an argument when initializing the react native plugin.  It is a function that returns the normalized path for use when retrieving release assets

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/598)
<!-- Reviewable:end -->
