### PR TITLE
Add sampleRate config option

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -145,6 +145,17 @@ Those configuration options are documented below:
             includePaths: [/https?:\/\/getsentry\.com/, /https?:\/\/cdn\.getsentry\.com/]
         }
 
+.. describe:: sampleRate
+
+    A sampling rate to apply to events. A value of 0.0 will send no events,
+    and a value of 1.0 will send all events (default).
+
+    .. code-block:: javascript
+
+        {
+            sampleRate: 0.5 // send 50% of events, drop the other half
+        }
+
 .. describe:: dataCallback
 
     A function that allows mutation of the data payload right before being

--- a/src/raven.js
+++ b/src/raven.js
@@ -52,7 +52,8 @@ function Raven() {
         collectWindowErrors: true,
         maxMessageLength: 0,
         stackTraceLimit: 50,
-        autoBreadcrumbs: true
+        autoBreadcrumbs: true,
+        sampleRate: 1
     };
     this._ignoreOnError = 0;
     this._isRavenInstalled = false;
@@ -1489,7 +1490,10 @@ Raven.prototype = {
             return;
         }
 
-        this._sendProcessedPayload(data);
+        if (Math.random() < globalOptions.sampleRate) {
+            this._sendProcessedPayload(data);
+        }
+
     },
 
     _getUuid: function () {

--- a/src/raven.js
+++ b/src/raven.js
@@ -1490,10 +1490,13 @@ Raven.prototype = {
             return;
         }
 
-        if (Math.random() < globalOptions.sampleRate) {
+        if (typeof globalOptions.sampleRate === 'number') {
+            if (Math.random() < globalOptions.sampleRate) {
+                this._sendProcessedPayload(data);
+            }
+        } else {
             this._sendProcessedPayload(data);
         }
-
     },
 
     _getUuid: function () {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -841,6 +841,28 @@ describe('globals', function() {
             });
         });
 
+        it('should respect `globalOptions.sampleRate` to omit event', function() {
+            Raven._globalOptions.sampleRate = 0.5;
+            this.sinon.stub(Math, 'random').returns(0.8);
+            this.sinon.stub(Raven, '_sendProcessedPayload');
+            Raven._send({message: 'bar'});
+            assert.isFalse(Raven._sendProcessedPayload.called);
+        });
+
+        it('should respect `globalOptions.sampleRate` to include event', function() {
+            Raven._globalOptions.sampleRate = 0.5;
+            this.sinon.stub(Math, 'random').returns(0.3);
+            this.sinon.stub(Raven, '_sendProcessedPayload');
+            Raven._send({message: 'bar'});
+            assert.isTrue(Raven._sendProcessedPayload.called);
+        });
+
+        it('should always send if `globalOptions.sampleRate` is omitted', function() {
+            this.sinon.stub(Raven, '_makeRequest');
+            Raven._send({message: 'bar'});
+            assert.isTrue(Raven._makeRequest.called);
+        });
+
         it('should strip empty tags', function() {
             this.sinon.stub(Raven, 'isSetup').returns(true);
             this.sinon.stub(Raven, '_makeRequest');


### PR DESCRIPTION
Not sure if we're worried about testing this; we didn't in getsentry/raven-python#978.

I'm also not sure if we want to wait until after dataCallback, shouldSendCallback, etc before applying the sample factor, or apply it before we get to them; I followed the python implementation's lead here and applied it after.

I also simplified the docs wording a bit relative to raven-python. We might want to clarify somehow the difference between setting sample rate to 0 and just disabling raven?

/cc @dcramer @benvinegar 