### PR TITLE
[react-native] capture and report fatals on next launch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -128,11 +128,12 @@ module.exports = function(grunt) {
         },
         test: {
             src: 'test/**/*.test.js',
-                dest: 'build/raven.test.js',
-                options: {
+            dest: 'build/raven.test.js',
+            options: {
                 browserifyOptions: {
                     debug: true // source maps
                 },
+                ignore: ['react-native'],
                 plugin: [proxyquire.plugin]
             }
         }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "json-stringify-safe": "^5.0.1"
   },
   "devDependencies": {
+    "bluebird": "^3.4.1",
     "browserify-versionify": "^1.0.6",
     "bundle-collapser": "^1.2.1",
     "chai": "2.3.0",


### PR DESCRIPTION
Addresses #468, #533, and _maybe_ #489 

---

When a fatal (global) error is thrown, raven-js now captures it and persists it before calling the original error handler when in production mode (e.g. so the JS error can bubble out and crash the app).  Then, when the react native plugin initializes, it checks for a persisted error, and reports it.

Some finer details:

* In development mode, errors are _not_ persisted, and the default error handler is _always_ called.  This allows redboxes to pop as expected.
* Any subsequent fatals thrown while raven-js is persisting the first one are ignored (we want to crash ASAP).
* If the error fails to report; it won't be cleared.  This provides a _very_ rudimentary retry mechanism (true offline support should be implemented more robustly, IMO).
* I snuck in `Raven.addShouldSendCallback` so that the react-native plugin doesn't bash over existing configurations
* `onInitialize` is useful for detecting if an error was previously reported (say, if you want to pop a "we're sorry" alert, or fix up your store)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/626)
<!-- Reviewable:end -->
