### PR TITLE
`dataCallback`, `shouldSendCallback` are passed prior callback as 2nd arg

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -451,7 +451,10 @@ Raven.prototype = {
      * @return {Raven}
      */
     setDataCallback: function(callback) {
-        this._globalOptions.dataCallback = callback;
+        var original = this._globalOptions.dataCallback;
+        this._globalOptions.dataCallback = isFunction(callback)
+          ? function (data) { return callback(data, original); }
+          : callback;
 
         return this;
     },
@@ -464,7 +467,10 @@ Raven.prototype = {
      * @return {Raven}
      */
     setShouldSendCallback: function(callback) {
-        this._globalOptions.shouldSendCallback = callback;
+        var original = this._globalOptions.shouldSendCallback;
+        this._globalOptions.shouldSendCallback = isFunction(callback)
+            ? function (data) { return callback(data, original); }
+            : callback;
 
         return this;
     },

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1787,9 +1787,14 @@ describe('Raven (public API)', function() {
 
     describe('.setDataCallback', function() {
         it('should set the globalOptions.dataCallback attribute', function() {
-            var foo = function(){};
+            var foo = sinon.stub();
             Raven.setDataCallback(foo);
-            assert.equal(Raven._globalOptions.dataCallback, foo);
+
+            // note that setDataCallback creates a callback/closure around
+            // foo, so can't test for equality - just verify that calling the wrapper
+            // also calls foo
+            Raven._globalOptions.dataCallback();
+            assert.isTrue(foo.calledOnce);
         });
 
         it('should clear globalOptions.dataCallback with no arguments', function() {
@@ -1798,13 +1803,33 @@ describe('Raven (public API)', function() {
             Raven.setDataCallback();
             assert.isUndefined(Raven._globalOptions.dataCallback);
         });
+
+        it('should generate a wrapper that passes the prior callback as the 2nd argument', function () {
+            var foo = sinon.stub();
+            var bar = sinon.spy(function(data, orig) {
+                assert.equal(orig, foo);
+                foo();
+            });
+            Raven._globalOptions.dataCallback = foo;
+            Raven.setDataCallback(bar);
+            Raven._globalOptions.dataCallback({
+                'a': 1 // "data"
+            });
+            assert.isTrue(bar.calledOnce);
+            assert.isTrue(foo.calledOnce);
+        });
     });
 
     describe('.setShouldSendCallback', function() {
         it('should set the globalOptions.shouldSendCallback attribute', function() {
-            var foo = function(){};
+            var foo = sinon.stub();
             Raven.setShouldSendCallback(foo);
-            assert.equal(Raven._globalOptions.shouldSendCallback, foo);
+
+            // note that setShouldSendCallback creates a callback/closure around
+            // foo, so can't test for equality - just verify that calling the wrapper
+            // also calls foo
+            Raven._globalOptions.shouldSendCallback();
+            assert.isTrue(foo.calledOnce);
         });
 
         it('should clear globalOptions.shouldSendCallback with no arguments', function() {
@@ -1812,6 +1837,21 @@ describe('Raven (public API)', function() {
             Raven._globalOptions.shouldSendCallback = foo;
             Raven.setShouldSendCallback();
             assert.isUndefined(Raven._globalOptions.shouldSendCallback);
+        });
+
+        it('should generate a wrapper that passes the prior callback as the 2nd argument', function () {
+            var foo = sinon.stub();
+            var bar = sinon.spy(function(data, orig) {
+                assert.equal(orig, foo);
+                foo();
+            });
+            Raven._globalOptions.shouldSendCallback = foo;
+            Raven.setShouldSendCallback(bar);
+            Raven._globalOptions.shouldSendCallback({
+                'a': 1 // "data"
+            });
+            assert.isTrue(bar.calledOnce);
+            assert.isTrue(foo.calledOnce);
         });
     });
 


### PR DESCRIPTION
Fixes #428 (and eventually #477)

Now you can do the following for both `setDataCallback` and `setShouldSendCallback`:

```javascript
Raven.setDataCallback(function (data, priorDataCallback) {
  if (priorDataCallback) {
    data = priorDataCallback(data);
  }
  data.message = 'derp';
  return data;
});
```

This way it is possible to preserve OR override the behavior of any previously set callback, without adding new API methods (e.g. `addDataCallback` and `addShouldSendCallback`). It also lets subsequent callbacks mutate data before or after the prior callback is invoked, which the `add` API is not capable of doing (execution would be serial FIFO).

I'm not 100% on doing this, but I think it could be a satisfactory solution – especially since we've gone this far without it. Would love to get the community's feedback.

cc @mattrobenolt @nevir @mitsuhiko 