### PR TITLE
Fix android react native release builds stacktrace

### DIFF
--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -33,9 +33,13 @@ var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';
  * Strip device-specific IDs from React Native file:// paths
  */
 function normalizeUrl(url, pathStripRe) {
-    return url
-        .replace(/^file\:\/\//, '')
-        .replace(pathStripRe, '');
+  if (url.indexOf('/') !== -1) {
+      return url
+          .replace(/^file\:\/\//, '')
+          .replace(pathStripRe, '');
+  } else {
+      return '/' + url;
+  }
 }
 
 /**

--- a/test/vendor/fixtures/captured-errors.js
+++ b/test/vendor/fixtures/captured-errors.js
@@ -400,4 +400,48 @@ CapturedExceptions.ANDROID_REACT_NATIVE = {
 
 };
 
+CapturedExceptions.ANDROID_REACT_NATIVE_PROD = {
+    message: 'Error: test',
+    name: 'Error',
+    stack: 'value@index.android.bundle:12:1917\n' +
+    'onPress@index.android.bundle:12:2336\n' +
+    'touchableHandlePress@index.android.bundle:258:1497\n' +
+    '[native code]\n' +
+    '_performSideEffectsForTransition@index.android.bundle:252:8508\n' +
+    '[native code]\n' +
+    '_receiveSignal@index.android.bundle:252:7291\n' +
+    '[native code]\n' +
+    'touchableHandleResponderRelease@index.android.bundle:252:4735\n' +
+    '[native code]\n' +
+    'u@index.android.bundle:79:142\n' +
+    'invokeGuardedCallback@index.android.bundle:79:459\n' +
+    'invokeGuardedCallbackAndCatchFirstError@index.android.bundle:79:580\n' +
+    'c@index.android.bundle:95:365\n' +
+    'a@index.android.bundle:95:567\n' +
+    'v@index.android.bundle:146:501\n' +
+    'g@index.android.bundle:146:604\n' +
+    'forEach@[native code]\n' +
+    'i@index.android.bundle:149:80\n' +
+    'processEventQueue@index.android.bundle:146:1432\n' +
+    's@index.android.bundle:157:88\n' +
+    'handleTopLevel@index.android.bundle:157:174\n' +
+    'index.android.bundle:156:572\n' +
+    'a@index.android.bundle:93:276\n' +
+    'c@index.android.bundle:93:60\n' +
+    'perform@index.android.bundle:177:596\n' +
+    'batchedUpdates@index.android.bundle:188:464\n' +
+    'i@index.android.bundle:176:358\n' +
+    'i@index.android.bundle:93:90\n' +
+    'u@index.android.bundle:93:150\n' +
+    '_receiveRootNodeIDEvent@index.android.bundle:156:544\n' +
+    'receiveTouches@index.android.bundle:156:918\n' +
+    'value@index.android.bundle:29:3016\n' +
+    'index.android.bundle:29:955\n' +
+    'value@index.android.bundle:29:2417\n' +
+    'value@index.android.bundle:29:927\n' +
+    '[native code]'
+};
+
+
+
 module.exports = CapturedExceptions;

--- a/test/vendor/tracekit-parser.test.js
+++ b/test/vendor/tracekit-parser.test.js
@@ -257,5 +257,14 @@ describe('TraceKit', function () {
             assert.deepEqual(stackFrames.stack[0], { url: '/home/username/sample-workspace/sampleapp.collect.react/src/components/GpsMonitorScene.js', func: 'render', args: [], line: 78, column: 24 });
             assert.deepEqual(stackFrames.stack[7], { url: '/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js', func: 'this', args: [], line: 74, column: 41 });
         });
+
+        it('should parse React Native errors on Android Production', function () {
+            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.ANDROID_REACT_NATIVE_PROD);
+            assert.ok(stackFrames);
+            assert.deepEqual(stackFrames.stack.length, 37);
+            assert.deepEqual(stackFrames.stack[0], { url: 'index.android.bundle', func: 'value', args: [], line: 12, column: 1917 });
+            assert.deepEqual(stackFrames.stack[35], { url: 'index.android.bundle', func: 'value', args: [], line: 29, column: 927 });
+            assert.deepEqual(stackFrames.stack[36], { url: '[native code]', func: '?', args: [], line: null, column: null });
+        });
     });
 });

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -370,7 +370,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
         if (typeof ex.stack === 'undefined' || !ex.stack) return;
 
         var chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
-            gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|\[native).*?)(?::(\d+))?(?::(\d+))?\s*$/i,
+            gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$/i,
             winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|webpack|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
 
             // Used to additionally parse URL/line/column from eval frames


### PR DESCRIPTION
This is basically this PR with a test: https://github.com/getsentry/raven-js/pull/950
Thx @yury

It seems that if you build a react native android app in release, the stacktrace has a special format.
This PR fixes the regex we have.

Also discussed this with @mitsuhiko, this PR is the faster, a bit more hacky solution.
I didn't dare to refactor the whole `computeStackTraceFromStackProp` function.
Someday we could refactor it like: 
before we iterate every line and check which regex matches, we could first detect what kind of stacktrace it is and then just use the specific regex.

Nevertheless, tested it also in a real react-native app and it works.

Before:
<img width="1279" alt="screen shot 2017-06-27 at 15 25 56" src="https://user-images.githubusercontent.com/363802/27589788-f92d8c7a-5b4c-11e7-8f97-10d7379fb742.png">

After:
<img width="1273" alt="screen shot 2017-06-27 at 15 36 54" src="https://user-images.githubusercontent.com/363802/27590290-80f9bc54-5b4e-11e7-8f44-65617f0d91a5.png">
