### PR TITLE
can set maxEventsPerPage config option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -299,7 +299,6 @@ Those configuration options are documented below:
 
     If set to `true`, Raven.js outputs some light debugging information onto the console.
 
-
 .. describe:: instrument
 
     Enables/disables instrumentation of globals. Possible values are:
@@ -313,6 +312,11 @@ Those configuration options are documented below:
         instrument: {
             'tryCatch': true, // Instruments timers and event targets
         }
+
+.. describe:: maxEventsPerPage
+
+    By default, Raven captures as many events as possible. If you want to reduce this number, you can change
+    it by setting `maxEventsPerPage`. The counter will automatically restart on every page change.
 
 Putting it all together
 -----------------------

--- a/src/raven.js
+++ b/src/raven.js
@@ -81,6 +81,7 @@ function Raven() {
   this._keypressTimeout;
   this._location = _window.location;
   this._lastHref = this._location && this._location.href;
+  this._sentEvents = 0;
   this._resetBackoff();
 
   // eslint-disable-next-line guard-for-in
@@ -875,6 +876,9 @@ Raven.prototype = {
     var parsedTo = parseUrl(to);
     var parsedFrom = parseUrl(from);
 
+    // refresh max events count
+    this._sentEvents = 0;
+
     // because onpopstate only tells you the "new" (to) value of location.href, and
     // not the previous (from) value, we need to track the value of the current URL
     // state ourselves
@@ -1254,6 +1258,9 @@ Raven.prototype = {
           // params to preserve 0 arity
           return function(/* state, title, url */) {
             var url = arguments.length > 2 ? arguments[2] : undefined;
+
+            // refresh max events count
+            self._sentEvents = 0;
 
             // url argument is optional
             if (url) {
@@ -1699,12 +1706,22 @@ Raven.prototype = {
       return;
     }
 
+    // Check if the request should be filtered due to max events per page
+    if (
+      globalOptions.maxEventsPerPage &&
+      this._sentEvents >= globalOptions.maxEventsPerPage
+    ) {
+      return;
+    }
+
     // Backoff state: Sentry server previously responded w/ an error (e.g. 429 - too many requests),
     // so drop requests until "cool-off" period has elapsed.
     if (this._shouldBackoff()) {
       this._logDebug('warn', 'Raven dropped error due to backoff: ', data);
       return;
     }
+
+    this._sentEvents++; // failed events count towards maxEvents
 
     if (typeof globalOptions.sampleRate === 'number') {
       if (Math.random() < globalOptions.sampleRate) {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2174,6 +2174,57 @@ describe('Raven (public API)', function() {
         });
       });
     });
+
+    describe('maxEventsPerPage', function(){
+      it('allows many events when maxEventsPerPage is undefined', function () {
+        var stub = this.sinon.stub(Raven,'_sendProcessedPayload')
+        this.sinon.spy(stub)
+
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+
+        assert.equal(Raven._sendProcessedPayload.callCount, 5);
+      });
+
+      it('should only allow up to maxEventsPerPage requests', function () {
+        var stub = this.sinon.stub(Raven,'_sendProcessedPayload')
+        this.sinon.spy(stub)
+
+        Raven._globalOptions.maxEventsPerPage = 3;
+
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+
+        assert.equal(Raven._sendProcessedPayload.callCount, 3);
+      });
+
+      it('should reset maxErrors on SPA page change', function () {
+        var stub = this.sinon.stub(Raven,'_sendProcessedPayload')
+        this.sinon.spy(stub)
+
+        Raven._globalOptions.maxEventsPerPage = 3;
+
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+
+        assert.equal(Raven._sendProcessedPayload.callCount, 3);
+
+        Raven._captureUrlChange('/foo', '/bar');
+
+        Raven.captureException(new Error('foo'))
+        Raven.captureException(new Error('foo'))
+
+        assert.equal(Raven._sendProcessedPayload.callCount, 5);
+      });
+    });
   });
 
   describe('.wrap', function() {

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -71,6 +71,9 @@ declare module Raven {
 
         /** Enables/disables automatic collection of breadcrumbs. */
         autoBreadcrumbs?: boolean | AutoBreadcrumbOptions
+
+        /** By default, Raven captures as many events as possible. If you want to reduce this number, you can change it by setting `maxEventsPerPage`. The counter will automatically restart on every page change. */
+        maxEventsPerPage?: number;
     }
 
     interface RavenInstrumentationOptions {


### PR DESCRIPTION
this needs to be noted in the docs but I don't want to have those pulled out before this ships. 

I reset _sentErrors in _captureUrlChange and the pushState wrapper, which is a little bit janky but I  believe it covers a wider range of applications without doing much harm. (although I could be misunderstanding the behavior of these apis)