### PR TITLE
Add error callback

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -159,6 +159,20 @@ Those configuration options are documented below:
             }
         }
 
+.. describe:: errorCallback
+
+    A function that allows mutation of the data payload with the original Error object.
+    Only executed for error handling and not for ``captureMessage``.
+
+    .. code-block:: javascript
+
+        {
+            errorCallback: function(data, error) {
+              // do something to data with the original errror
+              return data;
+            }
+        }
+
 .. describe:: breadcrumbCallback
 
     A function that allows filtering or mutating breadcrumb payloads.

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -780,6 +780,79 @@ describe('globals', function() {
             });
         });
 
+        it('should let errorCallback override everything', function() {
+            this.sinon.stub(Raven, 'isSetup').returns(true);
+            this.sinon.stub(Raven, '_makeRequest');
+
+            Raven._globalOptions = {
+                projectId: 2,
+                logger: 'javascript',
+                maxMessageLength: 100,
+                errorCallback: function() {
+                    return {message: 'ibrokeit'};
+                }
+            };
+            Raven._globalContext = {user: {name: 'Matt'}};
+
+            Raven._send({message: 'bar', stacktrace: true});
+            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+                message: 'ibrokeit',
+                event_id: 'abc123'
+            });
+        });
+
+        it('should not call errorCallback for non error messages', function(done) {
+            this.sinon.stub(Raven, 'isSetup').returns(true);
+            this.sinon.stub(Raven, '_makeRequest');
+
+            Raven._globalOptions = {
+                projectId: 2,
+                logger: 'javascript',
+                maxMessageLength: 100,
+                errorCallback: function() {
+                  done(new Error("errorCallback should not be executed"));
+                }
+            };
+            Raven._globalContext = {user: {name: 'Matt'}};
+            Raven._send({message: 'bar'});
+            done();
+        });
+
+        it('should ignore errorCallback if it does not return anything', function() {
+            this.sinon.stub(Raven, 'isSetup').returns(true);
+            this.sinon.stub(Raven, '_makeRequest');
+            this.sinon.stub(Raven, '_getHttpData').returns({
+                url: 'http://localhost/?a=b',
+                headers: {'User-Agent': 'lolbrowser'}
+            });
+
+            Raven._globalProject = '2';
+            Raven._globalOptions = {
+                logger: 'javascript',
+                maxMessageLength: 100,
+                errorCallback: function() {
+                    return;
+                }
+            };
+
+            Raven._send({message: 'bar', stacktrace: true});
+            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+                project: '2',
+                logger: 'javascript',
+                platform: 'javascript',
+                request: {
+                    url: 'http://localhost/?a=b',
+                    headers: {
+                        'User-Agent': 'lolbrowser'
+                    }
+                },
+                event_id: 'abc123',
+                message: 'bar',
+                stacktrace: true,
+                extra: {'session:duration': 100}
+            });
+        });
+
         it('should let dataCallback override everything', function() {
             this.sinon.stub(Raven, 'isSetup').returns(true);
             this.sinon.stub(Raven, '_makeRequest');


### PR DESCRIPTION
Add an `errorCallback` method. This method acts similar to `dataCallback` except that it isn't executed for `captureMessage` and is passed the original error object.

```js
Raven.config(url, {
  errorCallback: (data, error) => {
    return {
      ...data,
      details: error.details
    };
  }
});
```

This resovles issue https://github.com/getsentry/raven-js/issues/483