### PR TITLE
Handle cycle ref in JSON.stringify

### DIFF
--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -23,7 +23,7 @@
 // /var/containers/Bundle/Application/{DEVICE_ID}/HelloWorld.app/main.jsbundle
 
 var PATH_STRIP_RE = /^.*\/[^\.]+(\.app|CodePush)/;
-
+var stringify = require('json-stringify-safe');
 var FATAL_ERROR_KEY = '--rn-fatal--';
 var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';
 
@@ -137,7 +137,7 @@ function reactNativePlugin(Raven, options) {
  */
 reactNativePlugin._persistPayload = function(payload) {
     var AsyncStorage = require('react-native').AsyncStorage;
-    return AsyncStorage.setItem(ASYNC_STORAGE_KEY, JSON.stringify(payload))
+    return AsyncStorage.setItem(ASYNC_STORAGE_KEY, stringify(payload))
         ['catch'](function() { return null; });
 }
 
@@ -198,7 +198,7 @@ reactNativePlugin._transport = function (options) {
     // Just set a phony Origin value; only matters if Sentry Project is configured
     // to whitelist specific origins.
     request.setRequestHeader('Origin', 'react-native://');
-    request.send(JSON.stringify(options.data));
+    request.send(stringify(options.data));
 };
 
 /**


### PR DESCRIPTION
React Native plugin calls the native JSON.stringify, which could causes cycling reference throws. This uses json-stringify-safe package, which is already used in Raven.js core.