### PR TITLE
Fix for IE8 Parsing error

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -128,7 +128,7 @@ Raven.prototype = {
             xhr: true,
             console: true,
             dom: true,
-            location: true,
+            location: true
         };
 
         var autoBreadcrumbs = globalOptions.autoBreadcrumbs;


### PR DESCRIPTION
IE8 Does not accept the trailing comma on Object definition.
This fix let the IE8 parser to correctly parse the object instead of throwing an error for the trailing comma and exiting from the script.