### PR TITLE
Fix line/column/url extraction from some eval frames

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -33,6 +33,7 @@ Raven.setUserContext({
 <button onclick="divide(1, 0)">Sourcemap breakage</button>
 <button onclick="derp()">window.onerror</button>
 <button onclick="testOptions()">test options</button>
+<button onclick="throwEval()">throw eval</button>
 <button onclick="testSynthetic()">test synthetic</button>
 <button onclick="throwString()">throw string</button>
 <button onclick="showDialog()">show dialog</button>

--- a/example/scratch.js
+++ b/example/scratch.js
@@ -41,6 +41,10 @@ function throwString() {
     throw 'oops';
 }
 
+function throwEval() {
+    eval('derp();');
+}
+
 function showDialog() {
     broken();
     Raven.showReportDialog();

--- a/test/vendor/fixtures/captured-errors.js
+++ b/test/vendor/fixtures/captured-errors.js
@@ -234,6 +234,18 @@ CapturedExceptions.FIREFOX_31 = {
     columnNumber: 12
 };
 
+CapturedExceptions.FIREFOX_43_EVAL = {
+    columnNumber: 30,
+    fileName: 'http://localhost:8080/file.js line 25 > eval line 2 > eval',
+    lineNumber: 1,
+    message: 'message string',
+    stack: 'baz@http://localhost:8080/file.js line 26 > eval line 2 > eval:1:30\n' +
+    'foo@http://localhost:8080/file.js line 26 > eval:2:96\n' +
+    '@http://localhost:8080/file.js line 26 > eval:4:18\n' +
+    'speak@http://localhost:8080/file.js:26:17\n' +
+    '@http://localhost:8080/file.js:33:9'
+};
+
 // Internal errors sometimes thrown by Firefox
 // More here: https://developer.mozilla.org/en-US/docs/Mozilla/Errors
 //
@@ -250,6 +262,17 @@ CapturedExceptions.FIREFOX_44_NS_EXCEPTION = {
     columnNumber: 0,
     lineNumber: 703,
     result: 2147500037
+};
+
+CapturedExceptions.FIREFOX_50_RESOURCE_URL = {
+    stack: 'render@resource://path/data/content/bundle.js:5529:16\n' +
+    'dispatchEvent@resource://path/data/content/vendor.bundle.js:18:23028\n' +
+    'wrapped@resource://path/data/content/bundle.js:7270:25',
+    fileName: 'resource://path/data/content/bundle.js',
+    lineNumber: 5529,
+    columnNumber: 16,
+    message: 'this.props.raw[this.state.dataSource].rows is undefined',
+    name: 'TypeError'
 };
 
 CapturedExceptions.SAFARI_6 = {
@@ -344,22 +367,22 @@ CapturedExceptions.CHROME_48_BLOB = {
     "    at n.handle (blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379:7:2863)"
 };
 
+CapturedExceptions.CHROME_48_EVAL = {
+    message: 'message string',
+    name: 'Error',
+    stack: 'Error: message string\n' +
+    'at baz (eval at foo (eval at speak (http://localhost:8080/file.js:21:17)), <anonymous>:1:30)\n' +
+    'at foo (eval at speak (http://localhost:8080/file.js:21:17), <anonymous>:2:96)\n' +
+    'at eval (eval at speak (http://localhost:8080/file.js:21:17), <anonymous>:4:18)\n' +
+    'at Object.speak (http://localhost:8080/file.js:21:17)\n' +
+    'at http://localhost:8080/file.js:31:13\n'
+};
+
 CapturedExceptions.PHANTOMJS_1_19 = {
     stack: "Error: foo\n" +
     "    at file:///path/to/file.js:878\n" +
     "    at foo (http://path/to/file.js:4283)\n" +
     "    at http://path/to/file.js:4287"
-};
-
-CapturedExceptions.FIREFOX_50_RESOURCE_URL = {
-    stack: 'render@resource://path/data/content/bundle.js:5529:16\n' +
-    'dispatchEvent@resource://path/data/content/vendor.bundle.js:18:23028\n' +
-    'wrapped@resource://path/data/content/bundle.js:7270:25',
-    fileName: 'resource://path/data/content/bundle.js',
-    lineNumber: 5529,
-    columnNumber: 16,
-    message: 'this.props.raw[this.state.dataSource].rows is undefined',
-    name: 'TypeError'
 };
 
 CapturedExceptions.ANDROID_REACT_NATIVE = {

--- a/test/vendor/tracekit-parser.test.js
+++ b/test/vendor/tracekit-parser.test.js
@@ -123,6 +123,7 @@ describe('TraceKit', function () {
             assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8080/file.js', func: 'I.e.fn.(anonymous function) [as index]', args: [], line: 10, column: 3651 });
         });
 
+
         it('should parse Chrome error with webpack URLs', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_XX_WEBPACK);
             assert.ok(stackFrames);
@@ -131,6 +132,17 @@ describe('TraceKit', function () {
             assert.deepEqual(stackFrames.stack[1], { url: 'webpack:///./src/components/test/test.jsx?', func: 'TESTTESTTEST.render', args: [], line: 272, column: 32 });
             assert.deepEqual(stackFrames.stack[2], { url: 'webpack:///./~/react-transform-catch-errors/lib/index.js?', func: 'TESTTESTTEST.tryRender', args: [], line: 34, column: 31 });
             assert.deepEqual(stackFrames.stack[3], { url: 'webpack:///./~/react-proxy/modules/createPrototypeProxy.js?', func: 'TESTTESTTEST.proxiedMethod', args: [], line: 44, column: 30 });
+        });
+
+        it('should parse nested eval() from Chrome', function() {
+            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_48_EVAL);
+            assert.ok(stackFrames);
+            assert.deepEqual(stackFrames.stack.length, 5);
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8080/file.js', func: 'baz', args: [], line: 21, column: 17});
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8080/file.js', func: 'foo', args: [], line: 21, column: 17});
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8080/file.js', func: 'eval', args: [], line: 21, column: 17});
+            assert.deepEqual(stackFrames.stack[3], { url: 'http://localhost:8080/file.js', func: 'Object.speak', args: [], line: 21, column: 17});
+            assert.deepEqual(stackFrames.stack[4], { url: 'http://localhost:8080/file.js', func: '?', args: [], line: 31, column: 13});
         });
 
         it('should parse Chrome error with blob URLs', function () {
@@ -226,6 +238,18 @@ describe('TraceKit', function () {
             assert.deepEqual(stackFrames.stack.length, 3);
             assert.deepEqual(stackFrames.stack[0], { url: 'resource://path/data/content/bundle.js', func: 'render', args: [], line: 5529, column: 16 });
         });
+
+        it('should parse Firefox errors with eval URLs', function () {
+            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_43_EVAL);
+            assert.ok(stackFrames);
+            assert.deepEqual(stackFrames.stack.length, 5);
+            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8080/file.js', func: 'baz', args:[], line: 26, column: null});
+            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8080/file.js', func: 'foo', args:[], line: 26, column: null});
+            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8080/file.js', func: '?', args:[], line: 26, column: null});
+            assert.deepEqual(stackFrames.stack[3], { url: 'http://localhost:8080/file.js', func: 'speak', args:[], line: 26, column: 17});
+            assert.deepEqual(stackFrames.stack[4], { url: 'http://localhost:8080/file.js', func: '?', args:[], line: 33, column: 9});
+        });
+
         it('should parse React Native errors on Android', function () {
             var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.ANDROID_REACT_NATIVE);
             assert.ok(stackFrames);

--- a/test/vendor/tracekit.test.js
+++ b/test/vendor/tracekit.test.js
@@ -73,9 +73,9 @@ describe('TraceKit', function(){
 
             assert.equal(trace.stack[2].func, 'eval');
             // TODO: fix nested evals
-            assert.equal(trace.stack[2].url, 'eval at <anonymous> (http://example.com/js/test.js:26:5), <anonymous>');
-            assert.equal(trace.stack[2].line, 1); // second set of line/column numbers used
-            assert.equal(trace.stack[2].column, 26);
+            assert.equal(trace.stack[2].url, 'http://example.com/js/test.js');
+            assert.equal(trace.stack[2].line, 26);
+            assert.equal(trace.stack[2].column, 5);
         });
     });
 

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -392,8 +392,12 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
 
         var chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
             gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|\[native).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
-            geckoEval = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i,
             winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|webpack|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
+
+            // Used to additionally parse URL/line/column from eval frames
+            geckoEval = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i,
+            chromeEval = /\((\S*)(?::(\d+))(?::(\d+))\)/,
+
             lines = ex.stack.split('\n'),
             stack = [],
             submatch,
@@ -405,7 +409,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
             if ((parts = chrome.exec(lines[i]))) {
                 var isNative = parts[2] && parts[2].indexOf('native') === 0; // start of line
                 var isEval = parts[2] && parts[2].indexOf('eval') === 0; // start of line
-                if (isEval && (submatch = /\((\S*)(?::(\d+))(?::(\d+))\)/.exec(parts[2]))) {
+                if (isEval && (submatch = chromeEval.exec(parts[2]))) {
                     // throw out eval line/column and use top-most line/column number
                     parts[2] = submatch[1]; // url
                     parts[3] = submatch[2]; // line


### PR DESCRIPTION
This mirrors the behavior in [stacktracejs/error-stack-parser](https://github.com/stacktracejs/error-stack-parser/) (from where I borrowed the tests). The eval "source" line/column is thrown out, and the invocation line (and column, on Chrome) is used instead.

Before we were pulling out URLs that were unusable, so we weren't fetching the source content associated with these eval frames anyways. There is a question of whether Sentry itself should have an "is_eval" meta attribute on frames, or perhaps just a "meta" attribute where we can note in the UI what's going on (cc @mitsuhiko).

cc @LewisJEllis @maxbittker