### PR TITLE
Fixes bad path for npm-based installation

### DIFF
--- a/docs/integrations/ember.rst
+++ b/docs/integrations/ember.rst
@@ -67,8 +67,8 @@ npm
 
 .. code-block:: javascript
 
-    app.import('bower_components/raven-js/dist/raven.js');
-    app.import('bower_components/raven-js/dist/plugins/ember.js');
+    app.import('node_modules/raven-js/dist/raven.js');
+    app.import('node_modules/raven-js/dist/plugins/ember.js');
 
 .. code-block:: html
 


### PR DESCRIPTION
Replaces `bower_components...` path with `node_modules...` for npm-based installation.


Before submitting a pull request, please verify the following:

* [ ] If you've added code that should be tested, please add tests.
* [ ] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [ ] Ensure your code lints and the test suite passes (npm test).
