### PR TITLE
Update Angular 2 docs to reflect error handler API changes

### DIFF
--- a/docs/integrations/angular2.rst
+++ b/docs/integrations/angular2.rst
@@ -54,55 +54,31 @@ First, configure SystemJS to locate the Raven.js package:
       }
     });
 
-Then, in your main application file (where ``bootstrap`` is called, e.g. main.ts):
+Then, in your main module file (where ``@NgModule`` is called, e.g. app.module.ts):
 
 .. code-block:: js
 
-    import Raven from 'raven-js';
-    import { bootstrap } from 'angular2/platform/browser';
-    import { MainApp } from './app.component';
-    import { provide, ErrorHandler } from 'angular2/core';
+    import Raven = require('raven-js');
+    import { BrowserModule } from '@angular/platform-browser';
+    import { AppComponent } from './app.component';
+    import { NgModule, ErrorHandler } from 'angular2/core';
 
     Raven
       .config('___PUBLIC_DSN___')
       .install();
 
-    class RavenErrorHandler {
-      call(err:any) {
-        Raven.captureException(err.originalException);
+    class RavenErrorHandler implements ErrorHandler {
+      handleError(err:any) : void {
+        Raven.captureException(err.originalError);
       }
     }
 
-    bootstrap(MainApp, [
-      provide(ErrorHandler, {useClass: RavenErrorHandler})
-    ]);
+    @NgModule({
+      imports: [ BrowserModule ],
+      declarations: [ AppComponent ],
+      bootstrap: [ AppComponent ],
+      providers: [ {provide: ErrorHandler, useClass: RavenErrorHandler}]
+    })
+    export class AppModule { }
 
 Once you've completed these two steps, you are done.
-
-Webpack, Angular CLI, and Other Module Loaders
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-In Webpack, Angular CLI, and other module loaders/packagers, you may need to use the **require** keyword as
-part of your `import` statement:
-
-.. code-block:: js
-
-    import Raven = require('raven-js');  // NOTE: "require" not "from"
-    import { bootstrap } from 'angular2/platform/browser';
-    import { MainApp } from './app.component';
-    import { provide, ErrorHandler } from 'angular2/core';
-
-    Raven
-      .config('___PUBLIC_DSN___')
-      .install();
-
-    class RavenErrorHandler {
-      call(err:any) {
-        Raven.captureException(err.originalException);
-      }
-    }
-
-    bootstrap(MainApp, [
-      provide(ErrorHandler, {useClass: RavenErrorHandler})
-    ]);
-

--- a/docs/integrations/angular2.rst
+++ b/docs/integrations/angular2.rst
@@ -3,8 +3,8 @@ Angular 2
 
 On its own, Raven.js will report any uncaught exceptions triggered from your application. For advanced usage examples of Raven.js, please read :doc:`Raven.js usage <../usage>`.
 
-Additionally, Raven.js can be configured to catch any Angular 2-specific exceptions reported through the `angular2/core/ExceptionHandler
-<https://angular.io/docs/js/latest/api/core/index/ExceptionHandler-class.html>`_ component.
+Additionally, Raven.js can be configured to catch any Angular 2-specific exceptions reported through the `angular2/core/ErrorHandler
+<https://angular.io/docs/js/latest/api/core/index/ErrorHandler-class.html>`_ component.
 
 
 TypeScript Support
@@ -61,20 +61,20 @@ Then, in your main application file (where ``bootstrap`` is called, e.g. main.ts
     import Raven from 'raven-js';
     import { bootstrap } from 'angular2/platform/browser';
     import { MainApp } from './app.component';
-    import { provide, ExceptionHandler } from 'angular2/core';
+    import { provide, ErrorHandler } from 'angular2/core';
 
     Raven
       .config('___PUBLIC_DSN___')
       .install();
 
-    class RavenExceptionHandler {
+    class RavenErrorHandler {
       call(err:any) {
         Raven.captureException(err.originalException);
       }
     }
 
     bootstrap(MainApp, [
-      provide(ExceptionHandler, {useClass: RavenExceptionHandler})
+      provide(ErrorHandler, {useClass: RavenErrorHandler})
     ]);
 
 Once you've completed these two steps, you are done.
@@ -90,19 +90,19 @@ part of your `import` statement:
     import Raven = require('raven-js');  // NOTE: "require" not "from"
     import { bootstrap } from 'angular2/platform/browser';
     import { MainApp } from './app.component';
-    import { provide, ExceptionHandler } from 'angular2/core';
+    import { provide, ErrorHandler } from 'angular2/core';
 
     Raven
       .config('___PUBLIC_DSN___')
       .install();
 
-    class RavenExceptionHandler {
+    class RavenErrorHandler {
       call(err:any) {
         Raven.captureException(err.originalException);
       }
     }
 
     bootstrap(MainApp, [
-      provide(ExceptionHandler, {useClass: RavenExceptionHandler})
+      provide(ErrorHandler, {useClass: RavenErrorHandler})
     ]);
 


### PR DESCRIPTION
This was renamed to `ErrorHandler`: https://angular.io/docs/js/latest/api/core/index/ErrorHandler-class.html

As reported via [the Sentry forum](https://forum.sentry.io/t/angular2-rc5-installation/104/2).

cc @wengole @dcramer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/getsentry/raven-js/732)
<!-- Reviewable:end -->
