### PR TITLE
Trim URLs in breadcrumbs; add `maxUrlLength` config opt

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -205,6 +205,12 @@ Those configuration options are documented below:
     By default, Raven does not truncate messages. If you need to truncate
     characters for whatever reason, you may set this to limit the length.
 
+.. describe:: maxUrlLength
+
+    By default, Raven will truncate URLs as they appear in breadcrumbs and other meta
+    interfaces to 250 characters in order to minimize bytes over the wire. This does *not*
+    affect URLs in stack traces.
+
 .. describe:: autoBreadcrumbs
 
     Enables/disables automatic collection of breadcrumbs. Possible values are:

--- a/src/raven.js
+++ b/src/raven.js
@@ -50,6 +50,9 @@ function Raven() {
         crossOrigin: 'anonymous',
         collectWindowErrors: true,
         maxMessageLength: 0,
+
+        // By default, truncates URL values to 250 chars
+        maxUrlLength: 250,
         stackTraceLimit: 50,
         autoBreadcrumbs: true,
         sampleRate: 1
@@ -1320,7 +1323,44 @@ Raven.prototype = {
             exception.value = truncate(exception.value, max);
         }
 
+        var request = data.request;
+        if (request) {
+            if (request.url) {
+                request.url = truncate(request.url, this._globalOptions.maxUrlLength);
+            }
+            if (request.Referer) {
+                request.Referer = truncate(request.Referer, this._globalOptions.maxUrlLength);
+            }
+        }
+
+        if (data.breadcrumbs && data.breadcrumbs.values)
+            this._trimBreadcrumbs(data.breadcrumbs);
+
         return data;
+    },
+
+    /**
+     * Truncate breadcrumb values (right now just URLs)
+     */
+    _trimBreadcrumbs: function (breadcrumbs) {
+        // known breadcrumb properties with urls
+        // TODO: also consider arbitrary prop values that start with (https?)?://
+        var urlprops = {to: 1, from: 1, url: 1},
+            crumb,
+            data;
+
+        for (var i = 0; i < breadcrumbs.values.length; i++) {
+            crumb = breadcrumbs.values[i];
+            if (!crumb.hasOwnProperty('data'))
+                continue;
+
+            data = crumb.data;
+            for (var prop in urlprops) {
+                if (data.hasOwnProperty(prop)) {
+                    data[prop] = truncate(data[prop], this._globalOptions.maxUrlLength);
+                }
+            }
+        }
     },
 
     _getHttpData: function() {

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -56,6 +56,9 @@ interface RavenOptions {
     /** By default, Raven does not truncate messages. If you need to truncate characters for whatever reason, you may set this to limit the length. */
     maxMessageLength?: number;
 
+    /** By default, Raven will truncate URLs as they appear in breadcrumbs and other meta interfaces to 250 characters in order to minimize bytes over the wire. This does *not* affect URLs in stack traces. */
+    maxUrlLength?: number;
+
     /** Override the default HTTP data transport handler. */
     transport?: (options: RavenTransportOptions) => void;
 }


### PR DESCRIPTION
Fixes #874 (sort of)

cc @LewisJEllis @maxbittker