### PR TITLE
Fix export for Raven ambient definition

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -5,6 +5,7 @@
 declare var Raven: RavenStatic;
 
 export = Raven;
+export as namespace Raven;
 
 interface RavenOptions {
     /** The log level associated with this event. Default: error */


### PR DESCRIPTION
Fix TypeScript export for Raven ambient definition so can be included in projects using TypeScript. Currently due to the export statement, there is no namespace and so you cannot use Raven as it is not found. This is if you included raven as a script dependency in your HTML rather than doing a require and so becomes an ambient lib. It should follow the conventions of other library .d.ts files such as jQuery or underscore which always export a default namespace. 

All tests passing. 