### PR TITLE
Add options to disable timer and event target instrumentation

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -299,6 +299,21 @@ Those configuration options are documented below:
 
     If set to `true`, Raven.js outputs some light debugging information onto the console.
 
+
+.. describe:: instrument
+
+    Enables/disables instrumentation of globals. Possible values are:
+
+    * `true` (default)
+    * `false` - all instrumentation disabled
+    * A dictionary of individual instrumentation types that can be enabled/disabled:
+
+    .. code-block:: javascript
+
+        instrument: {
+            'tryCatch': true, // Instruments timers and event targets
+        }
+
 Putting it all together
 -----------------------
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1830,6 +1830,33 @@ describe('Raven (public API)', function() {
             });
         });
 
+        describe('instrument', function () {
+            it('should convert `true` to a dictionary of enabled instrument features', function () {
+                Raven.config(SENTRY_DSN);
+                assert.deepEqual(Raven._globalOptions.instrument, {
+                    tryCatch: true,
+                });
+            });
+
+            it('should leave false as-is', function () {
+                Raven.config(SENTRY_DSN, {
+                    instrument: false
+                });
+                assert.equal(Raven._globalOptions.instrument, false);
+            });
+
+            it('should merge objects with the default instrument settings', function () {
+                Raven.config(SENTRY_DSN, {
+                    instrument: {
+                        tryCatch: false
+                    }
+                });
+                assert.deepEqual(Raven._globalOptions.instrument, {
+                    tryCatch: false,
+                });
+            });
+        });
+
         describe('autoBreadcrumbs', function () {
             it('should convert `true` to a dictionary of enabled breadcrumb features', function () {
                 Raven.config(SENTRY_DSN);
@@ -2934,6 +2961,30 @@ describe('install/uninstall', function () {
 
             // Cleanup.
             document.addEventListener = temp;
+        });
+
+        it('should instrument try/catch by default', function () {
+            this.sinon.stub(Raven, '_instrumentTryCatch');
+            Raven.config(SENTRY_DSN).install();
+            assert.isTrue(Raven._instrumentTryCatch.calledOnce);
+        });
+
+        it('should not instrument try/catch if instrument is false', function () {
+            this.sinon.stub(Raven, '_instrumentTryCatch');
+            Raven.config(SENTRY_DSN, {
+                instrument: false
+            }).install();
+            assert.isFalse(Raven._instrumentTryCatch.called);
+        });
+
+        it('should not instrument try/catch if instrument.tryCatch is false', function () {
+            this.sinon.stub(Raven, '_instrumentTryCatch');
+            Raven.config(SENTRY_DSN, {
+                instrument: {
+                    tryCatch: false
+                }
+            }).install();
+            assert.isFalse(Raven._instrumentTryCatch.called);
         });
 
         it('should instrument breadcrumbs by default', function () {

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -61,6 +61,13 @@ interface RavenOptions {
 
     /** Override the default HTTP data transport handler. */
     transport?: (options: RavenTransportOptions) => void;
+
+    /** Enables/disables instrumentation of globals. */
+    instrument?: boolean | RavenInstrumentationOptions;
+}
+
+interface RavenInstrumentationOptions {
+    tryCatch?: boolean;
 }
 
 interface RavenStatic {


### PR DESCRIPTION
Within react-native, it doesn't make sense for us to instrument timers because [they are already wrapped in try/catch and their errors are reported to ErrorUtils](https://github.com/facebook/react-native/blob/master/Libraries/BatchedBridge/MessageQueue.js#L215-L224). Additionally, if we don't disable the timer instrumentation then the error will be handled separately by ErrorUtils and the try/catch wrapper. This lead to, in my case, fatal errors being reported immediately (rather than on next load) and not having the correct metadata on Android because I wasn't able to modify the stack before passing it through TraceKit.

As for event targets, it doesn't seem necessary within the React Native context where these mostly don't exist -- I imagine people would want this off by default in RN.

See the related PR to react-native-sentry: https://github.com/getsentry/react-native-sentry/pull/40