### PR TITLE
Don't trim exception msgs before dataCallback

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1061,10 +1061,7 @@ Raven.prototype = {
         if (!!this._globalOptions.ignoreErrors.test && this._globalOptions.ignoreErrors.test(message)) return;
 
         message += '';
-        message = truncate(message, this._globalOptions.maxMessageLength);
-
         fullMessage = (type ? type + ': ' : '') + message;
-        fullMessage = truncate(fullMessage, this._globalOptions.maxMessageLength);
 
         if (frames && frames.length) {
             fileurl = frames[0].filename || fileurl;


### PR DESCRIPTION
Fixes #605 

Truncation still takes place [in Raven.prototype._trimPacket](https://github.com/getsentry/raven-js/blob/master/dist/raven.js#L1215), which is called right before transmission to the Sentry server. We have [truncation tests](https://github.com/getsentry/raven-js/blob/master/test/raven.test.js#L1077) and they are unaffected by this change.

cc @mattrobenolt – anything I'm missing?
