### PR TITLE
fixed username to name in RavenUserContext (in .d.ts)

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -117,7 +117,7 @@ interface RavenWrapOptions extends RavenOptions {
  */
 interface RavenUserContext {
     id?: string;
-    username?: string;
+    name?: string;
     email?: string;
 }
 


### PR DESCRIPTION
In the d.ts for raven.js the interface `RavenUserContext ` has the member `username.

If you look at the corresponding [js-file](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L658) you see that the meber should really be called `name.`