### PR TITLE
Remove jQuery.ready auto-wrap

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -932,15 +932,6 @@ Raven.prototype = {
         for (var i = 0; i < eventTargets.length; i++) {
             wrapEventTarget(eventTargets[i]);
         }
-
-        var $ = _window.jQuery || _window.$;
-        if ($ && $.fn && $.fn.ready) {
-            fill($.fn, 'ready', function (orig) {
-                return function (fn) {
-                    return orig.call(this, self.wrap(fn));
-                };
-            }, wrappedBuiltIns);
-        }
     },
 
 

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -320,25 +320,6 @@ describe('integration', function () {
               }
             );
         });
-
-        it('should capture exceptions from $.fn.ready (jQuery)', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    $(function () {
-                        foo();
-                    });
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    // # of frames alter significantly between chrome/firefox & safari
-                    assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
-                }
-            );
-        });
     });
 
     describe('breadcrumbs', function () {


### PR DESCRIPTION
jQuery is used less and less, and this code is triggering a deprecation warning. We should just educate people to use `Raven.context` to wrap their application start.

Fixes #817 

cc @getsentry/javascript