### PR TITLE
Remove duplicate "is" in source maps documentation

### DIFF
--- a/docs/sourcemaps.rst
+++ b/docs/sourcemaps.rst
@@ -5,8 +5,7 @@ Source Maps
 
 Sentry supports un-minifying JavaScript via `Source Maps
 <http://blog.sentry.io/2015/10/29/debuggable-javascript-with-source-maps.html>`_. This lets you
-view source code context obtained from stack traces in their original untransformed form, which is
-is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level
+view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level
 language (e.g. TypeScript, ES6).
 
 Generating a Source Map


### PR DESCRIPTION
From https://docs.sentry.io/clients/javascript/sourcemaps/#raven-js-sourcemaps

![source maps sentry documentation 2016-11-09 11-48-05](https://cloud.githubusercontent.com/assets/3228068/20152268/6d84477a-a672-11e6-8a63-b435ac0c51dd.png)
