### PR TITLE
Fix RN frames on Android ...

### DIFF
--- a/test/vendor/fixtures/captured-errors.js
+++ b/test/vendor/fixtures/captured-errors.js
@@ -340,7 +340,7 @@ CapturedExceptions.PHANTOMJS_1_19 = {
     "    at http://path/to/file.js:4287"
 };
 
-CapturedExceptions.FIREFOX_50_RESOURCE_URL= {
+CapturedExceptions.FIREFOX_50_RESOURCE_URL = {
     stack: 'render@resource://path/data/content/bundle.js:5529:16\n' +
     'dispatchEvent@resource://path/data/content/vendor.bundle.js:18:23028\n' +
     'wrapped@resource://path/data/content/bundle.js:7270:25',
@@ -349,6 +349,21 @@ CapturedExceptions.FIREFOX_50_RESOURCE_URL= {
     columnNumber: 16,
     message: 'this.props.raw[this.state.dataSource].rows is undefined',
     name: 'TypeError'
+};
+
+CapturedExceptions.ANDROID_REACT_NATIVE = {
+    message: 'Error: test',
+    name: 'Error',
+    stack: 'Error: test\n' +
+    'at render(/home/username/sample-workspace/sampleapp.collect.react/src/components/GpsMonitorScene.js:78:24)\n' +
+    'at _renderValidatedComponentWithoutOwnerOrContext(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js:1050:29)\n' +
+    'at _renderValidatedComponent(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js:1075:15)\n' +
+    'at renderedElement(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js:484:29)\n' +
+    'at _currentElement(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactCompositeComponent.js:346:40)\n' +
+    'at child(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactReconciler.js:68:25)\n' +
+    'at children(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/shared/stack/reconciler/ReactMultiChild.js:264:10)\n' +
+    'at this(/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js:74:41)\n'
+
 };
 
 module.exports = CapturedExceptions;

--- a/test/vendor/tracekit-parser.test.js
+++ b/test/vendor/tracekit-parser.test.js
@@ -216,6 +216,12 @@ describe('TraceKit', function () {
             assert.deepEqual(stackFrames.stack.length, 3);
             assert.deepEqual(stackFrames.stack[0], { url: 'resource://path/data/content/bundle.js', func: 'render', args: [], line: 5529, column: 16 });
         });
-
+        it('should parse React Native errors on Android', function () {
+            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.ANDROID_REACT_NATIVE);
+            assert.ok(stackFrames);
+            assert.deepEqual(stackFrames.stack.length, 8);
+            assert.deepEqual(stackFrames.stack[0], { url: '/home/username/sample-workspace/sampleapp.collect.react/src/components/GpsMonitorScene.js', func: 'render', args: [], line: 78, column: 24 });
+            assert.deepEqual(stackFrames.stack[7], { url: '/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js', func: 'this', args: [], line: 74, column: 41 });
+        });
     });
 });

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -385,7 +385,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
     function computeStackTraceFromStackProp(ex) {
         if (typeof ex.stack === 'undefined' || !ex.stack) return;
 
-        var chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|<anonymous>).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
+        var chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|<anonymous>|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
             gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|resource|\[native).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
             winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
             lines = ex.stack.split('\n'),
@@ -396,7 +396,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
 
         for (var i = 0, j = lines.length; i < j; ++i) {
             if ((parts = chrome.exec(lines[i]))) {
-                var isNative = parts[2] && parts[2].indexOf('native') !== -1;
+                var isNative = parts[2] && parts[2].indexOf('native') === 0; // start of line
                 element = {
                     'url': !isNative ? parts[2] : null,
                     'func': parts[1] || UNKNOWN_FUNCTION,


### PR DESCRIPTION
1. Don't treat presence of "native" string everywhere as meaning "native code"
2. Properly parse when not protocol / only leading forward slash

fixes #731

See also: csnover/tracekit#69

cc @getsentry/javascript