### PR TITLE
Handle PhantomJS 1.x file:/// urls

### DIFF
--- a/test/vendor/fixtures/captured-errors.js
+++ b/test/vendor/fixtures/captured-errors.js
@@ -333,4 +333,11 @@ CapturedExceptions.CHROME_48_BLOB = {
     "    at n.handle (blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379:7:2863)"
 };
 
+CapturedExceptions.PHANTOMJS_1_19 = {
+    stack: "Error: foo\n" +
+    "    at file:///path/to/file.js:878\n" +
+    "    at foo (http://path/to/file.js:4283)\n" +
+    "    at http://path/to/file.js:4287"
+};
+
 module.exports = CapturedExceptions;

--- a/test/vendor/tracekit-parser.test.js
+++ b/test/vendor/tracekit-parser.test.js
@@ -267,6 +267,9 @@ describe('TraceKit', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.PHANTOMJS_1_19);
             assert.ok(stackFrames);
             assert.deepEqual(stackFrames.stack.length, 3);
+            assert.deepEqual(stackFrames.stack[0], { url: 'file:///path/to/file.js', func: '?', args: [], line: 878, column: null });
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 4283, column: null });
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '?', args: [], line: 4287, column: null });
         });
     });
 });

--- a/test/vendor/tracekit-parser.test.js
+++ b/test/vendor/tracekit-parser.test.js
@@ -262,5 +262,11 @@ describe('TraceKit', function () {
             assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15 });
             assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 168 });
         });
+
+        it('should parse PhantomJS 1.19 error', function () {
+            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.PHANTOMJS_1_19);
+            assert.ok(stackFrames);
+            assert.deepEqual(stackFrames.stack.length, 3);
+        });
     });
 });

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -382,7 +382,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
 
         var chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|<anonymous>).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
             gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|\[native).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
-            winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:ms-appx|https?|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
+            winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
             lines = ex.stack.split('\n'),
             stack = [],
             parts,


### PR DESCRIPTION
I discovered that we were dropping frames from PhantomJS – specifically those without method names and begining with `file:///`

cc @mattrobenolt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/642)
<!-- Reviewable:end -->
