### PR TITLE
Introduce maxBreadcrumbs, increase default (and max) limit to 100

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -167,6 +167,11 @@ Those configuration options are documented below:
     By default, Raven does not truncate messages. If you need to truncate
     characters for whatever reason, you may set this to limit the length.
 
+.. describe:: maxBreadcrumbs
+
+    By default, Raven captures as many as 100 breadcrumb entries. If you find this too noisy, you can reduce this
+    number by setting `maxBreadcrumbs`. Note that this number cannot be set higher than the default of 100.
+
 .. describe:: transport
 
     Override the default HTTP data transport handler.

--- a/src/raven.js
+++ b/src/raven.js
@@ -65,7 +65,6 @@ function Raven() {
     this._startTime = now();
     this._wrappedBuiltIns = [];
     this._breadcrumbs = [];
-    this._breadcrumbLimit = 20;
     this._lastCapturedEvent = null;
     this._keypressTimeout;
     this._location = window.location;
@@ -137,6 +136,7 @@ Raven.prototype = {
         this._globalOptions.ignoreUrls = this._globalOptions.ignoreUrls.length ? joinRegExp(this._globalOptions.ignoreUrls) : false;
         this._globalOptions.whitelistUrls = this._globalOptions.whitelistUrls.length ? joinRegExp(this._globalOptions.whitelistUrls) : false;
         this._globalOptions.includePaths = joinRegExp(this._globalOptions.includePaths);
+        this._globalOptions.maxBreadcrumbs = Math.max(0, Math.min(this._globalOptions.maxBreadcrumbs || 100, 100)); // default and hard limit is 100
 
         this._globalKey = uri.user;
         this._globalSecret = uri.pass && uri.pass.substr(1);
@@ -358,7 +358,7 @@ Raven.prototype = {
         }, obj);
 
         this._breadcrumbs.push(crumb);
-        if (this._breadcrumbs.length > this._breadcrumbLimit) {
+        if (this._breadcrumbs.length > this._globalOptions.maxBreadcrumbs) {
             this._breadcrumbs.shift();
         }
     },

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1578,6 +1578,28 @@ describe('Raven (public API)', function() {
                 assert.isFalse(TraceKit.collectWindowErrors);
             });
         });
+
+        describe('maxBreadcrumbs', function () {
+            it('should override the default', function () {
+                Raven.config(SENTRY_DSN, { maxBreadcrumbs: 50 });
+                assert.equal(Raven._globalOptions.maxBreadcrumbs, 50);
+            });
+
+            it('should not permit maxBreadcrumbs above 100', function () {
+                Raven.config(SENTRY_DSN, { maxBreadcrumbs: 200 });
+                assert.equal(Raven._globalOptions.maxBreadcrumbs, 100);
+            });
+
+            it('should not permit maxBreadcrumbs below 0', function () {
+               Raven.config(SENTRY_DSN, { maxBreadcrumbs: -1 });
+                assert.equal(Raven._globalOptions.maxBreadcrumbs, 0);
+            });
+
+            it('should set maxBreadcrumbs to the default if not provided', function () {
+                Raven.config(SENTRY_DSN);
+                assert.equal(Raven._globalOptions.maxBreadcrumbs, 100);
+            });
+        });
     });
 
     describe('.wrap', function() {
@@ -2063,7 +2085,7 @@ describe('Raven (public API)', function() {
         });
 
         it('should dequeue the oldest breadcrumb when over limit', function() {
-            Raven._breadcrumbLimit = 5;
+            Raven._globalOptions.maxBreadcrumbs = 5;
             Raven._breadcrumbs = [
                 { message: '1', timestamp: 0.1 },
                 { message: '2', timestamp: 0.1 },


### PR DESCRIPTION
cc @dcramer @macqueen @mattrobenolt

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/685)
<!-- Reviewable:end -->
