### PR TITLE
Record fetch requests in breadcrumb

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "bundle-collapser": "^1.2.1",
     "chai": "2.3.0",
     "derequire": "2.0.3",
+    "es6-promise": "^4.0.5",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-cli": "^0.1.13",
@@ -43,7 +44,8 @@
     "proxyquireify": "^3.0.2",
     "sinon": "1.7.3",
     "through2": "^2.0.0",
-    "typescript": "^1.8.10"
+    "typescript": "^1.8.10",
+    "whatwg-fetch": "^1.0.0"
   },
   "keywords": [
     "exceptions",

--- a/test/integration/frame.html
+++ b/test/integration/frame.html
@@ -3,6 +3,8 @@
 <head>
   <meta charset="utf-8">
   <title></title>
+  <script src="../../node_modules/es6-promise/dist/es6-promise.auto.js"></script>
+  <script src="../../node_modules/whatwg-fetch/fetch.js"></script>
   <script>
     // http://paulirish.com/2011/requestanimationframe-for-smart-animating/
     // http://my.opera.com/emoller/blog/2011/12/20/requestanimationframe-for-smart-er-animating


### PR DESCRIPTION
Hello,

this is an integration of capturing fetch requests the same way XMLHttpRequests are captured for breadcrumb.

Tests are passing on my browser using `node_modules/.bin/grunt run:test` on `http://localhost:8000/test/integration/`
However, running `node_modules/.bin/grunt test` fails locally with

```
Running "mocha:integration" (mocha) task
Testing: test/integration/index.html

․․․․․․․․․․․․․․․․XMLHttpRequest cannot load https://example.com/api/1/store/?sentry_key=public. Origin file:// is not allowed by Access-Control-Allow-Origin.
․․․․․․․․․․․

  26 passing (5s)
  1 failing

  1) integration breadcrumbs should record a fetch request:
     timeout of 2000ms exceeded
```

I don't know why. If anyone has an idea...