### PR TITLE
Adding a breadcrumbCallback for filtering and cleaning

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -159,6 +159,23 @@ Those configuration options are documented below:
             }
         }
 
+.. describe:: breadcrumbCallback
+
+    A function that allows filtering or mutating breadcrumb payloads.
+    Return false to throw away the breadcrumb.
+
+    .. code-block:: javascript
+
+        {
+            breadcrumbCallback: function(crumb) {
+              if (crumb.type === 'http') {
+                return crumb;
+              }
+
+              return false;
+            }
+        }
+
 .. describe:: shouldSendCallback
 
     A callback function that allows you to apply your own filters to

--- a/src/raven.js
+++ b/src/raven.js
@@ -413,6 +413,12 @@ Raven.prototype = {
             timestamp: now() / 1000
         }, obj);
 
+        if (isFunction(this._globalOptions.shouldSendBreadcrumbCallback)) {
+            if (!this._globalOptions.shouldSendBreadcrumbCallback(crumb)) {
+                return this;
+            }
+        }
+
         this._breadcrumbs.push(crumb);
         if (this._breadcrumbs.length > this._globalOptions.maxBreadcrumbs) {
             this._breadcrumbs.shift();
@@ -542,6 +548,22 @@ Raven.prototype = {
         this._globalOptions.shouldSendCallback = isFunction(callback)
             ? function (data) { return callback(data, original); }
             : callback;
+
+        return this;
+    },
+
+    /*
+     * Set the shouldSendBreadcrumbCallback option
+     *
+     * @param {function} callback The callback to run which allows
+     *                            introspecting breadcrumbs before sending
+     * @return {Raven}
+     */
+    setShouldSendBreadcrumbCallback: function(callback) {
+        var original = this._globalOptions.shouldSendBreadcrumbCallback;
+        this._globalOptions.shouldSendBreadcrumbCallback = isFunction(callback)
+          ? function (data) { return callback(data, original); }
+          : callback;
 
         return this;
     },

--- a/src/raven.js
+++ b/src/raven.js
@@ -413,8 +413,12 @@ Raven.prototype = {
             timestamp: now() / 1000
         }, obj);
 
-        if (isFunction(this._globalOptions.shouldSendBreadcrumbCallback)) {
-            if (!this._globalOptions.shouldSendBreadcrumbCallback(crumb)) {
+        if (isFunction(this._globalOptions.breadcrumbCallback)) {
+            var result = this._globalOptions.breadcrumbCallback(crumb);
+
+            if (result) {
+                crumb = result;
+            } else {
                 return this;
             }
         }
@@ -537,6 +541,22 @@ Raven.prototype = {
     },
 
     /*
+     * Set the breadcrumbCallback option
+     *
+     * @param {function} callback The callback to run which allows filtering
+     *                            or mutating breadcrumbs
+     * @return {Raven}
+     */
+    setBreadcrumbCallback: function(callback) {
+        var original = this._globalOptions.breadcrumbCallback;
+        this._globalOptions.breadcrumbCallback = isFunction(callback)
+          ? function (data) { return callback(data, original); }
+          : callback;
+
+        return this;
+    },
+
+    /*
      * Set the shouldSendCallback option
      *
      * @param {function} callback The callback to run which allows
@@ -548,22 +568,6 @@ Raven.prototype = {
         this._globalOptions.shouldSendCallback = isFunction(callback)
             ? function (data) { return callback(data, original); }
             : callback;
-
-        return this;
-    },
-
-    /*
-     * Set the shouldSendBreadcrumbCallback option
-     *
-     * @param {function} callback The callback to run which allows
-     *                            introspecting breadcrumbs before sending
-     * @return {Raven}
-     */
-    setShouldSendBreadcrumbCallback: function(callback) {
-        var original = this._globalOptions.shouldSendBreadcrumbCallback;
-        this._globalOptions.shouldSendBreadcrumbCallback = isFunction(callback)
-          ? function (data) { return callback(data, original); }
-          : callback;
 
         return this;
     },

--- a/src/raven.js
+++ b/src/raven.js
@@ -416,9 +416,9 @@ Raven.prototype = {
         if (isFunction(this._globalOptions.breadcrumbCallback)) {
             var result = this._globalOptions.breadcrumbCallback(crumb);
 
-            if (result) {
+            if (isObject(result) && !isEmptyObject(result)) {
                 crumb = result;
-            } else {
+            } else if (result === false) {
                 return this;
             }
         }

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2269,6 +2269,27 @@ describe('Raven (public API)', function() {
                 assert.strictEqual(Raven._breadcrumbs.length, 0);
             });
 
+            it('should not filter the breadcrumb if callback returns undefined', function() {
+                Raven.setBreadcrumbCallback(function() {});
+
+                Raven.captureBreadcrumb({
+                    type: 'http',
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                });
+
+                assert.deepEqual(Raven._breadcrumbs, [{
+                    type: 'http',
+                    timestamp: 0.1,
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                }]);
+            });
+
             it('should mutate the breadcrumb if it returns an object', function() {
                 Raven.setBreadcrumbCallback(function(crumb) {
                     crumb.type = 'whee';
@@ -2283,18 +2304,18 @@ describe('Raven (public API)', function() {
                     }
                 });
 
-                assert.deepEqual(Raven._breadcrumbs[0], {
+                assert.deepEqual(Raven._breadcrumbs, [{
                     type: 'whee',
                     timestamp: 0.1,
                     data: {
                         url: 'http://example.org/api/0/auth/',
                         status_code: 200
                     }
-                });
+                }]);
             });
 
             it('should enable replacing the breadcrumb', function() {
-                Raven.setBreadcrumbCallback(function(crumb) {
+                Raven.setBreadcrumbCallback(function() {
                     return {
                         foo: 'bar'
                     }
@@ -2311,6 +2332,52 @@ describe('Raven (public API)', function() {
                 assert.deepEqual(Raven._breadcrumbs[0], {
                     foo: 'bar'
                 });
+            });
+
+            it('should not replace the breadcrumb if a non object is returned', function() {
+                Raven.setBreadcrumbCallback(function() {
+                    return 'foo';
+                });
+
+                Raven.captureBreadcrumb({
+                    type: 'http',
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                });
+
+                assert.deepEqual(Raven._breadcrumbs, [{
+                    type: 'http',
+                    timestamp: 0.1,
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                }]);
+            });
+
+            it('should not replace the breadcrumb if an empty object is returned', function() {
+                Raven.setBreadcrumbCallback(function() {
+                    return {};
+                });
+
+                Raven.captureBreadcrumb({
+                    type: 'http',
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                });
+
+                assert.deepEqual(Raven._breadcrumbs, [{
+                    type: 'http',
+                    timestamp: 0.1,
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                }]);
             });
 
             it('should call the callback with the breadcrumb object', function() {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1961,6 +1961,41 @@ describe('Raven (public API)', function() {
         });
     });
 
+    describe('.setShouldSendBreadcrumbCallback', function() {
+        it('should set the globalOptions.shouldSendBreadcrumbCallback attribute', function() {
+            var foo = sinon.stub();
+            Raven.setShouldSendBreadcrumbCallback(foo);
+
+            // note that shouldSendBreadcrumbCallback creates a callback/closure around
+            // foo, so can't test for equality - just verify that calling the wrapper
+            // also calls foo
+            Raven._globalOptions.shouldSendBreadcrumbCallback();
+            assert.isTrue(foo.calledOnce);
+        });
+
+        it('should clear globalOptions.shouldSendBreadcrumbCallback with no arguments', function() {
+            var foo = function(){};
+            Raven._globalOptions.shouldSendBreadcrumbCallback = foo;
+            Raven.setShouldSendBreadcrumbCallback();
+            assert.isUndefined(Raven._globalOptions.shouldSendBreadcrumbCallback);
+        });
+
+        it('should generate a wrapper that passes the prior callback as the 2nd argument', function () {
+            var foo = sinon.stub();
+            var bar = sinon.spy(function(data, orig) {
+                assert.equal(orig, foo);
+                foo();
+            });
+            Raven._globalOptions.shouldSendBreadcrumbCallback = foo;
+            Raven.setShouldSendBreadcrumbCallback(bar);
+            Raven._globalOptions.shouldSendBreadcrumbCallback({
+                'a': 1 // "data"
+            });
+            assert.isTrue(bar.calledOnce);
+            assert.isTrue(foo.calledOnce);
+        });
+    });
+
     describe('.setShouldSendCallback', function() {
         it('should set the globalOptions.shouldSendCallback attribute', function() {
             var foo = sinon.stub();
@@ -2215,6 +2250,105 @@ describe('Raven (public API)', function() {
                 { message: '5', timestamp: 0.1 },
                 { message: 'lol', timestamp: 0.1 }
             ]);
+        });
+
+        describe('shouldSendBreadcrumbCallback', function() {
+            it('should filter the breadcrumb if it returns false', function() {
+                Raven.setShouldSendBreadcrumbCallback(function() {
+                    return false;
+                });
+
+                Raven.captureBreadcrumb({
+                    type: 'http',
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                });
+
+                assert.strictEqual(Raven._breadcrumbs.length, 0);
+            });
+
+            it('should not filter the breadcrumb if it returns true', function() {
+                Raven.setShouldSendBreadcrumbCallback(function() {
+                    return true;
+                });
+
+                Raven.captureBreadcrumb({
+                    type: 'http',
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                });
+
+                assert.deepEqual(Raven._breadcrumbs[0], {
+                    type: 'http',
+                    timestamp: 0.1,
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                });
+            });
+
+            it('should call the callback with the breadcrumb object', function() {
+                var callback = this.sinon.stub().returns(true);
+                Raven.setShouldSendBreadcrumbCallback(callback);
+
+                Raven.captureBreadcrumb({
+                    type: 'http',
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                });
+
+                assert.isTrue(callback.calledWith({
+                    type: 'http',
+                    timestamp: 0.1,
+                    data: {
+                        url: 'http://example.org/api/0/auth/',
+                        status_code: 200
+                    }
+                }));
+            });
+
+            it('should enable filtering one breadcrumb but not another', function() {
+                function callback(data) {
+                    if (data.data.url === 'example') {
+                        return false;
+                    }
+
+                    return true;
+                }
+
+                Raven.setShouldSendBreadcrumbCallback(callback);
+                Raven.captureBreadcrumb({
+                    type: 'http',
+                    data: {
+                        url: 'example',
+                        status_code: 200
+                    }
+                });
+
+                Raven.captureBreadcrumb({
+                    type: 'http',
+                    data: {
+                        url: 'foo',
+                        status_code: 301
+                    }
+                });
+
+                assert.deepEqual(Raven._breadcrumbs, [{
+                    type: 'http',
+                    timestamp: 0.1,
+                    data: {
+                        url: 'foo',
+                        status_code: 301
+                    }
+                }]);
+            });
         });
     });
 

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -213,6 +213,9 @@ interface RavenStatic {
     /** Specify a callback function that allows you to apply your own filters to determine if the message should be sent to Sentry. */
     setShouldSendCallback(data: any, orig?: any): RavenStatic;
 
+    /** Specify a callback function that allows you to apply your own filters to determine if a breadcrumb should be sent to Sentry. */
+    setShouldSendBreadcrumbCallback(data: any, orig?: any): RavenStatic;
+
     /** Show Sentry user feedback dialog */
     showReportDialog(options: Object): void;
 }

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -210,11 +210,11 @@ interface RavenStatic {
     /** Specify a function that allows mutation of the data payload right before being sent to Sentry. */
     setDataCallback(data: any, orig?: any): RavenStatic;
 
+    /** Specify a callback function that allows you to mutate or filter breadcrumbs when they are captured. */
+    setBreadcrumbCallback(data: any, orig?: any): RavenStatic;
+
     /** Specify a callback function that allows you to apply your own filters to determine if the message should be sent to Sentry. */
     setShouldSendCallback(data: any, orig?: any): RavenStatic;
-
-    /** Specify a callback function that allows you to apply your own filters to determine if a breadcrumb should be sent to Sentry. */
-    setShouldSendBreadcrumbCallback(data: any, orig?: any): RavenStatic;
 
     /** Show Sentry user feedback dialog */
     showReportDialog(options: Object): void;


### PR DESCRIPTION
Adding a way to filter breadcrumbs. This enables filtered breadcrumbs to not count against the breadcrumb limit.

Fixes https://github.com/getsentry/raven-js/issues/672 and https://github.com/getsentry/raven-js/issues/579

Based on the conversation in #579, I considered making this callback allow modification of the breadcrumb blob if it returns an object, and filtering if it returns false. I decided against that because I would prefer to keep the data modification in one place (`dataCallback`) instead of being spread over many functions.

I believe I followed the contributing guidelines, let me know if I missed something.
