### PR TITLE
Fix pushState exception when run inside Chrome Apps (fixes #601)

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -889,7 +889,12 @@ Raven.prototype = {
         }
 
         // record navigation (URL) changes
-        if ('history' in window && history.pushState) {
+        // NOTE: in Chrome App environment, touching history.pushState, *even inside
+        //       a try/catch block*, will cause Chrome to output an error to console.error
+        // borrowed from: https://github.com/angular/angular.js/pull/13945/files
+        var isChromePackagedApp = window.chrome && chrome.app && chrome.app.runtime;
+        var hasPushState = !isChromePackagedApp && window.history && history.pushState;
+        if (hasPushState) {
             // TODO: remove onpopstate handler on uninstall()
             var oldOnPopState = window.onpopstate;
             window.onpopstate = function () {

--- a/src/raven.js
+++ b/src/raven.js
@@ -892,7 +892,8 @@ Raven.prototype = {
         // NOTE: in Chrome App environment, touching history.pushState, *even inside
         //       a try/catch block*, will cause Chrome to output an error to console.error
         // borrowed from: https://github.com/angular/angular.js/pull/13945/files
-        var isChromePackagedApp = window.chrome && chrome.app && chrome.app.runtime;
+        var chrome = window.chrome;
+        var isChromePackagedApp = chrome && chrome.app && chrome.app.runtime;
         var hasPushState = !isChromePackagedApp && window.history && history.pushState;
         if (hasPushState) {
             // TODO: remove onpopstate handler on uninstall()


### PR DESCRIPTION
I verified this fix using the "Hello, World" example from Chrome's [chrome-app-samples](https://github.com/GoogleChrome/chrome-app-samples) repo.

Wondering if it's worth emulating this environment (`window.chrome.app`) in one of our integration tests (probably).

cc @mattrobenolt 