### PR TITLE
chore(typings): Updated typings to have the possibility to enable sta…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "raven-js",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "dependencies": {},
   "main": "dist/raven.js",
   "ignore": [

--- a/dist/plugins/angular.js
+++ b/dist/plugins/angular.js
@@ -1,4 +1,4 @@
-/*! Raven.js 3.7.0 (cf2ddee) | github.com/getsentry/raven-js */
+/*! Raven.js 3.7.1 (cf2ddee) | github.com/getsentry/raven-js */
 
 /*
  * Includes TraceKit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "raven-js",
-  "version": "3.7.0",
+  "version": "3.7.1",
   "license": "BSD-2-Clause",
   "homepage": "https://github.com/getsentry/raven-js",
   "scripts": {

--- a/src/raven.js
+++ b/src/raven.js
@@ -74,7 +74,7 @@ Raven.prototype = {
     // webpack (using a build step causes webpack #1617). Grunt verifies that
     // this value matches package.json during build.
     //   See: https://github.com/getsentry/raven-js/issues/465
-    VERSION: '3.7.0',
+    VERSION: '3.7.1',
 
     debug: false,
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1004,7 +1004,7 @@ describe('globals', function() {
                 extra: {'session:duration': 100},
             });
             assert.deepEqual(opts.auth, {
-                sentry_client: 'raven-js/3.7.0',
+                sentry_client: 'raven-js/3.7.1',
                 sentry_key: 'abc',
                 sentry_version: '7'
             });

--- a/typescript/raven-tests.ts
+++ b/typescript/raven-tests.ts
@@ -54,6 +54,7 @@ var err:Error = Raven.lastException();
 
 Raven.captureMessage('Broken!');
 Raven.captureMessage('Broken!', {tags: { key: "value" }});
+Raven.captureMessage('Broken!', { stacktrace: true });
 Raven.captureBreadcrumb({});
 
 Raven.setRelease('abc123');

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -39,6 +39,9 @@ interface RavenOptions {
         [id: string]: string;
     };
 
+    /** set to true to get the strack trace of your message */
+    stacktrace?: boolean; 
+
     extra?: any;
 
     /** In some cases you may see issues where Sentry groups multiple events together when they should be separate entities. In other cases, Sentry simply doesn’t group events together because they’re so sporadic that they never look the same. */


### PR DESCRIPTION
There is the option of stacktrace in https://github.com/getsentry/raven-js/blob/master/src/raven.js#L370 but there is no typings for it