### PR TITLE
Treat console.error messages as errors, stringify objects in messages

### DIFF
--- a/src/console.js
+++ b/src/console.js
@@ -1,4 +1,5 @@
 'use strict';
+var utils = require('./utils');
 
 var wrapMethod = function(console, level, callback) {
     var originalConsoleLevel = console[level];
@@ -15,7 +16,19 @@ var wrapMethod = function(console, level, callback) {
     console[level] = function () {
         var args = [].slice.call(arguments);
 
-        var msg = '' + args.join(' ');
+        var msg = args.map(function(x) {
+            var str;
+            if (utils.isObject(x)) {
+                try {
+                    str = JSON.stringify(x);
+                } catch (e) {
+                    str = str + ' (could not stringify: ' + e + ')';
+                }
+            } else {
+                str = '' + x;
+            }
+            return str;
+        }).join(' ');
         var data = {level: sentryLevel, logger: 'console', extra: {'arguments': args}};
         callback && callback(msg, data);
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -1135,11 +1135,21 @@ Raven.prototype = {
         if (autoBreadcrumbs.console && 'console' in _window && console.log) {
             // console
             var consoleMethodCallback = function (msg, data) {
-                self.captureBreadcrumb({
-                    message: msg,
-                    level: data.level,
-                    category: 'console'
-                });
+              if (data.level == 'error') {
+                  self.captureException(new Error(msg), {
+                      message: msg,
+                      level: data.level,
+                      category: 'console',
+                      trimHeadFrames: 2,
+                      stacktrace: true,
+                  });
+              } else {
+                  self.captureBreadcrumb({
+                      message: msg,
+                      level: data.level,
+                      category: 'console'
+                  });
+              }
             };
 
             each(['debug', 'info', 'warn', 'error', 'log'], function (_, level) {


### PR DESCRIPTION
This is not a complete PR as much as a suggestion, because I'm running with these changes locally.

1. My codebase treats `console.error` messages as errors, and this reports them as such.

2. My codebases includes objects in log messages, and this will provide something useful instead of just `[object Object]`.

Obviously this would need to be modified to include proper switches, documentation, etc.