### PR TITLE
Update type definitions for breadcrumbs

### DIFF
--- a/typescript/raven-tests.ts
+++ b/typescript/raven-tests.ts
@@ -19,7 +19,13 @@ var options = {
     whitelistUrls: [
         /https?:\/\/google\.com/,
         'https://www.google.com'
-    ]
+    ],
+    autoBreadcrumbs: {
+        xhr: false,
+        console: false,
+        dom: true,
+        location: false
+    }
 };
 
 Raven.config('https://public@sentry.io/1', options).install();

--- a/typescript/raven-tests.ts
+++ b/typescript/raven-tests.ts
@@ -55,7 +55,9 @@ var err:Error = Raven.lastException();
 Raven.captureMessage('Broken!');
 Raven.captureMessage('Broken!', {tags: { key: "value" }});
 +Raven.captureMessage('Broken!', { stacktrace: true });
-Raven.captureBreadcrumb({});
+Raven.captureBreadcrumb({
+    message: "This is a breadcrumb message."
+});
 
 Raven.setRelease('abc123');
 Raven.setEnvironment('production');

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -66,7 +66,7 @@ interface RavenOptions {
     instrument?: boolean | RavenInstrumentationOptions;
 
     /** Enables/disables automatic collection of breadcrumbs. */
-    autoBreadcrumbs?: boolean | AutoBreadCrumbOptions
+    autoBreadcrumbs?: boolean | AutoBreadcrumbOptions
 }
 
 interface RavenInstrumentationOptions {
@@ -171,7 +171,7 @@ interface RavenStatic {
     captureMessage(msg: string, options?: RavenOptions): RavenStatic;
 
     /** Log a breadcrumb */
-    captureBreadcrumb(crumb: BreadCrumb): RavenStatic;
+    captureBreadcrumb(crumb: Breadcrumb): RavenStatic;
 
     /**
      * Clear the user context, removing the user data that would be sent to Sentry.
@@ -249,17 +249,17 @@ interface RavenPlugin {
     (raven: RavenStatic, ...args: any[]): RavenStatic;
 }
 
-interface BreadCrumb {
+interface Breadcrumb {
     message?: string;
     category?: string;
     level?: LogLevel;
     data?: any;
-    type?: BreadCrumbType
+    type?: BreadcrumbType
 }
 
-type BreadCrumbType = "navigation" | "http";
+type BreadcrumbType = "navigation" | "http";
 
-interface AutoBreadCrumbOptions {
+interface AutoBreadcrumbOptions {
     xhr?: boolean;
     console?: boolean;
     dom?: boolean;

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -64,6 +64,8 @@ interface RavenOptions {
 
     /** Enables/disables instrumentation of globals. */
     instrument?: boolean | RavenInstrumentationOptions;
+
+    autoBreadcrumbs?: boolean | AutoBreadCrumbOptions
 }
 
 interface RavenInstrumentationOptions {
@@ -255,4 +257,12 @@ interface BreadCrumb {
 }
 
 type BreadCrumbType = "navigation" | "http";
+
+interface AutoBreadCrumbOptions {
+    xhr?: boolean;
+    console?: boolean;
+    dom?: boolean;
+    location?: boolean;
+}
+
 type LogLevel = "critical" | "error" | "warn" | "info" | "debug";

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -8,7 +8,7 @@ export = Raven;
 
 interface RavenOptions {
     /** The log level associated with this event. Default: error */
-    level?: string;
+    level?: LogLevel;
 
     /** The name of the logger used by Sentry. Default: javascript */
     logger?: string;
@@ -168,7 +168,7 @@ interface RavenStatic {
     captureMessage(msg: string, options?: RavenOptions): RavenStatic;
 
     /** Log a breadcrumb */
-    captureBreadcrumb(crumb: Object): RavenStatic;
+    captureBreadcrumb(crumb: BreadCrumb): RavenStatic;
 
     /**
      * Clear the user context, removing the user data that would be sent to Sentry.
@@ -245,3 +245,14 @@ interface RavenTransportOptions {
 interface RavenPlugin {
     (raven: RavenStatic, ...args: any[]): RavenStatic;
 }
+
+interface BreadCrumb {
+    message?: string;
+    category?: string;
+    level?: LogLevel;
+    data?: any;
+    type?: BreadCrumbType
+}
+
+type BreadCrumbType = "navigation" | "http";
+type LogLevel = "critical" | "error" | "warn" | "info" | "debug";

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -65,6 +65,7 @@ interface RavenOptions {
     /** Enables/disables instrumentation of globals. */
     instrument?: boolean | RavenInstrumentationOptions;
 
+    /** Enables/disables automatic collection of breadcrumbs. */
     autoBreadcrumbs?: boolean | AutoBreadCrumbOptions
 }
 


### PR DESCRIPTION
Updates the typings for some breadcrumb related methods to match documentation.

Related to #897 