### PR TITLE
Record error/message level in breadcrumb (fixes #580)

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1223,7 +1223,8 @@ Raven.prototype = {
         this.captureBreadcrumb({
             category: 'sentry',
             message: data.message,
-            event_id: data.event_id
+            event_id: data.event_id,
+            level: data.level || 'error' // presume error unless specified
         });
 
         var url = this._globalEndpoint;

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -633,7 +633,7 @@ describe('globals', function() {
             });
         });
 
-        it('should create and append \'error\' breadcrumb', function () {
+        it('should create and append \'sentry\' breadcrumb', function () {
             this.sinon.stub(Raven, 'isSetup').returns(true);
             this.sinon.stub(Raven, '_makeRequest');
             this.sinon.stub(Raven, '_getHttpData').returns({
@@ -652,7 +652,14 @@ describe('globals', function() {
 
             assert.deepEqual(Raven._breadcrumbs, [
                 { type: 'http', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }},
-                { category: 'sentry', message: 'bar', timestamp: 0.1, /* 100ms */ event_id: 'abc123' }
+                { category: 'sentry', message: 'bar', timestamp: 0.1, /* 100ms */ event_id: 'abc123', level: 'error' }
+            ]);
+
+            Raven._send({message: 'foo', level: 'warning' });
+            assert.deepEqual(Raven._breadcrumbs, [
+                { type: 'http', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }},
+                { category: 'sentry', message: 'bar', timestamp: 0.1, /* 100ms */ event_id: 'abc123', level: 'error' },
+                { category: 'sentry', message: 'foo', timestamp: 0.1, /* 100ms */ event_id: 'abc123', level: 'warning' }
             ]);
         });
 


### PR DESCRIPTION
Now "sentry" breadcrumbs have the proper level attached, and are reflected in the UI:

![image](https://cloud.githubusercontent.com/assets/2153/16432799/b88080a4-3d3b-11e6-96e8-84d7bf07383d.png)

cc @mattrobenolt 