### PR TITLE
Add return type for showReportDialog

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "pretest": "npm install",
     "test": "grunt test && npm run-script test-typescript",
-    "test-typescript": "node_modules/typescript/bin/tsc --noEmit typescript/raven-tests.ts"
+    "test-typescript": "node_modules/typescript/bin/tsc --noEmit --noImplicitAny typescript/raven-tests.ts"
   },
   "repository": {
     "type": "git",

--- a/typescript/raven-tests.ts
+++ b/typescript/raven-tests.ts
@@ -59,10 +59,10 @@ Raven.captureBreadcrumb({});
 Raven.setRelease('abc123');
 Raven.setEnvironment('production');
 
-Raven.setDataCallback(function (data) {});
-Raven.setDataCallback(function (data, original) {});
-Raven.setShouldSendCallback(function (data) {});
-Raven.setShouldSendCallback(function (data, original) {});
+Raven.setDataCallback(function (data: any) {});
+Raven.setDataCallback(function (data: any, original: any) {});
+Raven.setShouldSendCallback(function (data: any) {});
+Raven.setShouldSendCallback(function (data: any, original: any) {});
 
 Raven.showReportDialog({
     eventId: 'abcdef123456'

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -211,7 +211,7 @@ interface RavenStatic {
     setShouldSendCallback(data: any, orig?: any): RavenStatic;
 
     /** Show Sentry user feedback dialog */
-    showReportDialog(options: Object);
+    showReportDialog(options: Object): void;
 }
 
 interface RavenTransportOptions {


### PR DESCRIPTION
Typescript with noImplicitReturns option doesn't work. 

```
ERROR in /home/ilya/test-project/node_modules/raven-js/typescript/raven.d.ts
(214,5): error TS7010: 'showReportDialog', which lacks return-type annotation, implicitly has an 'any' return type.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/711)
<!-- Reviewable:end -->
