### PR TITLE
Replace errors with users in Usage documentation

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -85,7 +85,7 @@ would only really be useful in a large web app where the user logs in/out
 without a page reload.*
 
 This data is generally submitted with each error or message and allows you
-to figure out which errors are affected by problems.
+to figure out which users are affected by problems.
 
 Capturing Messages
 ------------------


### PR DESCRIPTION
From https://docs.sentry.io/clients/javascript/usage/#tracking-users
>This data is generally submitted with each error or message and allows you to figure out which errors are affected by problems.

I think the last `errors` is meant to be `users`:
>This data is generally submitted with each error or message and allows you to figure out which users are affected by problems.
