### PR TITLE
Remove Vue.util.formatComponentName usage as it's not present on production

### DIFF
--- a/plugins/vue.js
+++ b/plugins/vue.js
@@ -4,6 +4,17 @@
  */
 'use strict';
 
+function formatComponentName (vm) {
+    if (vm.$root === vm) {
+        return 'root instance'
+    }
+    var name = vm._isVue
+        ? vm.$options.name || vm.$options._componentTag
+        : vm.name
+    return (name ? 'component <' + name + '>' : 'anonymous component') +
+        (vm._isVue && vm.$options.__file ? ' at ' + vm.$options.__file  : '')
+}
+
 function vuePlugin(Raven, Vue) {
     Vue = Vue || window.Vue;
 
@@ -14,7 +25,7 @@ function vuePlugin(Raven, Vue) {
     Vue.config.errorHandler = function VueErrorHandler(error, vm) {
         Raven.captureException(error, {
           extra: {
-            componentName: Vue.util.formatComponentName(vm),
+            componentName: formatComponentName(vm),
             propsData: vm.$options.propsData
           }
         });

--- a/test/plugins/vue.test.js
+++ b/test/plugins/vue.test.js
@@ -12,12 +12,7 @@ describe('Vue plugin', function () {
         beforeEach(function () {
             this.sinon.stub(Raven, 'captureException');
             this.MockVue = {
-                config: {},
-                util: {
-                    formatComponentName: function() {
-                        return '<root component>'
-                    }
-                }
+                config: {}
             };
         });
 
@@ -38,7 +33,7 @@ describe('Vue plugin', function () {
                 propsData: {
                     foo: 'bar'
                 },
-                componentName: '<root component>'
+                componentName: 'anonymous component'
             });
         });
 


### PR DESCRIPTION
As you can see on the code below, `Vue.util.formatComponent` is not present on production bundles, so `raven` shouldn't depend on it for getting component names: 

https://github.com/vuejs/vue/blob/51e7608528c2e958e3705425bad3d6325ce97765/src/core/util/debug.js#L7

That causes sentry to not capture any error at all. It instead throws this error on console:
![screen shot 2017-02-06 at 11 00 44](https://cloud.githubusercontent.com/assets/1817719/22648177/8b74f862-ec5c-11e6-81de-4da7d3598c89.png)

This function is not subject to many changes, so I think we can just copy its content and update if needed on the future. What do you guys think?
