### PR TITLE
Update path regex to work with most recent codepush release

### DIFF
--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -22,7 +22,7 @@
 // Example React Native path format (iOS):
 // /var/containers/Bundle/Application/{DEVICE_ID}/HelloWorld.app/main.jsbundle
 
-var PATH_STRIP_RE = /^.*\/[^\.]+(\.app|CodePush)/;
+var PATH_STRIP_RE = /^.*\/[^\.]+(\.app|CodePush|CodePush|.*(?=\/))/;
 var stringify = require('json-stringify-safe');
 var FATAL_ERROR_KEY = '--rn-fatal--';
 var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';


### PR DESCRIPTION
If you're using a combination of Sentry with sourcemaps and the latest release of CodePush the normalized path will be something like `/53cdab92442e11ea3b4a090c2a2d0df8d7d0a96beb46e911651782bb0bde288b/main.jsbundle` instead of `/main.jsbundle`. This breaks the stacktrace even when you uploaded sourcemaps as the path isn't matching up anymore. 

This PR fixes the regex to include CodePush paths that are in the form of `/var/mobile/Containers/Data/Application/{DEVICE_ID}/Library/Application%20Support/CodePush/{CODE_PUSH_STRING}/main.jsbundle`