### PR TITLE
Can enable synthetic traces globally via stacktrace: true (fixes #743)

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -363,11 +363,13 @@ Raven.prototype = {
             return;
         }
 
+        options = options || {};
+
         var data = objectMerge({
             message: msg + ''  // Make sure it's actually a string
         }, options);
 
-        if (options && options.stacktrace) {
+        if (this._globalOptions.stacktrace || (options && options.stacktrace)) {
             var ex;
             // create a stack trace from this point; just trim
             // off extra frames so they don't include this function call (or


### PR DESCRIPTION
cc @maxbittker