### PR TITLE
Callback to set options depending on captured exception

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -200,6 +200,25 @@ Those configuration options are documented below:
             }
         }
 
+.. describe:: optionsFromException
+
+    A callback function that allows you to define some options to be
+    sent to Sentry, based on the captured exception.
+
+    .. code-block:: javascript
+
+        {
+            optionsFromException: function(ex, options) {
+              options = Object.assign({}, options)
+
+              if (ex.level) {
+                options.level = ex.level
+              }
+
+              return options;
+            }
+        }
+
 .. describe:: maxMessageLength
 
     By default, Raven does not truncate messages. If you need to truncate

--- a/src/raven.js
+++ b/src/raven.js
@@ -375,6 +375,10 @@ Raven.prototype = {
             }, options));
         }
 
+        if (isFunction(this._globalOptions.optionsFromException)) {
+            options = this._globalOptions.optionsFromException(ex, options)
+        }
+
         // Store the raw exception object for potential debugging and introspection
         this._lastCapturedException = ex;
 

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -53,6 +53,9 @@ interface RavenOptions {
     /** A callback function that allows you to apply your own filters to determine if the message should be sent to Sentry. */
     shouldSendCallback?: (data: any) => boolean;
 
+    /** A callback function that allows you to define some options to be sent to Sentry, based on the captured exception. */
+    optionsFromException?: (ex: Error, options?: RavenOptions) => RavenOptions;
+
     /** By default, Raven does not truncate messages. If you need to truncate characters for whatever reason, you may set this to limit the length. */
     maxMessageLength?: number;
 


### PR DESCRIPTION
When throwing an error, it sometimes make sense to add some extra data directly to the `Error` object like so:

```js
const error = new Error('foo')
error.extra = {foo: 'bar'}
throw error
```

Right now, if we want this extra sent alongside the error, we need to override `Raven.captureException` like so:

```js
const originalCaptureException = Raven.captureException.bind(Raven)
Raven.captureException = (ex, options) => {
  options = Object.assign({}, options)
  options.extra = Object.assign({}, ex.extra, options.extra)
  originalCaptureException(ex, options)
}
```

With this PR, it allows us to replace this overriding with a simple config:

```js
Raven.config(SENTRY_DSN, {
  optionsFromException(ex, options) {
    options = Object.assign({}, options)
    options.extra = Object.assign({}, ex.extra, options.extra)
    return options
  }
})
```