### PR TITLE
Unmask `[object Object]` errors

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -366,6 +366,16 @@ Raven.prototype = {
         if (!!this._globalOptions.ignoreErrors.test && this._globalOptions.ignoreErrors.test(msg)) {
             return;
         }
+        
+        // Ensure that msg is a string. 
+        if (typeof msg !== 'string'){
+            try {
+                // Attempt to stringify so that msg isn't masked as `[object Object]`
+                msg = JSON.stringify(msg);
+            } catch (ex) {
+                //Do nothing
+            }
+        }
 
         options = options || {};
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -371,7 +371,7 @@ Raven.prototype = {
         if (typeof msg !== 'string'){
             try {
                 // Attempt to stringify so that msg isn't masked as `[object Object]`
-                msg = JSON.stringify(msg);
+                msg = JSON.stringify(msg) || msg;
             } catch (ex) {
                 //Do nothing
             }

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2049,7 +2049,17 @@ describe('Raven (public API)', function() {
             Raven.captureMessage({});
             assert.isTrue(Raven._send.called);
             assert.deepEqual(Raven._send.lastCall.args, [{
-                message: '[object Object]'
+                message: '{}'
+            }]);
+        });
+        
+        it('should stringify when message is of type object', function() {
+            this.sinon.stub(Raven, 'isSetup').returns(true);
+            this.sinon.stub(Raven, '_send');
+            Raven.captureMessage({msg: 'lunar landing was faked'});
+            assert.isTrue(Raven._send.called);
+            assert.deepEqual(Raven._send.lastCall.args, [{
+                message: '{"msg":"lunar landing was faked"}'
             }]);
         });
 


### PR DESCRIPTION
Rather than logging `[object Object]` when msg is of type object, we attempt to stringify the object so that useful information within it can be preserved.