### PR TITLE
Add Angular 2 integration instructions

### DIFF
--- a/docs/integrations/angular.rst
+++ b/docs/integrations/angular.rst
@@ -1,16 +1,13 @@
-AngularJS
+Angular 1
 =========
 
-.. versionadded:: 1.3.0
-   Prior to 1.3.0, we had an Angular plugin, but was undocumented. 1.3.0 comes with a rewritten version with better support.
-
-To use Sentry with your Angular application, you will need to use both Raven.js (Sentry's browser JavaScript SDK) and the Raven.js Angular plugin.
+To use Sentry with your Angular 1.x application, you will need to use both Raven.js (Sentry's browser JavaScript SDK) and the Raven.js Angular plugin.
 
 On its own, Raven.js will report any uncaught exceptions triggered from your application. For advanced usage examples of Raven.js, please read :doc:`Raven.js usage <../usage>`.
 
 Additionally, the Raven.js Angular plugin will catch any Angular-specific exceptions reported through Angular's ``$exceptionHandler`` interface.
 
-**Note**: The Angular integration supports Angular 1.x.
+**Note**: This documentation is for Angular 1.x. See also: Angular 2.x.
 
 Installation
 ------------

--- a/docs/integrations/angular.rst
+++ b/docs/integrations/angular.rst
@@ -7,7 +7,7 @@ On its own, Raven.js will report any uncaught exceptions triggered from your app
 
 Additionally, the Raven.js Angular plugin will catch any Angular-specific exceptions reported through Angular's ``$exceptionHandler`` interface.
 
-**Note**: This documentation is for Angular 1.x. See also: Angular 2.x.
+**Note**: This documentation is for Angular 1.x. See also: :doc:`Angular 2.x <angular2>`
 
 Installation
 ------------

--- a/docs/integrations/angular2.rst
+++ b/docs/integrations/angular2.rst
@@ -1,0 +1,74 @@
+Angular 2
+=========
+
+On its own, Raven.js will report any uncaught exceptions triggered from your application. For advanced usage examples of Raven.js, please read :doc:`Raven.js usage <../usage>`.
+
+Additionally, Raven.js can be configured to catch any Angular 2-specific exceptions reported through the `angular2/core/ExceptionHandler
+<https://angular.io/docs/js/latest/api/core/index/ExceptionHandler-class.html>`_ component.
+
+**Note**: This document assumes you are writing your Angular 2 project in TypeScript, and using `SystemJS
+<https://github.com/systemjs/systemjs>`_ as your module bundler.
+
+
+TypeScript Support
+~~~~~~~~~~~~~~~~~~
+
+Raven.js ships with a `TypeScript declaration file
+<https://github.com/getsentry/raven-js/blob/master/typescript/raven.d.ts>`_, which helps static checking correctness of
+Raven.js API calls, and facilitates auto-complete in TypeScript-aware IDEs like Visual Studio Code.
+
+
+Installation
+------------
+
+Raven.js should be installed via npm.
+
+.. code-block:: sh
+
+    $ npm install raven-js --save
+
+
+Configuration
+-------------
+
+First, configure SystemJS to locate the Raven.js package:
+
+.. code-block:: js
+
+    System.config({
+        packages: {
+            /* ... existing packages above ... */
+            'raven-js': {
+              main: 'dist/raven.js'
+            }
+        },
+        paths: {
+            /* ... existing paths above ... */
+            'raven-js': 'node_modules/raven-js'
+        }
+    });
+
+Then, in your main application file (where ``bootstrap`` is called, e.g. main.ts):
+
+.. code-block:: js
+
+    import Raven from 'raven-js';
+    import { bootstrap } from 'angular2/platform/browser';
+    import { MainApp } from './app.component';
+    import { provide, ExceptionHandler } from 'angular2/core';
+
+    Raven
+        .config('__PUBLIC_DSN__')
+        .install();
+
+    class RavenExceptionHandler {
+      call(err:any) {
+        Raven.captureException(err.originalException);
+      }
+    }
+
+    bootstrap(MainApp, [
+        provide(ExceptionHandler, {useClass: RavenExceptionHandler})
+    ]);
+
+Once you've completed these two steps, you are done.

--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -34,6 +34,7 @@ To install a plugin just include the plugin **after** Raven has been loaded and 
    :maxdepth: 1
 
    angular
+   angular2
    backbone
    ember
    react


### PR DESCRIPTION
Note there's no plugin for this. Wrapping the Angular exception handler is really easy (see docs) – it seems silly to publish a plugin for what is a 4-line wrapper around `ExceptionHandler`.

If the integration becomes more complicated in the future, we can change it.

cc @mattrobenolt @mitsuhiko 