### PR TITLE
Add missing exports to Angular 2 Example

### DIFF
--- a/docs/integrations/angular2.rst
+++ b/docs/integrations/angular2.rst
@@ -67,7 +67,7 @@ Then, in your main module file (where ``@NgModule`` is called, e.g. app.module.t
       .config('___PUBLIC_DSN___')
       .install();
 
-    class RavenErrorHandler implements ErrorHandler {
+    export class RavenErrorHandler implements ErrorHandler {
       handleError(err:any) : void {
         Raven.captureException(err.originalError);
       }
@@ -99,7 +99,7 @@ Angular CLI now uses Webpack to build instead of SystemJS. All you need to do is
       .config('___PUBLIC_DSN___')
       .install();
 
-    class RavenErrorHandler implements ErrorHandler {
+    export class RavenErrorHandler implements ErrorHandler {
       handleError(err:any) : void {
         Raven.captureException(err.originalError);
       }


### PR DESCRIPTION
The exports are required for ahead of time compiling.

Should be added here too:
https://blog.sentry.io/2016/06/27/sentry-and-angular2.html
@benvinegar 