### PR TITLE
chore(typings): Updated typings to add the stacktrace option

### DIFF
--- a/typescript/raven-tests.ts
+++ b/typescript/raven-tests.ts
@@ -54,6 +54,7 @@ var err:Error = Raven.lastException();
 
 Raven.captureMessage('Broken!');
 Raven.captureMessage('Broken!', {tags: { key: "value" }});
++Raven.captureMessage('Broken!', { stacktrace: true });
 Raven.captureBreadcrumb({});
 
 Raven.setRelease('abc123');

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -39,6 +39,9 @@ interface RavenOptions {
         [id: string]: string;
     };
 
+    /** set to true to get the strack trace of your message */
+    stacktrace?: boolean;
+
     extra?: any;
 
     /** In some cases you may see issues where Sentry groups multiple events together when they should be separate entities. In other cases, Sentry simply doesn’t group events together because they’re so sporadic that they never look the same. */


### PR DESCRIPTION
There is the option of stacktrace in https://github.com/getsentry/raven-js/blob/master/src/raven.js#L370 but there is no typings for it