### PR TITLE
Add comment to Raven.wrap so people stop blaming Raven.js

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -280,6 +280,10 @@ Raven.prototype = {
             while(i--) args[i] = deep ? self.wrap(options, arguments[i]) : arguments[i];
 
             try {
+                // Attempt to invoke user-land function
+                // NOTE: If you are a Sentry user, and you are seeing this stack frame, it
+                //       means Raven caught an error invoking your application code. This is
+                //       expected behavior and NOT indicative of a bug with Raven.js.
                 return func.apply(this, args);
             } catch(e) {
                 self._ignoreNextOnError();


### PR DESCRIPTION
The idea is that this comment will appear in stack frames to help users understand what is happening, whereas right now they are just seeing this (screenshot below), which leads them to believe there is a bug in the library when it's really just normal operation:

**Before**:

![image](https://cloud.githubusercontent.com/assets/2153/22612548/39051bf8-ea26-11e6-9cc2-49fe509fd550.png)


**After**:

![image](https://cloud.githubusercontent.com/assets/2153/22612537/27d6581a-ea26-11e6-9699-8a2336b5b150.png)

Making this change cause I'm getting tired of explaining it to people.

cc @getsentry/javascript