### PR TITLE
Prevent `truncate` method to throw an error when `crumb.data.url` is `undefined`

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1391,7 +1391,7 @@ Raven.prototype = {
             data = objectMerge({}, crumb.data);
             for (var j = 0; j < urlProps.length; ++j) {
                 urlProp = urlProps[j];
-                if (data.hasOwnProperty(urlProp)) {
+                if (data.hasOwnProperty(urlProp) && data[urlProp]) {
                     data[urlProp] = truncate(data[urlProp], this._globalOptions.maxUrlLength);
                 }
             }

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1398,6 +1398,31 @@ describe('globals', function() {
             });
         });
 
+        it('should not throw error when url in breadcrumb is undefined', function() {
+            this.sinon.stub(Raven, 'isSetup').returns(true);
+            this.sinon.stub(Raven, '_makeRequest');
+            this.sinon.stub(Raven, '_getHttpData').returns({
+                url: 'http://localhost/?a=b',
+                headers: {'User-Agent': 'lolbrowser'}
+            });
+
+            Raven._globalProject = '2';
+            Raven._globalOptions = {
+                logger: 'javascript',
+                maxMessageLength: 100
+            };
+            Raven._globalOptions.maxUrlLength = 35;
+
+            var obj = {method: 'POST', url: undefined};
+            // Do not freeze crumb data
+
+            Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: obj}];
+
+            assert.doesNotThrow(function() {
+              Raven._send({message: 'bar'});
+            }, TypeError)
+        });
+
     });
 
     describe('makeRequest', function() {


### PR DESCRIPTION
I barely understand how it happened, but RavenJS stored breadcrumbs with undefined `data.url`.

It caused the `truncate()` method to throw an error having for consequence that our Exceptions were never logged into Sentry.

Here is a [temporary workaround](https://github.com/cozy/cozy-onboarding-v3/commit/acba1bb4488bf922e0bde52a8cd33737e6968ae7#diff-3e72429df0b60b148c3bc96902c6bf36R12) that I made in our app until a fix will be made.

Another solution should have been to prevent undefined `str` directly in `truncate()`.