### PR TITLE
Add allowSecretKey to interface

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -61,6 +61,9 @@ interface RavenOptions {
 
     /** Override the default HTTP data transport handler. */
     transport?: (options: RavenTransportOptions) => void;
+    
+    /** Allow use of private/secretKey. */
+    allowSecretKey?: boolean;
 
     /** Enables/disables instrumentation of globals. */
     instrument?: boolean | RavenInstrumentationOptions;


### PR DESCRIPTION
Typescript is spitting out errors when I try to use allowSecretKey

#967 