### PR TITLE
Recommend Raven.context in getting started docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,6 +38,15 @@ Next you need to configure Raven.js to use your `Sentry DSN
 
     Raven.config('___PUBLIC_DSN___').install()
 
+It is additionally recommended (but not required) to wrap your application start using `Raven.context`.
+This can help surface additional errors in some execution contexts.
+
+.. code-block:: javascript
+
+    Raven.context(function () {
+        initMyApp();
+    });
+
 At this point, Raven is ready to capture any uncaught exception.
 
 Once you have Raven up and running, it is highly recommended to check out :doc:`config`


### PR DESCRIPTION
I'm a little torn on adding this. For one, it's an additional onboarding step which might pose additional difficulty for users getting started. But for a small % of users (20%?), using `Raven.context` here will surface other errors that would otherwise get lost to `'Script error`". And because we discard `"Script error"` by default (and no console logging), I feel we need to recommend using it.

For more on this, see "An alternative solution: try/catch" in this [script error blog post](https://blog.sentry.io/2016/05/17/what-is-script-error.html).

cc @dcramer @mattrobenolt @lewisjellis