### PR TITLE
Allow importing of all declared types

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -2,10 +2,11 @@
 // Project: https://github.com/getsentry/raven-js
 // Definitions by: Santi Albo <https://github.com/santialbo/>, Benjamin Pannell <http://github.com/spartan563>
 
-declare var Raven: RavenStatic;
+declare var Raven: Raven.RavenStatic;
 
 export = Raven;
 
+module Raven {
 interface RavenOptions {
     /** The log level associated with this event. Default: error */
     level?: string;
@@ -228,4 +229,5 @@ interface RavenTransportOptions {
 
 interface RavenPlugin {
     (raven: RavenStatic, ...args: any[]): RavenStatic;
+}
 }

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -6,7 +6,7 @@ declare var Raven: Raven.RavenStatic;
 
 export = Raven;
 
-module Raven {
+declare module Raven {
 interface RavenOptions {
     /** The log level associated with this event. Default: error */
     level?: string;


### PR DESCRIPTION
There's been a regression in the TypeScript definitions. In version 3.2.0, I was able to import raven's types like so:

```
import Raven, { RavenOptions } from 'raven-js';

// further down...
export function captureMessage(msg: string, options?: RavenOptions) {
    Raven.captureMessage(msg, augmentOptions(options));
}

function augmentOptions(options?: RavenOptions): RavenOptions {
    // ...
}
```

In 3.7.0, the types are no longer exported, so this is no longer possible. This change would make it possible again.

I didn't re-indent the file in order to keep the diff obvious, but obviously it would be good to indent everything inside the new module block.
