### PR TITLE
Make grunt s3 build step push to /latest

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -256,6 +256,11 @@ module.exports = function(grunt) {
                     src: 'build/**/*',
                     dest: '<%= pkg.release %>/',
                     rel: 'build/'
+                },
+                {
+                    src: 'build/**/*',
+                    dest: 'latest/',
+                    rel: 'build/'
                 }]
             }
         },


### PR DESCRIPTION
/cc @benvinegar I'm pretty sure this is all we need here, pushing to the same file on s3 just does an in-place atomic update. Not completely sure about fastly caching but seems like the surrogate key we pass will already make it do what we want.