### PR TITLE
Support CodePush paths in culprit and frame filename

### DIFF
--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -22,7 +22,7 @@
 // Example React Native path format (iOS):
 // /var/containers/Bundle/Application/{DEVICE_ID}/HelloWorld.app/main.jsbundle
 
-var PATH_STRIP_RE = /^.*\/[^\.]+\.app/;
+var PATH_STRIP_RE = /^.*\/[^\.]+(\.app|CodePush)/;
 
 var FATAL_ERROR_KEY = '--rn-fatal--';
 var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';

--- a/test/plugins/react-native.test.js
+++ b/test/plugins/react-native.test.js
@@ -17,7 +17,7 @@ describe('React Native plugin', function () {
     });
 
     describe('_normalizeData()', function () {
-        it('should normalize culprit and frame filenames/URLs', function () {
+        it('should normalize culprit and frame filenames/URLs from app', function () {
             var data = {
                 project: '2',
                 logger: 'javascript',
@@ -37,6 +37,42 @@ describe('React Native plugin', function () {
 
                             }, {
                                 filename: 'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/file2.js',
+                                lineno: 12,
+                                colno: 13,
+                                'function': 'lol'
+                            }]
+                        }
+                    }],
+                }
+            };
+            reactNativePlugin._normalizeData(data);
+
+            assert.equal(data.culprit, '/app.js');
+            var frames = data.exception.values[0].stacktrace.frames;
+            assert.equal(frames[0].filename, '/file1.js');
+            assert.equal(frames[1].filename, '/file2.js');
+        });
+
+        it('should normalize culprit and frame filenames/URLs from CodePush', function () {
+            var data = {
+                project: '2',
+                logger: 'javascript',
+                platform: 'javascript',
+
+                culprit: 'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/app.js',
+                message: 'Error: crap',
+                exception: {
+                    type: 'Error',
+                    values: [{
+                        stacktrace: {
+                            frames: [{
+                                filename: 'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/file1.js',
+                                lineno: 10,
+                                colno: 11,
+                                'function': 'broken'
+
+                            }, {
+                                filename: 'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/file2.js',
                                 lineno: 12,
                                 colno: 13,
                                 'function': 'lol'


### PR DESCRIPTION
Solves https://github.com/getsentry/raven-js/issues/680

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/683)
<!-- Reviewable:end -->
