### PR TITLE
Remove json-stringify-safe dependency from package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,6 @@
     "url": "git://github.com/getsentry/raven-js.git"
   },
   "main": "src/singleton.js",
-  "dependencies": {
-    "json-stringify-safe": "^5.0.1"
-  },
   "devDependencies": {
     "bluebird": "^3.4.1",
     "browserify-versionify": "^1.0.6",

--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -23,7 +23,7 @@
 // /var/containers/Bundle/Application/{DEVICE_ID}/HelloWorld.app/main.jsbundle
 
 var PATH_STRIP_RE = /^.*\/[^\.]+(\.app|CodePush)/;
-var stringify = require('json-stringify-safe');
+var stringify = require('../vendor/json-stringify-safe/stringify');
 var FATAL_ERROR_KEY = '--rn-fatal--';
 var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';
 


### PR DESCRIPTION
After #883 this is no longer necessary.