### PR TITLE
Don't truncate a non-existent `message` property on `data`

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1113,7 +1113,9 @@ Raven.prototype = {
         // For now, we only want to truncate the two different messages
         // but this could/should be expanded to just trim everything
         var max = this._globalOptions.maxMessageLength;
-        data.message = truncate(data.message, max);
+        if (data.message) {
+            data.message = truncate(data.message, max);
+        }
         if (data.exception) {
             var exception = data.exception.values[0];
             exception.value = truncate(exception.value, max);


### PR DESCRIPTION
"Cannot read property 'length' of undefined when capturing exception" with undefined message when trying to capture an exception with a data object (second argument) that contains no data. For example:

```js
raven.captureException(new Error("foo"), {
	level: "warning",
	extra: {
		foo: "bar"
	}
});
```

Causes the Raven script to throw an exception because `data.message` is `undefined` and `truncate` only works with strings.

---

This should prevent this from happening.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/647)
<!-- Reviewable:end -->
