### PR TITLE
Fix "error TS7010: 'showReportDialog', which lacks return-type annota…

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -211,7 +211,7 @@ interface RavenStatic {
     setShouldSendCallback(data: any, orig?: any): RavenStatic;
 
     /** Show Sentry user feedback dialog */
-    showReportDialog(options: Object);
+    showReportDialog(options: Object): void;
 }
 
 interface RavenTransportOptions {


### PR DESCRIPTION
…tion, implicitly has an 'any' return type" if compiling with "noImplicitAny": true

This is causing issues for those who prefer to compile their Typescript app with "noImplicitAny": true

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/718)
<!-- Reviewable:end -->
