### PR TITLE
Add `json-stringify-safe` to avoid circular JSON references

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,9 @@
     "url": "git://github.com/getsentry/raven-js.git"
   },
   "main": "src/singleton.js",
+  "dependencies": {
+    "json-stringify-safe": "^5.0.1"
+  },
   "devDependencies": {
     "browserify-versionify": "^1.0.6",
     "bundle-collapser": "^1.2.1",

--- a/src/raven.js
+++ b/src/raven.js
@@ -4,6 +4,7 @@
 var TraceKit = require('../vendor/TraceKit/tracekit');
 var RavenConfigError = require('./configError');
 var utils = require('./utils');
+var stringify = require('json-stringify-safe');
 
 var isFunction = utils.isFunction;
 var isUndefined = utils.isUndefined;
@@ -428,7 +429,7 @@ Raven.prototype = {
      */
     getContext: function() {
         // lol javascript
-        return JSON.parse(JSON.stringify(this._globalContext));
+        return JSON.parse(stringify(this._globalContext));
     },
 
     /*
@@ -1285,7 +1286,7 @@ Raven.prototype = {
         // NOTE: auth is intentionally sent as part of query string (NOT as custom
         //       HTTP header) so as to avoid preflight CORS requests
         request.open('POST', url + '?' + urlencode(opts.auth));
-        request.send(JSON.stringify(opts.data));
+        request.send(stringify(opts.data));
     },
 
     // Note: this is shitty, but I can't figure out how to get


### PR DESCRIPTION
@benvinegar any idea how I could write some tests for this? Everything seems to stub out `_makeRequest` which is what calls `stringify`, and I don't want to make an actual XHR request. Also unittesting the vendored code is probably moot. But this does as advertises.

Fixes GH-651

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/652)
<!-- Reviewable:end -->
