### PR TITLE
Implement `console.assert` wrapping for console plugin.

### DIFF
--- a/plugins/console.js
+++ b/plugins/console.js
@@ -12,6 +12,7 @@
 'use strict';
 
 var wrapConsoleMethod = require('../src/console').wrapMethod;
+var wrapConsoleAssert = require('../src/console').wrapAssert;
 
 function consolePlugin(Raven, console, pluginOptions) {
     console = console || window.console || {};
@@ -28,20 +29,9 @@ function consolePlugin(Raven, console, pluginOptions) {
         wrapConsoleMethod(console, level, callback);
         level = logLevels.pop();
     }
-    
-    console.assert = function () {
-        var args = [].slice.call(arguments);
-        var result = args.shift();
-        if (!result) {
-            args.unshift("Assertion failed");
-            // IE9 doesn't allow calling apply on console functions directly
-            // See: https://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function#answer-5473193
-            Function.prototype.apply.call(
-                console.error,
-                console,
-                args
-            );
-        }
+
+    if (console.assert) {
+        wrapConsoleAssert(console);
     }
 }
 

--- a/plugins/console.js
+++ b/plugins/console.js
@@ -28,6 +28,21 @@ function consolePlugin(Raven, console, pluginOptions) {
         wrapConsoleMethod(console, level, callback);
         level = logLevels.pop();
     }
+    
+    console.assert = function () {
+        var args = [].slice.call(arguments);
+        var result = args.shift();
+        if (!result) {
+            args.unshift("Assertion failed");
+            // IE9 doesn't allow calling apply on console functions directly
+            // See: https://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function#answer-5473193
+            Function.prototype.apply.call(
+                console.error,
+                console,
+                args
+            );
+        }
+    }
 }
 
 module.exports = consolePlugin;

--- a/src/console.js
+++ b/src/console.js
@@ -32,6 +32,24 @@ var wrapMethod = function(console, level, callback) {
     };
 };
 
+var wrapAssert = function(console) {
+    console.assert = function () {
+        var args = [].slice.call(arguments);
+        var result = args.shift();
+        if (!result) {
+            args.unshift('Assertion failed');
+            // IE9 doesn't allow calling apply on console functions directly
+            // See: https://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function#answer-5473193
+            Function.prototype.apply.call(
+                console.error,
+                console,
+                args
+            );
+        }
+    };
+};
+
 module.exports = {
-    wrapMethod: wrapMethod
+    wrapMethod: wrapMethod,
+    wrapAssert: wrapAssert
 };


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-js/issues/653.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/654)

<!-- Reviewable:end -->
