### PR TITLE
Make uuid4 func defensive against window not existing

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1644,7 +1644,7 @@ function parseUrl(url) {
     };
 }
 function uuid4() {
-    var crypto = window.crypto || window.msCrypto;
+    var crypto = _window.crypto || _window.msCrypto;
 
     if (!isUndefined(crypto) && crypto.getRandomValues) {
         // Use window.crypto API if available


### PR DESCRIPTION
/cc @benvinegar @pbadenski

Comment in #784 reported that actually sending an error still fails on uuid generation; I missed a `window` reference in #785. I'll test this a little harder in webworkers than I did before. I had just checked that loading the module worked, but I'll test actually reporting an error.