### PR TITLE
Add crossorigin="anonymous" to docs index example

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -24,7 +24,7 @@ be included after other libraries are loaded, but before your main application c
 
 .. sourcecode:: html
 
-    <script src="https://cdn.ravenjs.com/###RAVEN_VERSION###/raven.min.js"></script>
+    <script src="https://cdn.ravenjs.com/###RAVEN_VERSION###/raven.min.js" crossorigin="anonymous"></script>
 
 For installation using npm or other package managers, see :doc:`install`.
 


### PR DESCRIPTION
This is everywhere else in the docs except _here_, the first most obvious place. _Sigh_.