### PR TITLE
Fix stacks including Firefox resource: URLs (#836)

### DIFF
--- a/test/vendor/fixtures/captured-errors.js
+++ b/test/vendor/fixtures/captured-errors.js
@@ -340,4 +340,15 @@ CapturedExceptions.PHANTOMJS_1_19 = {
     "    at http://path/to/file.js:4287"
 };
 
+CapturedExceptions.FIREFOX_50_RESOURCE_URL= {
+    stack: 'render@resource://path/data/content/bundle.js:5529:16\n' +
+    'dispatchEvent@resource://path/data/content/vendor.bundle.js:18:23028\n' +
+    'wrapped@resource://path/data/content/bundle.js:7270:25',
+    fileName: 'resource://path/data/content/bundle.js',
+    lineNumber: 5529,
+    columnNumber: 16,
+    message: 'this.props.raw[this.state.dataSource].rows is undefined',
+    name: 'TypeError'
+};
+
 module.exports = CapturedExceptions;

--- a/test/vendor/tracekit-parser.test.js
+++ b/test/vendor/tracekit-parser.test.js
@@ -209,5 +209,13 @@ describe('TraceKit', function () {
             assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 4283, column: null });
             assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '?', args: [], line: 4287, column: null });
         });
+
+        it('should parse Firefox errors with resource: URLs', function () {
+            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_50_RESOURCE_URL);
+            assert.ok(stackFrames);
+            assert.deepEqual(stackFrames.stack.length, 3);
+            assert.deepEqual(stackFrames.stack[0], { url: 'resource://path/data/content/bundle.js', func: 'render', args: [], line: 5529, column: 16 });
+        });
+
     });
 });

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -1,7 +1,12 @@
 'use strict';
 
 /*
- TraceKit - Cross brower stack traces - github.com/occ/TraceKit
+ TraceKit - Cross brower stack traces
+
+ This was originally forked from github.com/occ/TraceKit, but has since been
+ largely re-written and is now maintained as part of raven-js.  Tests for
+ this are in test/vendor.
+
  MIT license
 */
 
@@ -381,7 +386,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
         if (typeof ex.stack === 'undefined' || !ex.stack) return;
 
         var chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|<anonymous>).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
-            gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|\[native).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
+            gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|resource|\[native).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
             winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
             lines = ex.stack.split('\n'),
             stack = [],


### PR DESCRIPTION
Fixes TraceKit parser to generate full stacks even when resource: URLs are part of the stack.