### PR TITLE
Don't additionally pass msg if exception interface set

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -341,11 +341,10 @@ Raven.prototype = {
             return;
         }
 
-        msg = msg + ''; // Make sure it's actually a string
         // Fire away!
         this._send(
             objectMerge({
-                message: msg,
+                message: + '' // Make sure it's actually a string,
             }, options)
         );
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -344,7 +344,7 @@ Raven.prototype = {
         // Fire away!
         this._send(
             objectMerge({
-                message: msg + '' // Make sure it's actually a string,
+                message: msg + ''  // Make sure it's actually a string
             }, options)
         );
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -341,10 +341,11 @@ Raven.prototype = {
             return;
         }
 
+        msg = msg + ''; // Make sure it's actually a string
         // Fire away!
         this._send(
             objectMerge({
-                message: msg + ''  // Make sure it's actually a string
+                message: msg,
             }, options)
         );
 
@@ -1062,12 +1063,11 @@ Raven.prototype = {
     },
 
     _processException: function(type, message, fileurl, lineno, frames, options) {
-        var stacktrace, fullMessage;
+        var stacktrace;
 
         if (!!this._globalOptions.ignoreErrors.test && this._globalOptions.ignoreErrors.test(message)) return;
 
         message += '';
-        fullMessage = (type ? type + ': ' : '') + message;
 
         if (frames && frames.length) {
             fileurl = frames[0].filename || fileurl;
@@ -1097,8 +1097,7 @@ Raven.prototype = {
                     stacktrace: stacktrace
                 }]
             },
-            culprit: fileurl,
-            message: fullMessage
+            culprit: fileurl
         }, options);
 
         // Fire away!
@@ -1220,9 +1219,12 @@ Raven.prototype = {
             auth.sentry_secret = this._globalSecret;
         }
 
+        var exception = data.exception && data.exception.values[0];
         this.captureBreadcrumb({
             category: 'sentry',
-            message: data.message,
+            message: exception
+                ? (exception.type ? exception.type + ': ' : '') + exception.message
+                : data.message,
             event_id: data.event_id,
             level: data.level || 'error' // presume error unless specified
         });

--- a/src/raven.js
+++ b/src/raven.js
@@ -344,7 +344,7 @@ Raven.prototype = {
         // Fire away!
         this._send(
             objectMerge({
-                message: + '' // Make sure it's actually a string,
+                message: msg + '' // Make sure it's actually a string,
             }, options)
         );
 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -91,7 +91,7 @@ describe('integration', function () {
                 },
                 function () {
                     var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.isTrue(/SyntaxError/.test(ravenData.message)); // full message differs per-browser
+                    assert.isTrue(/SyntaxError/.test(ravenData.exception.values[0].type)); // full message differs per-browser
                     assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1); // just one frame
                 }
             );

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -482,8 +482,7 @@ describe('globals', function() {
                         }
                     }]
                 },
-                culprit: 'http://example.com/file1.js',
-                message: 'Error: lol'
+                culprit: 'http://example.com/file1.js'
             }]);
 
             Raven._processException('Error', 'lol', '', 10, frames.slice(0), {});
@@ -497,8 +496,7 @@ describe('globals', function() {
                         }
                     }]
                 },
-                culprit: 'http://example.com/file1.js',
-                message: 'Error: lol'
+                culprit: 'http://example.com/file1.js'
             }]);
 
             Raven._processException('Error', 'lol', '', 10, frames.slice(0), {extra: 'awesome'});
@@ -513,7 +511,6 @@ describe('globals', function() {
                     }]
                 },
                 culprit: 'http://example.com/file1.js',
-                message: 'Error: lol',
                 extra: 'awesome'
             }]);
         });
@@ -536,8 +533,7 @@ describe('globals', function() {
                         }
                     }]
                 },
-                culprit: 'http://example.com/override.js',
-                message: 'Error: lol'
+                culprit: 'http://example.com/override.js'
             }]);
 
             Raven._processException('Error', 'lol', 'http://example.com/override.js', 10, [], {});
@@ -555,8 +551,7 @@ describe('globals', function() {
                         }
                     }]
                 },
-                culprit: 'http://example.com/override.js',
-                message: 'Error: lol'
+                culprit: 'http://example.com/override.js'
             }]);
 
             Raven._processException('Error', 'lol', 'http://example.com/override.js', 10, [], {extra: 'awesome'});
@@ -575,7 +570,6 @@ describe('globals', function() {
                     }]
                 },
                 culprit: 'http://example.com/override.js',
-                message: 'Error: lol',
                 extra: 'awesome'
             }]);
         });
@@ -585,13 +579,6 @@ describe('globals', function() {
 
             Raven._processException('TypeError', undefined, 'http://example.com', []);
             assert.isTrue(Raven._send.called);
-        });
-
-        it('should omit error name as part of message if error name is undefined/falsy', function () {
-            this.sinon.stub(Raven, '_send');
-
-            Raven._processException(undefined, '\'foo\' is undefined', 'http://example.com', 10); // IE9 ReferenceError
-            assert.deepEqual(Raven._send.lastCall.args[0].message, '\'foo\' is undefined');
         });
     });
 


### PR DESCRIPTION
This removes the redundant "message" interface inside of the Sentry UI if an exception is passed. The message interface will appear if captured via `captureMessage` / no exception.

cc @mattrobenolt @dcramer 