### PR TITLE
No default export for TypeScript bindings, add Webpack instructions

### DIFF
--- a/docs/integrations/angular2.rst
+++ b/docs/integrations/angular2.rst
@@ -52,7 +52,7 @@ Then, in your main application file (where ``bootstrap`` is called, e.g. main.ts
 
 .. code-block:: js
 
-    import Raven from 'raven-js';
+    import Raven = require('raven-js');
     import { bootstrap } from 'angular2/platform/browser';
     import { MainApp } from './app.component';
     import { provide, ExceptionHandler } from 'angular2/core';

--- a/docs/integrations/angular2.rst
+++ b/docs/integrations/angular2.rst
@@ -52,7 +52,7 @@ Then, in your main application file (where ``bootstrap`` is called, e.g. main.ts
 
 .. code-block:: js
 
-    import Raven = require('raven-js');
+    import Raven from 'raven-js';
     import { bootstrap } from 'angular2/platform/browser';
     import { MainApp } from './app.component';
     import { provide, ExceptionHandler } from 'angular2/core';
@@ -72,3 +72,14 @@ Then, in your main application file (where ``bootstrap`` is called, e.g. main.ts
     ]);
 
 Once you've completed these two steps, you are done.
+
+Webpack and Other Module Loaders
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+In Webpack and other module loaders, you may need to use the require keyword to load Raven:
+
+.. code-block:: js
+
+    import Raven = require('raven-js');
+      .config('__PUBLIC_DSN__')
+      .install();

--- a/typescript/raven-tests.ts
+++ b/typescript/raven-tests.ts
@@ -1,8 +1,8 @@
-import Raven, {RavenOptions} from '..';
+import Raven = require('..');
 
 Raven.config('https://public@getsentry.com/1').install();
 
-var options: RavenOptions = {
+var options = {
     logger: 'my-logger',
     ignoreUrls: [
         /graph\.facebook\.com/i,
@@ -22,7 +22,7 @@ var options: RavenOptions = {
     ]
 };
 
-Raven.config('https://public@getsentry.com/1', 1).install();
+Raven.config('https://public@getsentry.com/1', options).install();
 
 var throwsError = () => {
     throw new Error('broken');

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -4,9 +4,9 @@
 
 declare var Raven: RavenStatic;
 
-export default Raven;
+export = Raven;
 
-export interface RavenOptions {
+interface RavenOptions {
     /** The log level associated with this event. Default: error */
     level?: string;
 
@@ -54,7 +54,7 @@ export interface RavenOptions {
     transport?: (options: RavenTransportOptions) => void;
 }
 
-export interface RavenStatic {
+interface RavenStatic {
 
     /** Raven.js version. */
     VERSION: string;


### PR DESCRIPTION
Fixes #643, #622

Basically, only SystemJS supported / added compatibility for the "default" export. So I've removed that from the TypeScript definition file, and changed the instructions to indicate how it can be loaded using non-SystemJS loaders.

In Webpack, Raven.js should now be imported like so:

```typescript
import Raven = require('raven-js');
```

This *looks* like CommonJS syntax, but it's TypeScript. More on [this syntax from the official TS docs](https://www.typescriptlang.org/docs/handbook/modules.html#export--and-import--require).

Note that the original syntax (`import Raven from 'raven-js'`) still works for use with SystemJS, so this is not a breaking change.

cc @mattrobenolt @mitsuhiko @galuszkak @toepoke

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/645)
<!-- Reviewable:end -->
