### PR TITLE
Window defensiveness

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -14,6 +14,7 @@ function now() {
     return +new Date();
 }
 
+// This is to be defensive in environments where window does not exist (see https://github.com/getsentry/raven-js/pull/785)
 var _window = typeof window !== 'undefined' ? window
             : typeof global !== 'undefined' ? global
             : typeof self !== 'undefined' ? self

--- a/src/raven.js
+++ b/src/raven.js
@@ -14,8 +14,11 @@ function now() {
     return +new Date();
 }
 
-var _window = typeof window !== 'undefined' ? window : undefined;
-var _document = _window && _window.document;
+var _window = typeof window !== 'undefined' ? window
+            : typeof global !== 'undefined' ? global
+            : typeof self !== 'undefined' ? self
+            : {};
+var _document = _window.document;
 
 // First, check for JSON support
 // If there is no JSON, we no-op the core features of Raven

--- a/src/singleton.js
+++ b/src/singleton.js
@@ -8,7 +8,11 @@
 
 var RavenConstructor = require('./raven');
 
-var _Raven = window.Raven;
+var _window = typeof window !== 'undefined' ? window
+            : typeof global !== 'undefined' ? global
+            : typeof self !== 'undefined' ? self
+            : {};
+var _Raven = _window.Raven;
 
 var Raven = new RavenConstructor();
 
@@ -19,7 +23,7 @@ var Raven = new RavenConstructor();
  * @return {Raven}
  */
 Raven.noConflict = function () {
-	window.Raven = _Raven;
+	_window.Raven = _Raven;
 	return Raven;
 };
 

--- a/src/singleton.js
+++ b/src/singleton.js
@@ -8,6 +8,7 @@
 
 var RavenConstructor = require('./raven');
 
+// This is to be defensive in environments where window does not exist (see https://github.com/getsentry/raven-js/pull/785)
 var _window = typeof window !== 'undefined' ? window
             : typeof global !== 'undefined' ? global
             : typeof self !== 'undefined' ? self

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -10,6 +10,7 @@ var TraceKit = {
     debug: false
 };
 
+// This is to be defensive in environments where window does not exist (see https://github.com/getsentry/raven-js/pull/785)
 var _window = typeof window !== 'undefined' ? window
             : typeof global !== 'undefined' ? global
             : typeof self !== 'undefined' ? self

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -10,6 +10,11 @@ var TraceKit = {
     debug: false
 };
 
+var _window = typeof window !== 'undefined' ? window
+            : typeof global !== 'undefined' ? global
+            : typeof self !== 'undefined' ? self
+            : {};
+
 // global reference to slice
 var _slice = [].slice;
 var UNKNOWN_FUNCTION = '?';
@@ -188,8 +193,8 @@ TraceKit.report = (function reportModuleWrapper() {
         if (_onErrorHandlerInstalled) {
             return;
         }
-        _oldOnerrorHandler = window.onerror;
-        window.onerror = traceKitWindowOnError;
+        _oldOnerrorHandler = _window.onerror;
+        _window.onerror = traceKitWindowOnError;
         _onErrorHandlerInstalled = true;
     }
 
@@ -198,7 +203,7 @@ TraceKit.report = (function reportModuleWrapper() {
         if (!_onErrorHandlerInstalled) {
             return;
         }
-        window.onerror = _oldOnerrorHandler;
+        _window.onerror = _oldOnerrorHandler;
         _onErrorHandlerInstalled = false;
         _oldOnerrorHandler = undefined;
     }


### PR DESCRIPTION
This makes us defensive against `window` not existing so we can work in webworkers. Should fix #784 and #747, though there are some things to figure out/change before merging.

The reason for big 4-branch `_window` thing is that in web workers, `self` is a sort-of-global-object-thing, and in Node `global` is the global object (not that we need raven-js to work in node, but I was testing a few things with it as an easy env that doesn't have `window`). If none of them exist, I fall back to an empty object rather than doing something like `Function('return this')()` (CSP issues) or `(function () { return this; })()` (strict mode issues); I'm pretty sure all of our uses of `_window` still turn out okay in that case, but we won't properly instrument `setTimeout` and `setInterval`. I'm not too worried about that case, though.

I'm not sure what the best approach is gonna be to making tracekit not blow up here; obviously we don't just wanna hand edit it to be defensive every time we update our vendor copy of tracekit (like I've done in this PR just to prove things work). I don't *think* we can pull off any sort of slick trick where we just make the `window` reference TraceKit uses actually be something we provide like our `_window`.  Not sure if it makes sense for us to send them a PR to make it defensive, but I guess the webworker use case could be motivating; it looks like the current code at https://github.com/csnover/TraceKit touches `window` a lot more than our current version, though, and I'm not really familiar with our usage of it/interest in updating.

/cc @MaxBittker @benvinegar 