### PR TITLE
Fix typo in typescript definition file

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -22,7 +22,7 @@ interface RavenOptions {
     /** The name of the server or device that the client is running on */
     serverName?: string;
 
-    /** List of messages to be fitlered out before being sent to Sentry. */
+    /** List of messages to be filtered out before being sent to Sentry. */
     ignoreErrors?: (RegExp | string)[];
 
     /** Similar to ignoreErrors, but will ignore errors from whole urls patching a regex pattern. */
@@ -39,7 +39,7 @@ interface RavenOptions {
         [id: string]: string;
     };
 
-    /** set to true to get the strack trace of your message */
+    /** set to true to get the stack trace of your message */
     stacktrace?: boolean;
 
     extra?: any;


### PR DESCRIPTION
Corrected typo on the comments in typescript definition file.