### PR TITLE
Unify code style using Prettier and updates ESLint rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,6 @@
+build/
+dist/
+example/
+vendor/
+test/
+

--- a/.eslintrc
+++ b/.eslintrc
@@ -11,29 +11,16 @@
   },
   "rules": {
     "block-scoped-var": 2,
-    "comma-dangle": [2, "never"],
-    "dot-notation": [
-      2,
-      {
-        "allowKeywords": false
-      }
-    ],
-    "eqeqeq": [
-      2,
-      "allow-null"
-    ],
+    "dot-notation": [2, {"allowKeywords": false}],
+    "eqeqeq": [2, "allow-null"],
     "guard-for-in": 2,
     "new-cap": 2,
     "no-caller": 2,
-    "no-cond-assign": [
-      2,
-      "except-parens"
-    ],
+    "no-cond-assign": [2, "except-parens"],
     "no-debugger": 2,
     "no-empty": 2,
     "no-eval": 2,
     "no-extend-native": 2,
-    "no-extra-parens": 2,
     "no-irregular-whitespace": 2,
     "no-iterator": 2,
     "no-loop-func": 2,
@@ -44,29 +31,13 @@
     "no-sequences": 2,
     "no-shadow": 2,
     "no-undef": 2,
-    "no-unused-vars": [
-      2,
-      {"args": "none"}
-    ],
+    "no-unused-vars": [2, {"args": "none"}],
     "no-with": 2,
-    "quotes": [
-      2,
-      "single",
-      "avoid-escape"
-    ],
-    "semi": [
-      0,
-      "never"
-    ],
-    "strict": [
-      2,
-      "global"
-    ],
-    "valid-typeof": 2,
-    "wrap-iife": [
-      2,
-      "inside"
-    ],
-    "eol-last": 2
-  }
+    "semi": [0, "never"],
+    "strict": [2, "global"],
+    "valid-typeof": 2
+  },
+  "extends": [
+    "prettier"
+  ]
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -203,7 +203,7 @@ module.exports = function(grunt) {
     },
 
     eslint: {
-      target: ['Gruntfile.js', 'src/**/*.js', 'plugins/**/*.js']
+      target: ['.']
     },
 
     mocha: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,365 +1,378 @@
 'use strict';
 
 module.exports = function(grunt) {
-    var _ = require('lodash');
-    var path = require('path');
-    var os = require('os');
-    var through = require('through2');
-    var proxyquire = require('proxyquireify');
-    var versionify = require('browserify-versionify');
-    var derequire = require('derequire/plugin');
-    var collapser = require('bundle-collapser/plugin');
+  var _ = require('lodash');
+  var path = require('path');
+  var os = require('os');
+  var through = require('through2');
+  var proxyquire = require('proxyquireify');
+  var versionify = require('browserify-versionify');
+  var derequire = require('derequire/plugin');
+  var collapser = require('bundle-collapser/plugin');
 
-    var excludedPlugins = [
-        'react-native'
-    ];
+  var excludedPlugins = ['react-native'];
 
-    var plugins = grunt.option('plugins');
-    // Create plugin paths and verify they exist
-    plugins = _.map(plugins ? plugins.split(',') : [], function (plugin) {
-        var p = 'plugins/' + plugin + '.js';
+  var plugins = grunt.option('plugins');
+  // Create plugin paths and verify they exist
+  plugins = _.map(plugins ? plugins.split(',') : [], function(plugin) {
+    var p = 'plugins/' + plugin + '.js';
 
-        if(!grunt.file.exists(p))
-            throw new Error("Plugin '" + plugin + "' not found in plugins directory.");
+    if (!grunt.file.exists(p))
+      throw new Error("Plugin '" + plugin + "' not found in plugins directory.");
 
-        return p;
+    return p;
+  });
+
+  // custom browserify transformer to re-write plugins to
+  // self-register with Raven via addPlugin
+  function AddPluginBrowserifyTransformer() {
+    return function(file) {
+      return through(function(buf, enc, next) {
+        buf = buf.toString('utf8');
+        if (/plugins/.test(file)) {
+          buf += "\nrequire('../src/singleton').addPlugin(module.exports);";
+        }
+        this.push(buf);
+        next();
+      });
+    };
+  }
+
+  // Taken from http://dzone.com/snippets/calculate-all-combinations
+  var combine = function(a) {
+    var fn = function(n, src, got, all) {
+      if (n === 0) {
+        all.push(got);
+        return;
+      }
+
+      for (var j = 0; j < src.length; j++) {
+        fn(n - 1, src.slice(j + 1), got.concat([src[j]]), all);
+      }
+    };
+
+    var excluded = _.map(excludedPlugins, function(plugin) {
+      return 'plugins/' + plugin + '.js';
     });
 
-    // custom browserify transformer to re-write plugins to
-    // self-register with Raven via addPlugin
-    function AddPluginBrowserifyTransformer() {
-        return function (file) {
-            return through(function (buf, enc, next) {
-                buf = buf.toString('utf8');
-                if (/plugins/.test(file)) {
-                    buf += "\nrequire('../src/singleton').addPlugin(module.exports);";
-                }
-                this.push(buf);
-                next();
-            });
-        };
+    // Remove the plugins that we don't want to build
+    a = _.filter(a, function(n) {
+      return excluded.indexOf(n) === -1;
+    });
+
+    var all = [a];
+
+    for (var i = 0; i < a.length; i++) {
+      fn(i, a, [], all);
     }
 
-    // Taken from http://dzone.com/snippets/calculate-all-combinations
-    var combine = function (a) {
-        var fn = function (n, src, got, all) {
-            if (n === 0) {
-                all.push(got);
-                return;
-            }
+    return all;
+  };
 
-            for (var j = 0; j < src.length; j++) {
-                fn(n - 1, src.slice(j + 1), got.concat([src[j]]), all);
-            }
-        };
+  var plugins = grunt.file.expand('plugins/*.js');
 
-        var excluded = _.map(excludedPlugins, function(plugin) {
-            return 'plugins/' + plugin + '.js';
-        });
+  var cleanedPlugins = plugins.filter(function(plugin) {
+    var pluginName = path.basename(plugin, '.js');
 
-        // Remove the plugins that we don't want to build
-        a = _.filter(a, function(n) {
-            return excluded.indexOf(n) === -1;
-        });
+    return excludedPlugins.indexOf(pluginName) === -1;
+  });
 
-        var all = [a];
+  var pluginSingleFiles = cleanedPlugins.map(function(plugin) {
+    var filename = path.basename(plugin);
 
-        for (var i = 0; i < a.length; i++) {
-            fn(i, a, [], all);
+    var file = {};
+    file.src = plugin;
+    file.dest = path.join('build', 'plugins', filename);
+
+    return file;
+  });
+
+  var pluginCombinations = combine(plugins);
+  var pluginConcatFiles = _.reduce(
+    pluginCombinations,
+    function(dict, comb) {
+      var key = _.map(comb, function(plugin) {
+        return path.basename(plugin, '.js');
+      });
+      key.sort();
+
+      var dest = path.join('build/', key.join(','), '/raven.js');
+      dict[dest] = ['src/singleton.js'].concat(comb);
+
+      return dict;
+    },
+    {}
+  );
+
+  var browserifyConfig = {
+    options: {
+      banner: grunt.file.read('template/_copyright.js'),
+      browserifyOptions: {
+        standalone: 'Raven' // umd
+      },
+      transform: [versionify],
+      plugin: [derequire, collapser]
+    },
+    core: {
+      src: 'src/singleton.js',
+      dest: 'build/raven.js'
+    },
+    'plugins-combined': {
+      files: pluginConcatFiles,
+      options: {
+        transform: [[versionify], [new AddPluginBrowserifyTransformer()]]
+      }
+    },
+    test: {
+      src: 'test/**/*.test.js',
+      dest: 'build/raven.test.js',
+      options: {
+        browserifyOptions: {
+          debug: false // source maps
+        },
+        ignore: ['react-native'],
+        plugin: [proxyquire.plugin]
+      }
+    }
+  };
+
+  // Create a dedicated entry in browserify config for
+  // each individual plugin (each needs a unique `standalone`
+  // config)
+  var browserifyPluginTaskNames = [];
+  pluginSingleFiles.forEach(function(item) {
+    var name = item.src
+      .replace(/.*\//, '') // everything before slash
+      .replace('.js', ''); // extension
+    var capsName = name.charAt(0).toUpperCase() + name.slice(1);
+    var config = {
+      src: item.src,
+      dest: item.dest,
+      options: {
+        browserifyOptions: {
+          // e.g. Raven.Plugins.Angular
+          standalone: 'Raven.Plugins.' + capsName
         }
-
-        return all;
+      }
     };
+    browserifyConfig[name] = config;
+    browserifyPluginTaskNames.push('browserify:' + name);
+  });
 
-    var plugins = grunt.file.expand('plugins/*.js');
+  var awsConfigPath = path.join(os.homedir(), '.aws', 'raven-js.json');
+  var gruntConfig = {
+    pkg: grunt.file.readJSON('package.json'),
+    aws: grunt.file.exists(awsConfigPath) ? grunt.file.readJSON(awsConfigPath) : {},
 
-    var cleanedPlugins = plugins.filter(function (plugin) {
-        var pluginName = path.basename(plugin, '.js');
+    clean: ['build'],
 
-        return excludedPlugins.indexOf(pluginName) === -1;
-    });
+    browserify: browserifyConfig,
 
-    var pluginSingleFiles = cleanedPlugins.map(function (plugin) {
-        var filename = path.basename(plugin);
+    uglify: {
+      options: {
+        sourceMap: true,
 
-        var file = {};
-        file.src = plugin;
-        file.dest = path.join('build', 'plugins', filename);
+        // Only preserve comments that start with (!)
+        preserveComments: /^!/,
 
-        return file;
-    });
-
-    var pluginCombinations = combine(plugins);
-    var pluginConcatFiles = _.reduce(pluginCombinations, function (dict, comb) {
-        var key = _.map(comb, function (plugin) {
-            return path.basename(plugin, '.js');
-        });
-        key.sort();
-
-        var dest = path.join('build/', key.join(','), '/raven.js');
-        dict[dest] = ['src/singleton.js'].concat(comb);
-
-        return dict;
-    }, {});
-
-    var browserifyConfig = {
-        options: {
-            banner: grunt.file.read('template/_copyright.js'),
-                browserifyOptions: {
-                standalone: 'Raven' // umd
-            },
-            transform: [versionify],
-            plugin: [
-                derequire,
-                collapser
-            ]
+        // Minify object properties that begin with _ ("private"
+        // methods and values)
+        mangleProperties: {
+          regex: /^_/
         },
-        core: {
-            src: 'src/singleton.js',
-            dest: 'build/raven.js'
-        },
-        'plugins-combined': {
-            files: pluginConcatFiles,
-            options: {
-                transform: [
-                    [versionify],
-                    [new AddPluginBrowserifyTransformer()]
-                ]
-            }
-        },
-        test: {
-            src: 'test/**/*.test.js',
-            dest: 'build/raven.test.js',
-            options: {
-                browserifyOptions: {
-                    debug: false// source maps
-                },
-                ignore: ['react-native'],
-                plugin: [proxyquire.plugin]
-            }
+
+        compress: {
+          booleans: true,
+          conditionals: true,
+          dead_code: true,
+          join_vars: true,
+          pure_getters: true,
+          sequences: true,
+          unused: true,
+
+          global_defs: {
+            __DEV__: false
+          }
         }
-    };
+      },
+      dist: {
+        src: ['build/**/*.js'],
+        ext: '.min.js',
+        expand: true
+      }
+    },
 
-    // Create a dedicated entry in browserify config for
-    // each individual plugin (each needs a unique `standalone`
-    // config)
-    var browserifyPluginTaskNames = [];
-    pluginSingleFiles.forEach(function (item) {
-        var name = item.src
-            .replace(/.*\//, '') // everything before slash
-            .replace('.js', ''); // extension
-        var capsName = name.charAt(0).toUpperCase() + name.slice(1);
-        var config = {
-            src: item.src,
-            dest: item.dest,
-            options: {
-                browserifyOptions: {
-                    // e.g. Raven.Plugins.Angular
-                    standalone: 'Raven.Plugins.' + capsName
-                }
-            }
-        };
-        browserifyConfig[name] = config;
-        browserifyPluginTaskNames.push('browserify:' + name);
-    });
+    eslint: {
+      target: ['Gruntfile.js', 'src/**/*.js', 'plugins/**/*.js']
+    },
 
-
-    var awsConfigPath = path.join(os.homedir(), '.aws', 'raven-js.json');
-    var gruntConfig = {
-        pkg: grunt.file.readJSON('package.json'),
-        aws: grunt.file.exists(awsConfigPath) ? grunt.file.readJSON(awsConfigPath): {},
-
-        clean: ['build'],
-
-        browserify: browserifyConfig,
-
-        uglify: {
-            options: {
-                sourceMap: true,
-
-                // Only preserve comments that start with (!)
-                preserveComments: /^!/,
-
-                // Minify object properties that begin with _ ("private"
-                // methods and values)
-                mangleProperties: {
-                    regex: /^_/
-                },
-
-                compress: {
-                    booleans: true,
-                    conditionals: true,
-                    dead_code: true,
-                    join_vars: true,
-                    pure_getters: true,
-                    sequences: true,
-                    unused: true,
-
-                    global_defs: {
-                        '__DEV__': false
-                    }
-                }
-            },
-            dist: {
-                src: ['build/**/*.js'],
-                ext: '.min.js',
-                expand: true
-            }
-        },
-
-        eslint: {
-            target: ['Gruntfile.js', 'src/**/*.js', 'plugins/**/*.js']
-        },
-
+    mocha: {
+      options: {
         mocha: {
-            options: {
-                mocha: {
-                    ignoreLeaks: true,
-                    grep: grunt.option('grep')
-                },
-                log: true,
-                reporter: 'Dot',
-                run: true
-            },
-            unit: {
-                src: ['test/index.html'],
-                nonull: true
-            },
-            integration: {
-                src: ['test/integration/index.html'],
-                nonull: true
-            }
+          ignoreLeaks: true,
+          grep: grunt.option('grep')
         },
+        log: true,
+        reporter: 'Dot',
+        run: true
+      },
+      unit: {
+        src: ['test/index.html'],
+        nonull: true
+      },
+      integration: {
+        src: ['test/integration/index.html'],
+        nonull: true
+      }
+    },
 
-        release: {
-            options: {
-                npm: false,
-                commitMessage: 'Release <%= version %>'
-            }
-        },
+    release: {
+      options: {
+        npm: false,
+        commitMessage: 'Release <%= version %>'
+      }
+    },
 
-        s3: {
-            options: {
-                key: '<%= aws.key %>',
-                secret: '<%= aws.secret %>',
-                bucket: '<%= aws.bucket %>',
-                access: 'public-read',
-                // Limit concurrency
-                maxOperations: 20,
-                headers: {
-                    // Surrogate-Key header for Fastly to purge by release
-                    'x-amz-meta-surrogate-key': '<%= pkg.release %>'
-                }
-            },
-            all: {
-                upload: [{
-                    src: 'build/**/*',
-                    dest: '<%= pkg.release %>/',
-                    rel: 'build/'
-                }]
-            }
-        },
-
-        connect: {
-            test: {
-                options: {
-                    port: 8000,
-                    debug: true,
-                    keepalive: true
-                }
-            },
-
-            docs: {
-                options: {
-                    port: 8000,
-                    debug: true,
-                    base: 'docs/_build/html',
-                    keepalive: true
-                }
-            }
-        },
-
-        copy: {
-            dist: {
-                expand: true,
-                flatten: false,
-                cwd: 'build/',
-                src: '**',
-                dest: 'dist/'
-            }
-        },
-
-        sri: {
-            dist: {
-                src: ['dist/*.js'],
-                options: {
-                    dest: 'dist/sri.json',
-                    pretty: true
-                }
-            },
-            build: {
-                src: ['build/**/*.js'],
-                options: {
-                    dest: 'build/sri.json',
-                    pretty: true
-                }
-            }
+    s3: {
+      options: {
+        key: '<%= aws.key %>',
+        secret: '<%= aws.secret %>',
+        bucket: '<%= aws.bucket %>',
+        access: 'public-read',
+        // Limit concurrency
+        maxOperations: 20,
+        headers: {
+          // Surrogate-Key header for Fastly to purge by release
+          'x-amz-meta-surrogate-key': '<%= pkg.release %>'
         }
-    };
+      },
+      all: {
+        upload: [
+          {
+            src: 'build/**/*',
+            dest: '<%= pkg.release %>/',
+            rel: 'build/'
+          }
+        ]
+      }
+    },
 
-    grunt.initConfig(gruntConfig);
-
-    // Custom Grunt tasks
-    grunt.registerTask('version', function() {
-        var pkg = grunt.config.get('pkg');
-
-        // Verify version string in source code matches what's in package.json
-        var Raven = require('./src/raven');
-        if (Raven.prototype.VERSION !== pkg.version) {
-            return grunt.util.error('Mismatched version in src/raven.js: ' + Raven.prototype.VERSION +
-                ' (should be ' + pkg.version + ')');
+    connect: {
+      test: {
+        options: {
+          port: 8000,
+          debug: true,
+          keepalive: true
         }
+      },
 
-        if (grunt.option('dev')) {
-            pkg.release = 'dev';
-        } else {
-            pkg.release = pkg.version;
+      docs: {
+        options: {
+          port: 8000,
+          debug: true,
+          base: 'docs/_build/html',
+          keepalive: true
         }
-        grunt.config.set('pkg', pkg);
-    });
+      }
+    },
 
-    // Grunt contrib tasks
-    grunt.loadNpmTasks('grunt-contrib-uglify');
-    grunt.loadNpmTasks('grunt-contrib-clean');
-    grunt.loadNpmTasks('grunt-contrib-connect');
-    grunt.loadNpmTasks('grunt-contrib-copy');
+    copy: {
+      dist: {
+        expand: true,
+        flatten: false,
+        cwd: 'build/',
+        src: '**',
+        dest: 'dist/'
+      }
+    },
 
-    // 3rd party Grunt tasks
-    grunt.loadNpmTasks('grunt-browserify');
-    grunt.loadNpmTasks('grunt-mocha');
-    grunt.loadNpmTasks('grunt-release');
-    grunt.loadNpmTasks('grunt-s3');
-    grunt.loadNpmTasks('grunt-gitinfo');
-    grunt.loadNpmTasks('grunt-sri');
-    grunt.loadNpmTasks('grunt-eslint');
+    sri: {
+      dist: {
+        src: ['dist/*.js'],
+        options: {
+          dest: 'dist/sri.json',
+          pretty: true
+        }
+      },
+      build: {
+        src: ['build/**/*.js'],
+        options: {
+          dest: 'build/sri.json',
+          pretty: true
+        }
+      }
+    }
+  };
 
-    // Build tasks
-    grunt.registerTask('_prep', ['clean', 'gitinfo', 'version']);
-    grunt.registerTask('browserify.core', ['_prep', 'browserify:core'].concat(browserifyPluginTaskNames));
-    grunt.registerTask('browserify.plugins-combined', ['_prep', 'browserify:plugins-combined']);
-    grunt.registerTask('build.test', ['_prep', 'browserify:test']);
-    grunt.registerTask('build.core', ['browserify.core', 'uglify', 'sri:dist']);
-    grunt.registerTask('build.plugins-combined', ['browserify.plugins-combined', 'uglify', 'sri:dist', 'sri:build']);
-    grunt.registerTask('build', ['build.plugins-combined']);
-    grunt.registerTask('dist', ['build.core', 'copy:dist']);
+  grunt.initConfig(gruntConfig);
 
-    // Test task
-    grunt.registerTask('test', ['eslint', 'browserify.core', 'browserify:test', 'mocha']);
+  // Custom Grunt tasks
+  grunt.registerTask('version', function() {
+    var pkg = grunt.config.get('pkg');
 
-    // Webserver tasks
-    grunt.registerTask('run:test', ['connect:test']);
-    grunt.registerTask('run:docs', ['connect:docs']);
+    // Verify version string in source code matches what's in package.json
+    var Raven = require('./src/raven');
+    if (Raven.prototype.VERSION !== pkg.version) {
+      return grunt.util.error(
+        'Mismatched version in src/raven.js: ' +
+          Raven.prototype.VERSION +
+          ' (should be ' +
+          pkg.version +
+          ')'
+      );
+    }
 
-    grunt.registerTask('publish', ['test', 'build.plugins-combined', 's3']);
-    grunt.registerTask('default', ['test']);
+    if (grunt.option('dev')) {
+      pkg.release = 'dev';
+    } else {
+      pkg.release = pkg.version;
+    }
+    grunt.config.set('pkg', pkg);
+  });
+
+  // Grunt contrib tasks
+  grunt.loadNpmTasks('grunt-contrib-uglify');
+  grunt.loadNpmTasks('grunt-contrib-clean');
+  grunt.loadNpmTasks('grunt-contrib-connect');
+  grunt.loadNpmTasks('grunt-contrib-copy');
+
+  // 3rd party Grunt tasks
+  grunt.loadNpmTasks('grunt-browserify');
+  grunt.loadNpmTasks('grunt-mocha');
+  grunt.loadNpmTasks('grunt-release');
+  grunt.loadNpmTasks('grunt-s3');
+  grunt.loadNpmTasks('grunt-gitinfo');
+  grunt.loadNpmTasks('grunt-sri');
+  grunt.loadNpmTasks('grunt-eslint');
+
+  // Build tasks
+  grunt.registerTask('_prep', ['clean', 'gitinfo', 'version']);
+  grunt.registerTask(
+    'browserify.core',
+    ['_prep', 'browserify:core'].concat(browserifyPluginTaskNames)
+  );
+  grunt.registerTask('browserify.plugins-combined', [
+    '_prep',
+    'browserify:plugins-combined'
+  ]);
+  grunt.registerTask('build.test', ['_prep', 'browserify:test']);
+  grunt.registerTask('build.core', ['browserify.core', 'uglify', 'sri:dist']);
+  grunt.registerTask('build.plugins-combined', [
+    'browserify.plugins-combined',
+    'uglify',
+    'sri:dist',
+    'sri:build'
+  ]);
+  grunt.registerTask('build', ['build.plugins-combined']);
+  grunt.registerTask('dist', ['build.core', 'copy:dist']);
+
+  // Test task
+  grunt.registerTask('test', ['eslint', 'browserify.core', 'browserify:test', 'mocha']);
+
+  // Webserver tasks
+  grunt.registerTask('run:test', ['connect:test']);
+  grunt.registerTask('run:docs', ['connect:docs']);
+
+  grunt.registerTask('publish', ['test', 'build.plugins-combined', 's3']);
+  grunt.registerTask('default', ['test']);
 };

--- a/package.json
+++ b/package.json
@@ -1,18 +1,25 @@
 {
   "name": "raven-js",
+  "description": "JavaScript client for Sentry",
+  "keywords": [
+    "debugging",
+    "errors",
+    "exceptions",
+    "logging",
+    "raven",
+    "sentry"
+  ],
   "version": "3.17.0",
+  "repository": "git://github.com/getsentry/raven-js.git",
   "license": "BSD-2-Clause",
   "homepage": "https://github.com/getsentry/raven-js",
+  "main": "src/singleton.js",
   "scripts": {
+    "precommit": "lint-staged",
     "pretest": "npm install",
     "test": "grunt test && npm run-script test-typescript",
     "test-typescript": "node_modules/typescript/bin/tsc --noEmit --noImplicitAny typescript/raven-tests.ts"
   },
-  "repository": {
-    "type": "git",
-    "url": "git://github.com/getsentry/raven-js.git"
-  },
-  "main": "src/singleton.js",
   "devDependencies": {
     "bluebird": "^3.4.1",
     "browserify-versionify": "^1.0.6",
@@ -35,22 +42,20 @@
     "grunt-release": "^0.13.0",
     "grunt-s3": "0.2.0-alpha.3",
     "grunt-sri": "mattrobenolt/grunt-sri#pretty",
+    "husky": "^0.14.3",
     "jquery": "^2.1.4",
+    "lint-staged": "^4.0.4",
     "lodash": "^3.10.1",
     "mocha": "2.5.3",
+    "prettier": "^1.6.1",
     "proxyquireify": "^3.0.2",
     "sinon": "1.7.3",
     "through2": "^2.0.0",
     "typescript": "^1.8.10",
     "whatwg-fetch": "^1.0.0"
   },
-  "keywords": [
-    "exceptions",
-    "debugging",
-    "logging",
-    "errors",
-    "sentry",
-    "raven"
-  ],
+  "lint-staged": {
+    "*.{js,json}": ["prettier --write --single-quote", "git add"]
+  },
   "typings": "typescript/raven.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "chai": "2.3.0",
     "derequire": "2.0.3",
     "es6-promise": "^4.0.5",
+    "eslint-config-prettier": "^2.3.0",
     "grunt": "^0.4.5",
     "grunt-browserify": "^4.0.1",
     "grunt-cli": "^0.1.13",
@@ -36,7 +37,7 @@
     "grunt-contrib-copy": "^0.8.2",
     "grunt-contrib-jshint": "^0.11.3",
     "grunt-contrib-uglify": "^0.11.0",
-    "grunt-eslint": "^17.3.1",
+    "grunt-eslint": "^20.0.0",
     "grunt-gitinfo": "^0.1.7",
     "grunt-mocha": "1.0.4",
     "grunt-release": "^0.13.0",
@@ -54,8 +55,16 @@
     "typescript": "^1.8.10",
     "whatwg-fetch": "^1.0.0"
   },
+  "prettier": {
+    "singleQuote": true,
+    "bracketSpacing": false,
+    "printWidth": 90
+  },
   "lint-staged": {
-    "*.{js,json}": ["prettier --write --single-quote", "git add"]
+    "*.js": [
+      "prettier --write",
+      "git add"
+    ]
   },
   "typings": "typescript/raven.d.ts"
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "homepage": "https://github.com/getsentry/raven-js",
   "main": "src/singleton.js",
   "scripts": {
+    "lint": "eslint .",
     "precommit": "lint-staged",
     "pretest": "npm install",
     "test": "grunt test && npm run-script test-typescript",

--- a/plugins/angular.js
+++ b/plugins/angular.js
@@ -11,60 +11,64 @@ var wrappedCallback = require('../src/utils').wrappedCallback;
 var angularPattern = /^\[((?:[$a-zA-Z0-9]+:)?(?:[$a-zA-Z0-9]+))\] (.*?)\n?(\S+)$/;
 var moduleName = 'ngRaven';
 
-
 function angularPlugin(Raven, angular) {
-    angular = angular || window.angular;
+  angular = angular || window.angular;
 
-    if (!angular) return;
+  if (!angular) return;
 
-    function RavenProvider() {
-        this.$get = ['$window', function($window) {
-            return Raven;
-        }];
-    }
+  function RavenProvider() {
+    this.$get = [
+      '$window',
+      function($window) {
+        return Raven;
+      }
+    ];
+  }
 
-    function ExceptionHandlerProvider($provide) {
-        $provide.decorator('$exceptionHandler',
-            ['Raven', '$delegate', exceptionHandler]);
-    }
+  function ExceptionHandlerProvider($provide) {
+    $provide.decorator('$exceptionHandler', ['Raven', '$delegate', exceptionHandler]);
+  }
 
-    function exceptionHandler(R, $delegate) {
-        return function (ex, cause) {
-            R.captureException(ex, {
-                extra: { cause: cause }
-            });
-            $delegate(ex, cause);
-        };
-    }
+  function exceptionHandler(R, $delegate) {
+    return function(ex, cause) {
+      R.captureException(ex, {
+        extra: {cause: cause}
+      });
+      $delegate(ex, cause);
+    };
+  }
 
-    angular.module(moduleName, [])
-        .provider('Raven',  RavenProvider)
-        .config(['$provide', ExceptionHandlerProvider]);
+  angular
+    .module(moduleName, [])
+    .provider('Raven', RavenProvider)
+    .config(['$provide', ExceptionHandlerProvider]);
 
-    Raven.setDataCallback(wrappedCallback(function(data) {
-        return angularPlugin._normalizeData(data);
-    }));
+  Raven.setDataCallback(
+    wrappedCallback(function(data) {
+      return angularPlugin._normalizeData(data);
+    })
+  );
 }
 
-angularPlugin._normalizeData = function (data) {
-    // We only care about mutating an exception
-    var exception = data.exception;
-    if (exception) {
-        exception = exception.values[0];
-        var matches = angularPattern.exec(exception.value);
+angularPlugin._normalizeData = function(data) {
+  // We only care about mutating an exception
+  var exception = data.exception;
+  if (exception) {
+    exception = exception.values[0];
+    var matches = angularPattern.exec(exception.value);
 
-        if (matches) {
-            // This type now becomes something like: $rootScope:inprog
-            exception.type = matches[1];
-            exception.value = matches[2];
+    if (matches) {
+      // This type now becomes something like: $rootScope:inprog
+      exception.type = matches[1];
+      exception.value = matches[2];
 
-            data.message = exception.type + ': ' + exception.value;
-            // auto set a new tag specifically for the angular error url
-            data.extra.angularDocs = matches[3].substr(0, 250);
-        }
+      data.message = exception.type + ': ' + exception.value;
+      // auto set a new tag specifically for the angular error url
+      data.extra.angularDocs = matches[3].substr(0, 250);
     }
+  }
 
-    return data;
+  return data;
 };
 
 angularPlugin.moduleName = moduleName;

--- a/plugins/console.js
+++ b/plugins/console.js
@@ -14,20 +14,20 @@
 var wrapConsoleMethod = require('../src/console').wrapMethod;
 
 function consolePlugin(Raven, console, pluginOptions) {
-    console = console || window.console || {};
-    pluginOptions = pluginOptions || {};
+  console = console || window.console || {};
+  pluginOptions = pluginOptions || {};
 
-    var logLevels = pluginOptions.levels || ['debug', 'info', 'warn', 'error'],
-        level = logLevels.pop();
+  var logLevels = pluginOptions.levels || ['debug', 'info', 'warn', 'error'],
+    level = logLevels.pop();
 
-    var callback = function (msg, data) {
-        Raven.captureMessage(msg, data);
-    };
+  var callback = function(msg, data) {
+    Raven.captureMessage(msg, data);
+  };
 
-    while(level) {
-        wrapConsoleMethod(console, level, callback);
-        level = logLevels.pop();
-    }
+  while (level) {
+    wrapConsoleMethod(console, level, callback);
+    level = logLevels.pop();
+  }
 }
 
 module.exports = consolePlugin;

--- a/plugins/ember.js
+++ b/plugins/ember.js
@@ -6,25 +6,27 @@
 'use strict';
 
 function emberPlugin(Raven, Ember) {
-    Ember = Ember || window.Ember;
+  Ember = Ember || window.Ember;
 
-    // quit if Ember isn't on the page
-    if (!Ember) return;
+  // quit if Ember isn't on the page
+  if (!Ember) return;
 
-    var _oldOnError = Ember.onerror;
-    Ember.onerror = function EmberOnError(error) {
-        Raven.captureException(error);
-        if (typeof _oldOnError === 'function') {
-            _oldOnError.call(this, error);
-        }
-    };
-    Ember.RSVP.on('error', function (reason) {
-        if (reason instanceof Error) {
-            Raven.captureException(reason, {extra: {context: 'Unhandled Promise error detected'}});
-        } else {
-            Raven.captureMessage('Unhandled Promise error detected', {extra: {reason: reason}});
-        }
-    });
+  var _oldOnError = Ember.onerror;
+  Ember.onerror = function EmberOnError(error) {
+    Raven.captureException(error);
+    if (typeof _oldOnError === 'function') {
+      _oldOnError.call(this, error);
+    }
+  };
+  Ember.RSVP.on('error', function(reason) {
+    if (reason instanceof Error) {
+      Raven.captureException(reason, {
+        extra: {context: 'Unhandled Promise error detected'}
+      });
+    } else {
+      Raven.captureMessage('Unhandled Promise error detected', {extra: {reason: reason}});
+    }
+  });
 }
 
 module.exports = emberPlugin;

--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -34,11 +34,9 @@ var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';
  */
 function normalizeUrl(url, pathStripRe) {
   if (url.indexOf('/') !== -1) {
-      return url
-          .replace(/^file\:\/\//, '')
-          .replace(pathStripRe, '');
+    return url.replace(/^file\:\/\//, '').replace(pathStripRe, '');
   } else {
-      return '/' + url;
+    return '/' + url;
   }
 }
 
@@ -47,92 +45,98 @@ function normalizeUrl(url, pathStripRe) {
  * use in a query string
  */
 function urlencode(obj) {
-    var pairs = [];
-    for (var key in obj) {
-        if ({}.hasOwnProperty.call(obj, key))
-            pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(obj[key]));
-    }
-    return pairs.join('&');
+  var pairs = [];
+  for (var key in obj) {
+    if ({}.hasOwnProperty.call(obj, key))
+      pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(obj[key]));
+  }
+  return pairs.join('&');
 }
 
 /**
  * Initializes React Native plugin
  */
 function reactNativePlugin(Raven, options) {
-    options = options || {};
+  options = options || {};
 
-    // react-native doesn't have a document, so can't use default Image
-    // transport - use XMLHttpRequest instead
-    Raven.setTransport(reactNativePlugin._transport);
+  // react-native doesn't have a document, so can't use default Image
+  // transport - use XMLHttpRequest instead
+  Raven.setTransport(reactNativePlugin._transport);
 
-    // Use data callback to strip device-specific paths from stack traces
-    Raven.setDataCallback(wrappedCallback(function(data) {
-        return reactNativePlugin._normalizeData(data, options.pathStrip);
-    }));
+  // Use data callback to strip device-specific paths from stack traces
+  Raven.setDataCallback(
+    wrappedCallback(function(data) {
+      return reactNativePlugin._normalizeData(data, options.pathStrip);
+    })
+  );
 
-    // Check for a previously persisted payload, and report it.
-    reactNativePlugin._restorePayload()
-        .then(function(payload) {
-            options.onInitialize && options.onInitialize(payload);
-            if (!payload) return;
-            Raven._sendProcessedPayload(payload, function(error) {
-                if (error) return; // Try again next launch.
-                reactNativePlugin._clearPayload();
-            });
-        })
-        ['catch'](function() {});
+  // Check for a previously persisted payload, and report it.
+  reactNativePlugin
+    ._restorePayload()
+    .then(function(payload) {
+      options.onInitialize && options.onInitialize(payload);
+      if (!payload) return;
+      Raven._sendProcessedPayload(payload, function(error) {
+        if (error) return; // Try again next launch.
+        reactNativePlugin._clearPayload();
+      });
+    })
+    ['catch'](function() {});
 
-    // Make sure that if multiple fatals occur, we only persist the first one.
-    //
-    // The first error is probably the most important/interesting error, and we
-    // want to crash ASAP, rather than potentially queueing up multiple errors.
-    var handlingFatal = false;
+  // Make sure that if multiple fatals occur, we only persist the first one.
+  //
+  // The first error is probably the most important/interesting error, and we
+  // want to crash ASAP, rather than potentially queueing up multiple errors.
+  var handlingFatal = false;
 
-    var defaultHandler = ErrorUtils.getGlobalHandler && ErrorUtils.getGlobalHandler() || ErrorUtils._globalHandler;
+  var defaultHandler =
+    (ErrorUtils.getGlobalHandler && ErrorUtils.getGlobalHandler()) ||
+    ErrorUtils._globalHandler;
 
-    Raven.setShouldSendCallback(function(data, originalCallback) {
-        if (!(FATAL_ERROR_KEY in data)) {
-            // not a fatal (will not crash runtime), continue as planned
-            return originalCallback ? originalCallback.call(this, data) : true;
-        }
+  Raven.setShouldSendCallback(function(data, originalCallback) {
+    if (!(FATAL_ERROR_KEY in data)) {
+      // not a fatal (will not crash runtime), continue as planned
+      return originalCallback ? originalCallback.call(this, data) : true;
+    }
 
-        var origError = data[FATAL_ERROR_KEY];
-        delete data[FATAL_ERROR_KEY];
+    var origError = data[FATAL_ERROR_KEY];
+    delete data[FATAL_ERROR_KEY];
 
-        reactNativePlugin._persistPayload(data)
-            .then(function() {
-                defaultHandler(origError, true);
-                handlingFatal = false; // In case it isn't configured to crash.
-                return null;
-            })
-            ['catch'](function() {});
+    reactNativePlugin
+      ._persistPayload(data)
+      .then(function() {
+        defaultHandler(origError, true);
+        handlingFatal = false; // In case it isn't configured to crash.
+        return null;
+      })
+      ['catch'](function() {});
 
-        return false; // Do not continue.
-    });
+    return false; // Do not continue.
+  });
 
-    ErrorUtils.setGlobalHandler(function(error, isFatal) {
-        var captureOptions = {
-            timestamp: new Date() / 1000
-        };
-        var error = arguments[0];
-        // We want to handle fatals, but only in production mode.
-        var shouldHandleFatal = isFatal && !global.__DEV__;
-        if (shouldHandleFatal) {
-            if (handlingFatal) {
-                console.log('Encountered multiple fatals in a row. The latest:', error);
-                return;
-            }
-            handlingFatal = true;
-            // We need to preserve the original error so that it can be rethrown
-            // after it is persisted (see our shouldSendCallback above).
-            captureOptions[FATAL_ERROR_KEY] = error;
-        }
-        Raven.captureException(error, captureOptions);
-        // Handle non-fatals regularly.
-        if (!shouldHandleFatal) {
-            defaultHandler(error);
-        }
-    });
+  ErrorUtils.setGlobalHandler(function(error, isFatal) {
+    var captureOptions = {
+      timestamp: new Date() / 1000
+    };
+    var error = arguments[0];
+    // We want to handle fatals, but only in production mode.
+    var shouldHandleFatal = isFatal && !global.__DEV__;
+    if (shouldHandleFatal) {
+      if (handlingFatal) {
+        console.log('Encountered multiple fatals in a row. The latest:', error);
+        return;
+      }
+      handlingFatal = true;
+      // We need to preserve the original error so that it can be rethrown
+      // after it is persisted (see our shouldSendCallback above).
+      captureOptions[FATAL_ERROR_KEY] = error;
+    }
+    Raven.captureException(error, captureOptions);
+    // Handle non-fatals regularly.
+    if (!shouldHandleFatal) {
+      defaultHandler(error);
+    }
+  });
 }
 
 /**
@@ -142,10 +146,11 @@ function reactNativePlugin(Raven, options) {
  * Returns a promise that guarantees never to reject.
  */
 reactNativePlugin._persistPayload = function(payload) {
-    var AsyncStorage = require('react-native').AsyncStorage;
-    return AsyncStorage.setItem(ASYNC_STORAGE_KEY, stringify(payload))
-        ['catch'](function() { return null; });
-}
+  var AsyncStorage = require('react-native').AsyncStorage;
+  return AsyncStorage.setItem(ASYNC_STORAGE_KEY, stringify(payload))['catch'](function() {
+    return null;
+  });
+};
 
 /**
  * Checks for any previously persisted errors (e.g. from last crash)
@@ -153,84 +158,90 @@ reactNativePlugin._persistPayload = function(payload) {
  * Returns a promise that guarantees never to reject.
  */
 reactNativePlugin._restorePayload = function() {
-    var AsyncStorage = require('react-native').AsyncStorage;
-    var promise = AsyncStorage.getItem(ASYNC_STORAGE_KEY)
-        .then(function(payload) { return JSON.parse(payload); })
-        ['catch'](function() { return null; });
-    // Make sure that we fetch ASAP.
-    AsyncStorage.flushGetRequests();
+  var AsyncStorage = require('react-native').AsyncStorage;
+  var promise = AsyncStorage.getItem(ASYNC_STORAGE_KEY)
+    .then(function(payload) {
+      return JSON.parse(payload);
+    })
+    ['catch'](function() {
+      return null;
+    });
+  // Make sure that we fetch ASAP.
+  AsyncStorage.flushGetRequests();
 
-    return promise;
+  return promise;
 };
 
 /**
  * Clears any persisted payloads.
  */
 reactNativePlugin._clearPayload = function() {
-    var AsyncStorage = require('react-native').AsyncStorage;
-    return AsyncStorage.removeItem(ASYNC_STORAGE_KEY)
-        ['catch'](function() { return null; });
-}
+  var AsyncStorage = require('react-native').AsyncStorage;
+  return AsyncStorage.removeItem(ASYNC_STORAGE_KEY)['catch'](function() {
+    return null;
+  });
+};
 
 /**
  * Custom HTTP transport for use with React Native applications.
  */
-reactNativePlugin._transport = function (options) {
-    var request = new XMLHttpRequest();
-    request.onreadystatechange = function (e) {
-        if (request.readyState !== 4) {
-            return;
-        }
+reactNativePlugin._transport = function(options) {
+  var request = new XMLHttpRequest();
+  request.onreadystatechange = function(e) {
+    if (request.readyState !== 4) {
+      return;
+    }
 
-        if (request.status === 200) {
-            if (options.onSuccess) {
-                options.onSuccess();
-            }
-        } else {
-            if (options.onError) {
-                var err = new Error('Sentry error code: ' + request.status);
-                err.request = request;
-                options.onError(err);
-            }
-        }
-    };
+    if (request.status === 200) {
+      if (options.onSuccess) {
+        options.onSuccess();
+      }
+    } else {
+      if (options.onError) {
+        var err = new Error('Sentry error code: ' + request.status);
+        err.request = request;
+        options.onError(err);
+      }
+    }
+  };
 
-    request.open('POST', options.url + '?' + urlencode(options.auth));
+  request.open('POST', options.url + '?' + urlencode(options.auth));
 
-    // NOTE: React Native ignores CORS and will NOT send a preflight
-    //       request for application/json.
-    // See: https://facebook.github.io/react-native/docs/network.html#xmlhttprequest
-    request.setRequestHeader('Content-type', 'application/json');
+  // NOTE: React Native ignores CORS and will NOT send a preflight
+  //       request for application/json.
+  // See: https://facebook.github.io/react-native/docs/network.html#xmlhttprequest
+  request.setRequestHeader('Content-type', 'application/json');
 
-    // Sentry expects an Origin header when using HTTP POST w/ public DSN.
-    // Just set a phony Origin value; only matters if Sentry Project is configured
-    // to whitelist specific origins.
-    request.setRequestHeader('Origin', 'react-native://');
-    request.send(stringify(options.data));
+  // Sentry expects an Origin header when using HTTP POST w/ public DSN.
+  // Just set a phony Origin value; only matters if Sentry Project is configured
+  // to whitelist specific origins.
+  request.setRequestHeader('Origin', 'react-native://');
+  request.send(stringify(options.data));
 };
 
 /**
  * Strip device-specific IDs found in culprit and frame filenames
  * when running React Native applications on a physical device.
  */
-reactNativePlugin._normalizeData = function (data, pathStripRe) {
-    if (!pathStripRe) {
-        pathStripRe = PATH_STRIP_RE;
-    }
+reactNativePlugin._normalizeData = function(data, pathStripRe) {
+  if (!pathStripRe) {
+    pathStripRe = PATH_STRIP_RE;
+  }
 
-    if (data.culprit) {
-        data.culprit = normalizeUrl(data.culprit, pathStripRe);
-    }
+  if (data.culprit) {
+    data.culprit = normalizeUrl(data.culprit, pathStripRe);
+  }
 
-    // NOTE: if data.exception exists, exception.values and exception.values[0] are
-    // guaranteed to exist
-    var stacktrace = data.stacktrace || data.exception && data.exception.values[0].stacktrace;
-    if (stacktrace) {
-        stacktrace.frames.forEach(function (frame) {
-            frame.filename = normalizeUrl(frame.filename, pathStripRe);
-        });
-    }
-    return data;
+  // NOTE: if data.exception exists, exception.values and exception.values[0] are
+  // guaranteed to exist
+  var stacktrace =
+    data.stacktrace || (data.exception && data.exception.values[0].stacktrace);
+  if (stacktrace) {
+    stacktrace.frames.forEach(function(frame) {
+      frame.filename = normalizeUrl(frame.filename, pathStripRe);
+    });
+  }
+  return data;
 };
 
 module.exports = reactNativePlugin;

--- a/plugins/require.js
+++ b/plugins/require.js
@@ -7,10 +7,10 @@
 'use strict';
 
 function requirePlugin(Raven) {
-    if (typeof define === 'function' && define.amd) {
-        window.define = Raven.wrap({deep: false}, define);
-        window.require = Raven.wrap({deep: false}, require);
-    }
+  if (typeof define === 'function' && define.amd) {
+    window.define = Raven.wrap({deep: false}, define);
+    window.require = Raven.wrap({deep: false}, require);
+  }
 }
 
 module.exports = requirePlugin;

--- a/plugins/vue.js
+++ b/plugins/vue.js
@@ -4,37 +4,36 @@
  */
 'use strict';
 
-function formatComponentName (vm) {
-    if (vm.$root === vm) {
-        return 'root instance'
-    }
-    var name = vm._isVue
-        ? vm.$options.name || vm.$options._componentTag
-        : vm.name
-    return (name ? 'component <' + name + '>' : 'anonymous component') +
-        (vm._isVue && vm.$options.__file ? ' at ' + vm.$options.__file  : '')
+function formatComponentName(vm) {
+  if (vm.$root === vm) {
+    return 'root instance';
+  }
+  var name = vm._isVue ? vm.$options.name || vm.$options._componentTag : vm.name;
+  return (
+    (name ? 'component <' + name + '>' : 'anonymous component') +
+    (vm._isVue && vm.$options.__file ? ' at ' + vm.$options.__file : '')
+  );
 }
 
 function vuePlugin(Raven, Vue) {
-    Vue = Vue || window.Vue;
+  Vue = Vue || window.Vue;
 
-    // quit if Vue isn't on the page
-    if (!Vue || !Vue.config) return;
+  // quit if Vue isn't on the page
+  if (!Vue || !Vue.config) return;
 
-    var _oldOnError = Vue.config.errorHandler;
-    Vue.config.errorHandler = function VueErrorHandler(error, vm) {
-        Raven.captureException(error, {
-          extra: {
-            componentName: formatComponentName(vm),
-            propsData: vm.$options.propsData
-          }
-        });
+  var _oldOnError = Vue.config.errorHandler;
+  Vue.config.errorHandler = function VueErrorHandler(error, vm) {
+    Raven.captureException(error, {
+      extra: {
+        componentName: formatComponentName(vm),
+        propsData: vm.$options.propsData
+      }
+    });
 
-        if (typeof _oldOnError === 'function') {
-            _oldOnError.call(this, error, vm);
-        }
-    };
+    if (typeof _oldOnError === 'function') {
+      _oldOnError.call(this, error, vm);
+    }
+  };
 }
 
 module.exports = vuePlugin;
-

--- a/src/configError.js
+++ b/src/configError.js
@@ -1,8 +1,8 @@
 'use strict';
 
 function RavenConfigError(message) {
-    this.name = 'RavenConfigError';
-    this.message = message;
+  this.name = 'RavenConfigError';
+  this.message = message;
 }
 RavenConfigError.prototype = new Error();
 RavenConfigError.prototype.constructor = RavenConfigError;

--- a/src/console.js
+++ b/src/console.js
@@ -1,37 +1,31 @@
 'use strict';
 
 var wrapMethod = function(console, level, callback) {
-    var originalConsoleLevel = console[level];
-    var originalConsole = console;
+  var originalConsoleLevel = console[level];
+  var originalConsole = console;
 
-    if (!(level in console)) {
-        return;
+  if (!(level in console)) {
+    return;
+  }
+
+  var sentryLevel = level === 'warn' ? 'warning' : level;
+
+  console[level] = function() {
+    var args = [].slice.call(arguments);
+
+    var msg = '' + args.join(' ');
+    var data = {level: sentryLevel, logger: 'console', extra: {arguments: args}};
+    callback && callback(msg, data);
+
+    // this fails for some browsers. :(
+    if (originalConsoleLevel) {
+      // IE9 doesn't allow calling apply on console functions directly
+      // See: https://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function#answer-5473193
+      Function.prototype.apply.call(originalConsoleLevel, originalConsole, args);
     }
-
-    var sentryLevel = level === 'warn'
-        ? 'warning'
-        : level;
-
-    console[level] = function () {
-        var args = [].slice.call(arguments);
-
-        var msg = '' + args.join(' ');
-        var data = {level: sentryLevel, logger: 'console', extra: {'arguments': args}};
-        callback && callback(msg, data);
-
-        // this fails for some browsers. :(
-        if (originalConsoleLevel) {
-            // IE9 doesn't allow calling apply on console functions directly
-            // See: https://stackoverflow.com/questions/5472938/does-ie9-support-console-log-and-is-it-a-real-function#answer-5473193
-            Function.prototype.apply.call(
-                originalConsoleLevel,
-                originalConsole,
-                args
-            );
-        }
-    };
+  };
 };
 
 module.exports = {
-    wrapMethod: wrapMethod
+  wrapMethod: wrapMethod
 };

--- a/src/raven.js
+++ b/src/raven.js
@@ -108,7 +108,7 @@ Raven.prototype = {
      * Configure Raven with a DSN and extra options
      *
      * @param {string} dsn The public Sentry DSN
-     * @param {object} options Optional set of of global options [optional]
+     * @param {object} options Set of global options [optional]
      * @return {Raven}
      */
     config: function(dsn, options) {

--- a/src/raven.js
+++ b/src/raven.js
@@ -82,7 +82,8 @@ function Raven() {
     this._lastHref = this._location && this._location.href;
     this._resetBackoff();
 
-    for (var method in this._originalConsole) {  // eslint-disable-line guard-for-in
+    // eslint-disable-next-line guard-for-in
+    for (var method in this._originalConsole) {
       this._originalConsoleMethods[method] = this._originalConsole[method];
     }
 }
@@ -1862,6 +1863,7 @@ function uuid4() {
 
     if (!isUndefined(crypto) && crypto.getRandomValues) {
         // Use window.crypto API if available
+        // eslint-disable-next-line no-undef
         var arr = new Uint16Array(8);
         crypto.getRandomValues(arr);
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -7,85 +7,86 @@ var RavenConfigError = require('./configError');
 var utils = require('./utils');
 
 var isError = utils.isError,
-    isObject = utils.isObject;
+  isObject = utils.isObject;
 
 var wrapConsoleMethod = require('./console').wrapMethod;
 
 var dsnKeys = 'source protocol user pass host port path'.split(' '),
-    dsnPattern = /^(?:(\w+):)?\/\/(?:(\w+)(:\w+)?@)?([\w\.-]+)(?::(\d+))?(\/.*)/;
+  dsnPattern = /^(?:(\w+):)?\/\/(?:(\w+)(:\w+)?@)?([\w\.-]+)(?::(\d+))?(\/.*)/;
 
 function now() {
-    return +new Date();
+  return +new Date();
 }
 
 // This is to be defensive in environments where window does not exist (see https://github.com/getsentry/raven-js/pull/785)
-var _window = typeof window !== 'undefined' ? window
-            : typeof global !== 'undefined' ? global
-            : typeof self !== 'undefined' ? self
-            : {};
+var _window =
+  typeof window !== 'undefined'
+    ? window
+    : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 var _document = _window.document;
 var _navigator = _window.navigator;
 
-
 function keepOriginalCallback(original, callback) {
-    return isFunction(callback) ?
-    function (data) { return callback(data, original) } :
-    callback;
+  return isFunction(callback)
+    ? function(data) {
+        return callback(data, original);
+      }
+    : callback;
 }
 
 // First, check for JSON support
 // If there is no JSON, we no-op the core features of Raven
 // since JSON is required to encode the payload
 function Raven() {
-    this._hasJSON = !!(typeof JSON === 'object' && JSON.stringify);
-    // Raven can run in contexts where there's no document (react-native)
-    this._hasDocument = !isUndefined(_document);
-    this._hasNavigator = !isUndefined(_navigator);
-    this._lastCapturedException = null;
-    this._lastData = null;
-    this._lastEventId = null;
-    this._globalServer = null;
-    this._globalKey = null;
-    this._globalProject = null;
-    this._globalContext = {};
-    this._globalOptions = {
-        logger: 'javascript',
-        ignoreErrors: [],
-        ignoreUrls: [],
-        whitelistUrls: [],
-        includePaths: [],
-        crossOrigin: 'anonymous',
-        collectWindowErrors: true,
-        maxMessageLength: 0,
+  this._hasJSON = !!(typeof JSON === 'object' && JSON.stringify);
+  // Raven can run in contexts where there's no document (react-native)
+  this._hasDocument = !isUndefined(_document);
+  this._hasNavigator = !isUndefined(_navigator);
+  this._lastCapturedException = null;
+  this._lastData = null;
+  this._lastEventId = null;
+  this._globalServer = null;
+  this._globalKey = null;
+  this._globalProject = null;
+  this._globalContext = {};
+  this._globalOptions = {
+    logger: 'javascript',
+    ignoreErrors: [],
+    ignoreUrls: [],
+    whitelistUrls: [],
+    includePaths: [],
+    crossOrigin: 'anonymous',
+    collectWindowErrors: true,
+    maxMessageLength: 0,
 
-        // By default, truncates URL values to 250 chars
-        maxUrlLength: 250,
-        stackTraceLimit: 50,
-        autoBreadcrumbs: true,
-        instrument: true,
-        sampleRate: 1
-    };
-    this._ignoreOnError = 0;
-    this._isRavenInstalled = false;
-    this._originalErrorStackTraceLimit = Error.stackTraceLimit;
-    // capture references to window.console *and* all its methods first
-    // before the console plugin has a chance to monkey patch
-    this._originalConsole = _window.console || {};
-    this._originalConsoleMethods = {};
-    this._plugins = [];
-    this._startTime = now();
-    this._wrappedBuiltIns = [];
-    this._breadcrumbs = [];
-    this._lastCapturedEvent = null;
-    this._keypressTimeout;
-    this._location = _window.location;
-    this._lastHref = this._location && this._location.href;
-    this._resetBackoff();
+    // By default, truncates URL values to 250 chars
+    maxUrlLength: 250,
+    stackTraceLimit: 50,
+    autoBreadcrumbs: true,
+    instrument: true,
+    sampleRate: 1
+  };
+  this._ignoreOnError = 0;
+  this._isRavenInstalled = false;
+  this._originalErrorStackTraceLimit = Error.stackTraceLimit;
+  // capture references to window.console *and* all its methods first
+  // before the console plugin has a chance to monkey patch
+  this._originalConsole = _window.console || {};
+  this._originalConsoleMethods = {};
+  this._plugins = [];
+  this._startTime = now();
+  this._wrappedBuiltIns = [];
+  this._breadcrumbs = [];
+  this._lastCapturedEvent = null;
+  this._keypressTimeout;
+  this._location = _window.location;
+  this._lastHref = this._location && this._location.href;
+  this._resetBackoff();
 
-    // eslint-disable-next-line guard-for-in
-    for (var method in this._originalConsole) {
-      this._originalConsoleMethods[method] = this._originalConsole[method];
-    }
+  // eslint-disable-next-line guard-for-in
+  for (var method in this._originalConsole) {
+    this._originalConsoleMethods[method] = this._originalConsole[method];
+  }
 }
 
 /*
@@ -95,94 +96,101 @@ function Raven() {
  */
 
 Raven.prototype = {
-    // Hardcode version string so that raven source can be loaded directly via
-    // webpack (using a build step causes webpack #1617). Grunt verifies that
-    // this value matches package.json during build.
-    //   See: https://github.com/getsentry/raven-js/issues/465
-    VERSION: '3.17.0',
+  // Hardcode version string so that raven source can be loaded directly via
+  // webpack (using a build step causes webpack #1617). Grunt verifies that
+  // this value matches package.json during build.
+  //   See: https://github.com/getsentry/raven-js/issues/465
+  VERSION: '3.17.0',
 
-    debug: false,
+  debug: false,
 
-    TraceKit: TraceKit, // alias to TraceKit
+  TraceKit: TraceKit, // alias to TraceKit
 
-    /*
+  /*
      * Configure Raven with a DSN and extra options
      *
      * @param {string} dsn The public Sentry DSN
      * @param {object} options Set of global options [optional]
      * @return {Raven}
      */
-    config: function(dsn, options) {
-        var self = this;
+  config: function(dsn, options) {
+    var self = this;
 
-        if (self._globalServer) {
-                this._logDebug('error', 'Error: Raven has already been configured');
-            return self;
+    if (self._globalServer) {
+      this._logDebug('error', 'Error: Raven has already been configured');
+      return self;
+    }
+    if (!dsn) return self;
+
+    var globalOptions = self._globalOptions;
+
+    // merge in options
+    if (options) {
+      each(options, function(key, value) {
+        // tags and extra are special and need to be put into context
+        if (key === 'tags' || key === 'extra' || key === 'user') {
+          self._globalContext[key] = value;
+        } else {
+          globalOptions[key] = value;
         }
-        if (!dsn) return self;
+      });
+    }
 
-        var globalOptions = self._globalOptions;
+    self.setDSN(dsn);
 
-        // merge in options
-        if (options) {
-            each(options, function(key, value){
-                // tags and extra are special and need to be put into context
-                if (key === 'tags' || key === 'extra' || key === 'user') {
-                    self._globalContext[key] = value;
-                } else {
-                    globalOptions[key] = value;
-                }
-            });
-        }
+    // "Script error." is hard coded into browsers for errors that it can't read.
+    // this is the result of a script being pulled in from an external domain and CORS.
+    globalOptions.ignoreErrors.push(/^Script error\.?$/);
+    globalOptions.ignoreErrors.push(/^Javascript error: Script error\.? on line 0$/);
 
-        self.setDSN(dsn);
+    // join regexp rules into one big rule
+    globalOptions.ignoreErrors = joinRegExp(globalOptions.ignoreErrors);
+    globalOptions.ignoreUrls = globalOptions.ignoreUrls.length
+      ? joinRegExp(globalOptions.ignoreUrls)
+      : false;
+    globalOptions.whitelistUrls = globalOptions.whitelistUrls.length
+      ? joinRegExp(globalOptions.whitelistUrls)
+      : false;
+    globalOptions.includePaths = joinRegExp(globalOptions.includePaths);
+    globalOptions.maxBreadcrumbs = Math.max(
+      0,
+      Math.min(globalOptions.maxBreadcrumbs || 100, 100)
+    ); // default and hard limit is 100
 
-        // "Script error." is hard coded into browsers for errors that it can't read.
-        // this is the result of a script being pulled in from an external domain and CORS.
-        globalOptions.ignoreErrors.push(/^Script error\.?$/);
-        globalOptions.ignoreErrors.push(/^Javascript error: Script error\.? on line 0$/);
+    var autoBreadcrumbDefaults = {
+      xhr: true,
+      console: true,
+      dom: true,
+      location: true
+    };
 
-        // join regexp rules into one big rule
-        globalOptions.ignoreErrors = joinRegExp(globalOptions.ignoreErrors);
-        globalOptions.ignoreUrls = globalOptions.ignoreUrls.length ? joinRegExp(globalOptions.ignoreUrls) : false;
-        globalOptions.whitelistUrls = globalOptions.whitelistUrls.length ? joinRegExp(globalOptions.whitelistUrls) : false;
-        globalOptions.includePaths = joinRegExp(globalOptions.includePaths);
-        globalOptions.maxBreadcrumbs = Math.max(0, Math.min(globalOptions.maxBreadcrumbs || 100, 100)); // default and hard limit is 100
+    var autoBreadcrumbs = globalOptions.autoBreadcrumbs;
+    if ({}.toString.call(autoBreadcrumbs) === '[object Object]') {
+      autoBreadcrumbs = objectMerge(autoBreadcrumbDefaults, autoBreadcrumbs);
+    } else if (autoBreadcrumbs !== false) {
+      autoBreadcrumbs = autoBreadcrumbDefaults;
+    }
+    globalOptions.autoBreadcrumbs = autoBreadcrumbs;
 
-        var autoBreadcrumbDefaults = {
-            xhr: true,
-            console: true,
-            dom: true,
-            location: true
-        };
+    var instrumentDefaults = {
+      tryCatch: true
+    };
 
-        var autoBreadcrumbs = globalOptions.autoBreadcrumbs;
-        if ({}.toString.call(autoBreadcrumbs) === '[object Object]') {
-            autoBreadcrumbs = objectMerge(autoBreadcrumbDefaults, autoBreadcrumbs);
-        } else if (autoBreadcrumbs !== false) {
-            autoBreadcrumbs = autoBreadcrumbDefaults;
-        }
-        globalOptions.autoBreadcrumbs = autoBreadcrumbs;
+    var instrument = globalOptions.instrument;
+    if ({}.toString.call(instrument) === '[object Object]') {
+      instrument = objectMerge(instrumentDefaults, instrument);
+    } else if (instrument !== false) {
+      instrument = instrumentDefaults;
+    }
+    globalOptions.instrument = instrument;
 
-        var instrumentDefaults = {
-            tryCatch: true
-        };
+    TraceKit.collectWindowErrors = !!globalOptions.collectWindowErrors;
 
-        var instrument = globalOptions.instrument;
-        if ({}.toString.call(instrument) === '[object Object]') {
-            instrument = objectMerge(instrumentDefaults, instrument);
-        } else if (instrument !== false) {
-            instrument = instrumentDefaults;
-        }
-        globalOptions.instrument = instrument;
+    // return for chaining
+    return self;
+  },
 
-        TraceKit.collectWindowErrors = !!globalOptions.collectWindowErrors;
-
-        // return for chaining
-        return self;
-    },
-
-    /*
+  /*
      * Installs a global window.onerror error handler
      * to capture and report uncaught exceptions.
      * At this point, install() is required to be called due
@@ -190,56 +198,55 @@ Raven.prototype = {
      *
      * @return {Raven}
      */
-    install: function() {
-        var self = this;
-        if (self.isSetup() && !self._isRavenInstalled) {
-            TraceKit.report.subscribe(function () {
-                self._handleOnErrorStackInfo.apply(self, arguments);
-            });
-            if (self._globalOptions.instrument && self._globalOptions.instrument.tryCatch) {
-              self._instrumentTryCatch();
-            }
+  install: function() {
+    var self = this;
+    if (self.isSetup() && !self._isRavenInstalled) {
+      TraceKit.report.subscribe(function() {
+        self._handleOnErrorStackInfo.apply(self, arguments);
+      });
+      if (self._globalOptions.instrument && self._globalOptions.instrument.tryCatch) {
+        self._instrumentTryCatch();
+      }
 
-            if (self._globalOptions.autoBreadcrumbs)
-                self._instrumentBreadcrumbs();
+      if (self._globalOptions.autoBreadcrumbs) self._instrumentBreadcrumbs();
 
-            // Install all of the plugins
-            self._drainPlugins();
+      // Install all of the plugins
+      self._drainPlugins();
 
-            self._isRavenInstalled = true;
-        }
+      self._isRavenInstalled = true;
+    }
 
-        Error.stackTraceLimit = self._globalOptions.stackTraceLimit;
-        return this;
-    },
+    Error.stackTraceLimit = self._globalOptions.stackTraceLimit;
+    return this;
+  },
 
-    /*
+  /*
      * Set the DSN (can be called multiple time unlike config)
      *
      * @param {string} dsn The public Sentry DSN
      */
-    setDSN: function(dsn) {
-        var self = this,
-            uri = self._parseDSN(dsn),
-          lastSlash = uri.path.lastIndexOf('/'),
-          path = uri.path.substr(1, lastSlash);
+  setDSN: function(dsn) {
+    var self = this,
+      uri = self._parseDSN(dsn),
+      lastSlash = uri.path.lastIndexOf('/'),
+      path = uri.path.substr(1, lastSlash);
 
-        self._dsn = dsn;
-        self._globalKey = uri.user;
-        self._globalSecret = uri.pass && uri.pass.substr(1);
-        self._globalProject = uri.path.substr(lastSlash + 1);
+    self._dsn = dsn;
+    self._globalKey = uri.user;
+    self._globalSecret = uri.pass && uri.pass.substr(1);
+    self._globalProject = uri.path.substr(lastSlash + 1);
 
-        self._globalServer = self._getGlobalServer(uri);
+    self._globalServer = self._getGlobalServer(uri);
 
-        self._globalEndpoint = self._globalServer +
-            '/' + path + 'api/' + self._globalProject + '/store/';
+    self._globalEndpoint =
+      self._globalServer + '/' + path + 'api/' + self._globalProject + '/store/';
 
-        // Reset backoff state since we may be pointing at a
-        // new project/server
-        this._resetBackoff();
-    },
+    // Reset backoff state since we may be pointing at a
+    // new project/server
+    this._resetBackoff();
+  },
 
-    /*
+  /*
      * Wrap code within a context so Raven can capture errors
      * reliably across domains that is executed immediately.
      *
@@ -247,17 +254,17 @@ Raven.prototype = {
      * @param {function} func The callback to be immediately executed within the context
      * @param {array} args An array of arguments to be called with the callback [optional]
      */
-    context: function(options, func, args) {
-        if (isFunction(options)) {
-            args = func || [];
-            func = options;
-            options = undefined;
-        }
+  context: function(options, func, args) {
+    if (isFunction(options)) {
+      args = func || [];
+      func = options;
+      options = undefined;
+    }
 
-        return this.wrap(options, func).apply(this, args);
-    },
+    return this.wrap(options, func).apply(this, args);
+  },
 
-    /*
+  /*
      * Wrap code within a context and returns back a new function to be executed
      *
      * @param {object} options A specific set of options for this context [optional]
@@ -265,356 +272,371 @@ Raven.prototype = {
      * @param {function} func A function to call before the try/catch wrapper [optional, private]
      * @return {function} The newly wrapped functions with a context
      */
-    wrap: function(options, func, _before) {
-        var self = this;
-        // 1 argument has been passed, and it's not a function
-        // so just return it
-        if (isUndefined(func) && !isFunction(options)) {
-            return options;
-        }
+  wrap: function(options, func, _before) {
+    var self = this;
+    // 1 argument has been passed, and it's not a function
+    // so just return it
+    if (isUndefined(func) && !isFunction(options)) {
+      return options;
+    }
 
-        // options is optional
-        if (isFunction(options)) {
-            func = options;
-            options = undefined;
-        }
+    // options is optional
+    if (isFunction(options)) {
+      func = options;
+      options = undefined;
+    }
 
-        // At this point, we've passed along 2 arguments, and the second one
-        // is not a function either, so we'll just return the second argument.
-        if (!isFunction(func)) {
-            return func;
-        }
+    // At this point, we've passed along 2 arguments, and the second one
+    // is not a function either, so we'll just return the second argument.
+    if (!isFunction(func)) {
+      return func;
+    }
 
-        // We don't wanna wrap it twice!
-        try {
-            if (func.__raven__) {
-                return func;
-            }
+    // We don't wanna wrap it twice!
+    try {
+      if (func.__raven__) {
+        return func;
+      }
 
-            // If this has already been wrapped in the past, return that
-            if (func.__raven_wrapper__ ){
-                return func.__raven_wrapper__ ;
-            }
-        } catch (e) {
-            // Just accessing custom props in some Selenium environments
-            // can cause a "Permission denied" exception (see raven-js#495).
-            // Bail on wrapping and return the function as-is (defers to window.onerror).
-            return func;
-        }
+      // If this has already been wrapped in the past, return that
+      if (func.__raven_wrapper__) {
+        return func.__raven_wrapper__;
+      }
+    } catch (e) {
+      // Just accessing custom props in some Selenium environments
+      // can cause a "Permission denied" exception (see raven-js#495).
+      // Bail on wrapping and return the function as-is (defers to window.onerror).
+      return func;
+    }
 
-        function wrapped() {
-            var args = [], i = arguments.length,
-                deep = !options || options && options.deep !== false;
+    function wrapped() {
+      var args = [],
+        i = arguments.length,
+        deep = !options || (options && options.deep !== false);
 
-            if (_before && isFunction(_before)) {
-                _before.apply(this, arguments);
-            }
+      if (_before && isFunction(_before)) {
+        _before.apply(this, arguments);
+      }
 
-            // Recursively wrap all of a function's arguments that are
-            // functions themselves.
-            while(i--) args[i] = deep ? self.wrap(options, arguments[i]) : arguments[i];
+      // Recursively wrap all of a function's arguments that are
+      // functions themselves.
+      while (i--) args[i] = deep ? self.wrap(options, arguments[i]) : arguments[i];
 
-            try {
-                // Attempt to invoke user-land function
-                // NOTE: If you are a Sentry user, and you are seeing this stack frame, it
-                //       means Raven caught an error invoking your application code. This is
-                //       expected behavior and NOT indicative of a bug with Raven.js.
-                return func.apply(this, args);
-            } catch(e) {
-                self._ignoreNextOnError();
-                self.captureException(e, options);
-                throw e;
-            }
-        }
+      try {
+        // Attempt to invoke user-land function
+        // NOTE: If you are a Sentry user, and you are seeing this stack frame, it
+        //       means Raven caught an error invoking your application code. This is
+        //       expected behavior and NOT indicative of a bug with Raven.js.
+        return func.apply(this, args);
+      } catch (e) {
+        self._ignoreNextOnError();
+        self.captureException(e, options);
+        throw e;
+      }
+    }
 
-        // copy over properties of the old function
-        for (var property in func) {
-            if (hasKey(func, property)) {
-                wrapped[property] = func[property];
-            }
-        }
-        wrapped.prototype = func.prototype;
+    // copy over properties of the old function
+    for (var property in func) {
+      if (hasKey(func, property)) {
+        wrapped[property] = func[property];
+      }
+    }
+    wrapped.prototype = func.prototype;
 
-        func.__raven_wrapper__ = wrapped;
-        // Signal that this function has been wrapped already
-        // for both debugging and to prevent it to being wrapped twice
-        wrapped.__raven__ = true;
-        wrapped.__inner__ = func;
+    func.__raven_wrapper__ = wrapped;
+    // Signal that this function has been wrapped already
+    // for both debugging and to prevent it to being wrapped twice
+    wrapped.__raven__ = true;
+    wrapped.__inner__ = func;
 
-        return wrapped;
-    },
+    return wrapped;
+  },
 
-    /*
+  /*
      * Uninstalls the global error handler.
      *
      * @return {Raven}
      */
-    uninstall: function() {
-        TraceKit.report.uninstall();
+  uninstall: function() {
+    TraceKit.report.uninstall();
 
-        this._restoreBuiltIns();
+    this._restoreBuiltIns();
 
-        Error.stackTraceLimit = this._originalErrorStackTraceLimit;
-        this._isRavenInstalled = false;
+    Error.stackTraceLimit = this._originalErrorStackTraceLimit;
+    this._isRavenInstalled = false;
 
-        return this;
-    },
+    return this;
+  },
 
-    /*
+  /*
      * Manually capture an exception and send it over to Sentry
      *
      * @param {error} ex An exception to be logged
      * @param {object} options A specific set of options for this error [optional]
      * @return {Raven}
      */
-    captureException: function(ex, options) {
-        // If not an Error is passed through, recall as a message instead
-        if (!isError(ex)) {
-            return this.captureMessage(ex, objectMerge({
-                trimHeadFrames: 1,
-                stacktrace: true // if we fall back to captureMessage, default to attempting a new trace
-            }, options));
-        }
+  captureException: function(ex, options) {
+    // If not an Error is passed through, recall as a message instead
+    if (!isError(ex)) {
+      return this.captureMessage(
+        ex,
+        objectMerge(
+          {
+            trimHeadFrames: 1,
+            stacktrace: true // if we fall back to captureMessage, default to attempting a new trace
+          },
+          options
+        )
+      );
+    }
 
-        // Store the raw exception object for potential debugging and introspection
-        this._lastCapturedException = ex;
+    // Store the raw exception object for potential debugging and introspection
+    this._lastCapturedException = ex;
 
-        // TraceKit.report will re-raise any exception passed to it,
-        // which means you have to wrap it in try/catch. Instead, we
-        // can wrap it here and only re-raise if TraceKit.report
-        // raises an exception different from the one we asked to
-        // report on.
-        try {
-            var stack = TraceKit.computeStackTrace(ex);
-            this._handleStackInfo(stack, options);
-        } catch(ex1) {
-            if(ex !== ex1) {
-                throw ex1;
-            }
-        }
+    // TraceKit.report will re-raise any exception passed to it,
+    // which means you have to wrap it in try/catch. Instead, we
+    // can wrap it here and only re-raise if TraceKit.report
+    // raises an exception different from the one we asked to
+    // report on.
+    try {
+      var stack = TraceKit.computeStackTrace(ex);
+      this._handleStackInfo(stack, options);
+    } catch (ex1) {
+      if (ex !== ex1) {
+        throw ex1;
+      }
+    }
 
-        return this;
-    },
+    return this;
+  },
 
-    /*
+  /*
      * Manually send a message to Sentry
      *
      * @param {string} msg A plain message to be captured in Sentry
      * @param {object} options A specific set of options for this message [optional]
      * @return {Raven}
      */
-    captureMessage: function(msg, options) {
-        // config() automagically converts ignoreErrors from a list to a RegExp so we need to test for an
-        // early call; we'll error on the side of logging anything called before configuration since it's
-        // probably something you should see:
-        if (!!this._globalOptions.ignoreErrors.test && this._globalOptions.ignoreErrors.test(msg)) {
-            return;
-        }
+  captureMessage: function(msg, options) {
+    // config() automagically converts ignoreErrors from a list to a RegExp so we need to test for an
+    // early call; we'll error on the side of logging anything called before configuration since it's
+    // probably something you should see:
+    if (
+      !!this._globalOptions.ignoreErrors.test &&
+      this._globalOptions.ignoreErrors.test(msg)
+    ) {
+      return;
+    }
 
-        options = options || {};
+    options = options || {};
 
-        var data = objectMerge({
-            message: msg + ''  // Make sure it's actually a string
-        }, options);
+    var data = objectMerge(
+      {
+        message: msg + '' // Make sure it's actually a string
+      },
+      options
+    );
 
-        if (this._globalOptions.stacktrace || (options && options.stacktrace)) {
-            var ex;
-            // Generate a "synthetic" stack trace from this point.
-            // NOTE: If you are a Sentry user, and you are seeing this stack frame, it is NOT indicative
-            //       of a bug with Raven.js. Sentry generates synthetic traces either by configuration,
-            //       or if it catches a thrown object without a "stack" property.
-            try {
-                throw new Error(msg);
-            } catch (ex1) {
-                ex = ex1;
-            }
+    if (this._globalOptions.stacktrace || (options && options.stacktrace)) {
+      var ex;
+      // Generate a "synthetic" stack trace from this point.
+      // NOTE: If you are a Sentry user, and you are seeing this stack frame, it is NOT indicative
+      //       of a bug with Raven.js. Sentry generates synthetic traces either by configuration,
+      //       or if it catches a thrown object without a "stack" property.
+      try {
+        throw new Error(msg);
+      } catch (ex1) {
+        ex = ex1;
+      }
 
-            // null exception name so `Error` isn't prefixed to msg
-            ex.name = null;
+      // null exception name so `Error` isn't prefixed to msg
+      ex.name = null;
 
-            options = objectMerge({
-                // fingerprint on msg, not stack trace (legacy behavior, could be
-                // revisited)
-                fingerprint: msg,
-                // since we know this is a synthetic trace, the top N-most frames
-                // MUST be from Raven.js, so mark them as in_app later by setting
-                // trimHeadFrames
-                trimHeadFrames: (options.trimHeadFrames || 0) + 1
-            }, options);
+      options = objectMerge(
+        {
+          // fingerprint on msg, not stack trace (legacy behavior, could be
+          // revisited)
+          fingerprint: msg,
+          // since we know this is a synthetic trace, the top N-most frames
+          // MUST be from Raven.js, so mark them as in_app later by setting
+          // trimHeadFrames
+          trimHeadFrames: (options.trimHeadFrames || 0) + 1
+        },
+        options
+      );
 
-            var stack = TraceKit.computeStackTrace(ex);
-            var frames = this._prepareFrames(stack, options);
-            data.stacktrace = {
-                // Sentry expects frames oldest to newest
-                frames: frames.reverse()
-            }
-        }
+      var stack = TraceKit.computeStackTrace(ex);
+      var frames = this._prepareFrames(stack, options);
+      data.stacktrace = {
+        // Sentry expects frames oldest to newest
+        frames: frames.reverse()
+      };
+    }
 
-        // Fire away!
-        this._send(data);
+    // Fire away!
+    this._send(data);
 
+    return this;
+  },
+
+  captureBreadcrumb: function(obj) {
+    var crumb = objectMerge(
+      {
+        timestamp: now() / 1000
+      },
+      obj
+    );
+
+    if (isFunction(this._globalOptions.breadcrumbCallback)) {
+      var result = this._globalOptions.breadcrumbCallback(crumb);
+
+      if (isObject(result) && !isEmptyObject(result)) {
+        crumb = result;
+      } else if (result === false) {
         return this;
-    },
+      }
+    }
 
-    captureBreadcrumb: function (obj) {
-        var crumb = objectMerge({
-            timestamp: now() / 1000
-        }, obj);
+    this._breadcrumbs.push(crumb);
+    if (this._breadcrumbs.length > this._globalOptions.maxBreadcrumbs) {
+      this._breadcrumbs.shift();
+    }
+    return this;
+  },
 
-        if (isFunction(this._globalOptions.breadcrumbCallback)) {
-            var result = this._globalOptions.breadcrumbCallback(crumb);
+  addPlugin: function(plugin /*arg1, arg2, ... argN*/) {
+    var pluginArgs = [].slice.call(arguments, 1);
 
-            if (isObject(result) && !isEmptyObject(result)) {
-                crumb = result;
-            } else if (result === false) {
-                return this;
-            }
-        }
+    this._plugins.push([plugin, pluginArgs]);
+    if (this._isRavenInstalled) {
+      this._drainPlugins();
+    }
 
-        this._breadcrumbs.push(crumb);
-        if (this._breadcrumbs.length > this._globalOptions.maxBreadcrumbs) {
-            this._breadcrumbs.shift();
-        }
-        return this;
-    },
+    return this;
+  },
 
-    addPlugin: function(plugin /*arg1, arg2, ... argN*/) {
-        var pluginArgs = [].slice.call(arguments, 1);
-
-        this._plugins.push([plugin, pluginArgs]);
-        if (this._isRavenInstalled) {
-            this._drainPlugins();
-        }
-
-        return this;
-    },
-
-    /*
+  /*
      * Set/clear a user to be sent along with the payload.
      *
      * @param {object} user An object representing user data [optional]
      * @return {Raven}
      */
-    setUserContext: function(user) {
-        // Intentionally do not merge here since that's an unexpected behavior.
-        this._globalContext.user = user;
+  setUserContext: function(user) {
+    // Intentionally do not merge here since that's an unexpected behavior.
+    this._globalContext.user = user;
 
-        return this;
-    },
+    return this;
+  },
 
-    /*
+  /*
      * Merge extra attributes to be sent along with the payload.
      *
      * @param {object} extra An object representing extra data [optional]
      * @return {Raven}
      */
-    setExtraContext: function(extra) {
-        this._mergeContext('extra', extra);
+  setExtraContext: function(extra) {
+    this._mergeContext('extra', extra);
 
-        return this;
-    },
+    return this;
+  },
 
-    /*
+  /*
      * Merge tags to be sent along with the payload.
      *
      * @param {object} tags An object representing tags [optional]
      * @return {Raven}
      */
-    setTagsContext: function(tags) {
-        this._mergeContext('tags', tags);
+  setTagsContext: function(tags) {
+    this._mergeContext('tags', tags);
 
-        return this;
-    },
+    return this;
+  },
 
-    /*
+  /*
      * Clear all of the context.
      *
      * @return {Raven}
      */
-    clearContext: function() {
-        this._globalContext = {};
+  clearContext: function() {
+    this._globalContext = {};
 
-        return this;
-    },
+    return this;
+  },
 
-    /*
+  /*
      * Get a copy of the current context. This cannot be mutated.
      *
      * @return {object} copy of context
      */
-    getContext: function() {
-        // lol javascript
-        return JSON.parse(stringify(this._globalContext));
-    },
+  getContext: function() {
+    // lol javascript
+    return JSON.parse(stringify(this._globalContext));
+  },
 
-
-    /*
+  /*
      * Set environment of application
      *
      * @param {string} environment Typically something like 'production'.
      * @return {Raven}
      */
-    setEnvironment: function(environment) {
-        this._globalOptions.environment = environment;
+  setEnvironment: function(environment) {
+    this._globalOptions.environment = environment;
 
-        return this;
-    },
+    return this;
+  },
 
-    /*
+  /*
      * Set release version of application
      *
      * @param {string} release Typically something like a git SHA to identify version
      * @return {Raven}
      */
-    setRelease: function(release) {
-        this._globalOptions.release = release;
+  setRelease: function(release) {
+    this._globalOptions.release = release;
 
-        return this;
-    },
+    return this;
+  },
 
-    /*
+  /*
      * Set the dataCallback option
      *
      * @param {function} callback The callback to run which allows the
      *                            data blob to be mutated before sending
      * @return {Raven}
      */
-    setDataCallback: function(callback) {
-        var original = this._globalOptions.dataCallback;
-        this._globalOptions.dataCallback =
-          keepOriginalCallback(original, callback);
-        return this;
-    },
+  setDataCallback: function(callback) {
+    var original = this._globalOptions.dataCallback;
+    this._globalOptions.dataCallback = keepOriginalCallback(original, callback);
+    return this;
+  },
 
-    /*
+  /*
      * Set the breadcrumbCallback option
      *
      * @param {function} callback The callback to run which allows filtering
      *                            or mutating breadcrumbs
      * @return {Raven}
      */
-    setBreadcrumbCallback: function(callback) {
-        var original = this._globalOptions.breadcrumbCallback;
-        this._globalOptions.breadcrumbCallback =
-          keepOriginalCallback(original, callback);
-        return this;
-    },
+  setBreadcrumbCallback: function(callback) {
+    var original = this._globalOptions.breadcrumbCallback;
+    this._globalOptions.breadcrumbCallback = keepOriginalCallback(original, callback);
+    return this;
+  },
 
-    /*
+  /*
      * Set the shouldSendCallback option
      *
      * @param {function} callback The callback to run which allows
      *                            introspecting the blob before sending
      * @return {Raven}
      */
-    setShouldSendCallback: function(callback) {
-        var original = this._globalOptions.shouldSendCallback;
-        this._globalOptions.shouldSendCallback =
-          keepOriginalCallback(original, callback);
-        return this;
-    },
+  setShouldSendCallback: function(callback) {
+    var original = this._globalOptions.shouldSendCallback;
+    this._globalOptions.shouldSendCallback = keepOriginalCallback(original, callback);
+    return this;
+  },
 
-    /**
+  /**
      * Override the default HTTP transport mechanism that transmits data
      * to the Sentry server.
      *
@@ -623,368 +645,424 @@ Raven.prototype = {
      *
      * @return {Raven}
      */
-    setTransport: function(transport) {
-        this._globalOptions.transport = transport;
+  setTransport: function(transport) {
+    this._globalOptions.transport = transport;
 
-        return this;
-    },
+    return this;
+  },
 
-    /*
+  /*
      * Get the latest raw exception that was captured by Raven.
      *
      * @return {error}
      */
-    lastException: function() {
-        return this._lastCapturedException;
-    },
+  lastException: function() {
+    return this._lastCapturedException;
+  },
 
-    /*
+  /*
      * Get the last event id
      *
      * @return {string}
      */
-    lastEventId: function() {
-        return this._lastEventId;
-    },
+  lastEventId: function() {
+    return this._lastEventId;
+  },
 
-    /*
+  /*
      * Determine if Raven is setup and ready to go.
      *
      * @return {boolean}
      */
-    isSetup: function() {
-        if (!this._hasJSON) return false;  // needs JSON support
-        if (!this._globalServer) {
-            if (!this.ravenNotConfiguredError) {
-              this.ravenNotConfiguredError = true;
-              this._logDebug('error', 'Error: Raven has not been configured.');
-            }
-            return false;
-        }
-        return true;
-    },
+  isSetup: function() {
+    if (!this._hasJSON) return false; // needs JSON support
+    if (!this._globalServer) {
+      if (!this.ravenNotConfiguredError) {
+        this.ravenNotConfiguredError = true;
+        this._logDebug('error', 'Error: Raven has not been configured.');
+      }
+      return false;
+    }
+    return true;
+  },
 
-    afterLoad: function () {
-        // TODO: remove window dependence?
+  afterLoad: function() {
+    // TODO: remove window dependence?
 
-        // Attempt to initialize Raven on load
-        var RavenConfig = _window.RavenConfig;
-        if (RavenConfig) {
-            this.config(RavenConfig.dsn, RavenConfig.config).install();
-        }
-    },
+    // Attempt to initialize Raven on load
+    var RavenConfig = _window.RavenConfig;
+    if (RavenConfig) {
+      this.config(RavenConfig.dsn, RavenConfig.config).install();
+    }
+  },
 
-    showReportDialog: function (options) {
-        if (!_document) // doesn't work without a document (React native)
-            return;
+  showReportDialog: function(options) {
+    if (
+      !_document // doesn't work without a document (React native)
+    )
+      return;
 
-        options = options || {};
+    options = options || {};
 
-        var lastEventId = options.eventId || this.lastEventId();
-        if (!lastEventId) {
-            throw new RavenConfigError('Missing eventId');
-        }
+    var lastEventId = options.eventId || this.lastEventId();
+    if (!lastEventId) {
+      throw new RavenConfigError('Missing eventId');
+    }
 
-        var dsn = options.dsn || this._dsn;
-        if (!dsn) {
-            throw new RavenConfigError('Missing DSN');
-        }
+    var dsn = options.dsn || this._dsn;
+    if (!dsn) {
+      throw new RavenConfigError('Missing DSN');
+    }
 
-        var encode = encodeURIComponent;
-        var qs = '';
-        qs += '?eventId=' + encode(lastEventId);
-        qs += '&dsn=' + encode(dsn);
+    var encode = encodeURIComponent;
+    var qs = '';
+    qs += '?eventId=' + encode(lastEventId);
+    qs += '&dsn=' + encode(dsn);
 
-        var user = options.user || this._globalContext.user;
-        if (user) {
-            if (user.name)  qs += '&name=' + encode(user.name);
-            if (user.email) qs += '&email=' + encode(user.email);
-        }
+    var user = options.user || this._globalContext.user;
+    if (user) {
+      if (user.name) qs += '&name=' + encode(user.name);
+      if (user.email) qs += '&email=' + encode(user.email);
+    }
 
-        var globalServer = this._getGlobalServer(this._parseDSN(dsn));
+    var globalServer = this._getGlobalServer(this._parseDSN(dsn));
 
-        var script = _document.createElement('script');
-        script.async = true;
-        script.src = globalServer + '/api/embed/error-page/' + qs;
-        (_document.head || _document.body).appendChild(script);
-    },
+    var script = _document.createElement('script');
+    script.async = true;
+    script.src = globalServer + '/api/embed/error-page/' + qs;
+    (_document.head || _document.body).appendChild(script);
+  },
 
-    /**** Private functions ****/
-    _ignoreNextOnError: function () {
-        var self = this;
-        this._ignoreOnError += 1;
-        setTimeout(function () {
-            // onerror should trigger before setTimeout
-            self._ignoreOnError -= 1;
-        });
-    },
+  /**** Private functions ****/
+  _ignoreNextOnError: function() {
+    var self = this;
+    this._ignoreOnError += 1;
+    setTimeout(function() {
+      // onerror should trigger before setTimeout
+      self._ignoreOnError -= 1;
+    });
+  },
 
-    _triggerEvent: function(eventType, options) {
-        // NOTE: `event` is a native browser thing, so let's avoid conflicting wiht it
-        var evt, key;
+  _triggerEvent: function(eventType, options) {
+    // NOTE: `event` is a native browser thing, so let's avoid conflicting wiht it
+    var evt, key;
 
-        if (!this._hasDocument)
-            return;
+    if (!this._hasDocument) return;
 
-        options = options || {};
+    options = options || {};
 
-        eventType = 'raven' + eventType.substr(0,1).toUpperCase() + eventType.substr(1);
+    eventType = 'raven' + eventType.substr(0, 1).toUpperCase() + eventType.substr(1);
 
-        if (_document.createEvent) {
-            evt = _document.createEvent('HTMLEvents');
-            evt.initEvent(eventType, true, true);
-        } else {
-            evt = _document.createEventObject();
-            evt.eventType = eventType;
-        }
+    if (_document.createEvent) {
+      evt = _document.createEvent('HTMLEvents');
+      evt.initEvent(eventType, true, true);
+    } else {
+      evt = _document.createEventObject();
+      evt.eventType = eventType;
+    }
 
-        for (key in options) if (hasKey(options, key)) {
-            evt[key] = options[key];
-        }
+    for (key in options)
+      if (hasKey(options, key)) {
+        evt[key] = options[key];
+      }
 
-        if (_document.createEvent) {
-            // IE9 if standards
-            _document.dispatchEvent(evt);
-        } else {
-            // IE8 regardless of Quirks or Standards
-            // IE9 if quirks
-            try {
-                _document.fireEvent('on' + evt.eventType.toLowerCase(), evt);
-            } catch(e) {
-                // Do nothing
-            }
-        }
-    },
+    if (_document.createEvent) {
+      // IE9 if standards
+      _document.dispatchEvent(evt);
+    } else {
+      // IE8 regardless of Quirks or Standards
+      // IE9 if quirks
+      try {
+        _document.fireEvent('on' + evt.eventType.toLowerCase(), evt);
+      } catch (e) {
+        // Do nothing
+      }
+    }
+  },
 
-    /**
+  /**
      * Wraps addEventListener to capture UI breadcrumbs
      * @param evtName the event name (e.g. "click")
      * @returns {Function}
      * @private
      */
-    _breadcrumbEventHandler: function(evtName) {
-        var self = this;
-        return function (evt) {
-            // reset keypress timeout; e.g. triggering a 'click' after
-            // a 'keypress' will reset the keypress debounce so that a new
-            // set of keypresses can be recorded
-            self._keypressTimeout = null;
+  _breadcrumbEventHandler: function(evtName) {
+    var self = this;
+    return function(evt) {
+      // reset keypress timeout; e.g. triggering a 'click' after
+      // a 'keypress' will reset the keypress debounce so that a new
+      // set of keypresses can be recorded
+      self._keypressTimeout = null;
 
-            // It's possible this handler might trigger multiple times for the same
-            // event (e.g. event propagation through node ancestors). Ignore if we've
-            // already captured the event.
-            if (self._lastCapturedEvent === evt)
-                return;
+      // It's possible this handler might trigger multiple times for the same
+      // event (e.g. event propagation through node ancestors). Ignore if we've
+      // already captured the event.
+      if (self._lastCapturedEvent === evt) return;
 
-            self._lastCapturedEvent = evt;
+      self._lastCapturedEvent = evt;
 
-            // try/catch both:
-            // - accessing evt.target (see getsentry/raven-js#838, #768)
-            // - `htmlTreeAsString` because it's complex, and just accessing the DOM incorrectly
-            //   can throw an exception in some circumstances.
-            var target;
-            try {
-                target = htmlTreeAsString(evt.target);
-            } catch (e) {
-                target = '<unknown>';
-            }
+      // try/catch both:
+      // - accessing evt.target (see getsentry/raven-js#838, #768)
+      // - `htmlTreeAsString` because it's complex, and just accessing the DOM incorrectly
+      //   can throw an exception in some circumstances.
+      var target;
+      try {
+        target = htmlTreeAsString(evt.target);
+      } catch (e) {
+        target = '<unknown>';
+      }
 
-            self.captureBreadcrumb({
-                category: 'ui.' + evtName, // e.g. ui.click, ui.input
-                message: target
-            });
-        };
-    },
+      self.captureBreadcrumb({
+        category: 'ui.' + evtName, // e.g. ui.click, ui.input
+        message: target
+      });
+    };
+  },
 
-    /**
+  /**
      * Wraps addEventListener to capture keypress UI events
      * @returns {Function}
      * @private
      */
-    _keypressEventHandler: function() {
-        var self = this,
-            debounceDuration = 1000; // milliseconds
+  _keypressEventHandler: function() {
+    var self = this,
+      debounceDuration = 1000; // milliseconds
 
-        // TODO: if somehow user switches keypress target before
-        //       debounce timeout is triggered, we will only capture
-        //       a single breadcrumb from the FIRST target (acceptable?)
-        return function (evt) {
-            var target;
-            try {
-                target = evt.target;
-            } catch (e) {
-                // just accessing event properties can throw an exception in some rare circumstances
-                // see: https://github.com/getsentry/raven-js/issues/838
-                return;
-            }
-            var tagName = target && target.tagName;
+    // TODO: if somehow user switches keypress target before
+    //       debounce timeout is triggered, we will only capture
+    //       a single breadcrumb from the FIRST target (acceptable?)
+    return function(evt) {
+      var target;
+      try {
+        target = evt.target;
+      } catch (e) {
+        // just accessing event properties can throw an exception in some rare circumstances
+        // see: https://github.com/getsentry/raven-js/issues/838
+        return;
+      }
+      var tagName = target && target.tagName;
 
-            // only consider keypress events on actual input elements
-            // this will disregard keypresses targeting body (e.g. tabbing
-            // through elements, hotkeys, etc)
-            if (!tagName || tagName !== 'INPUT' && tagName !== 'TEXTAREA' && !target.isContentEditable)
-                return;
+      // only consider keypress events on actual input elements
+      // this will disregard keypresses targeting body (e.g. tabbing
+      // through elements, hotkeys, etc)
+      if (
+        !tagName ||
+        (tagName !== 'INPUT' && tagName !== 'TEXTAREA' && !target.isContentEditable)
+      )
+        return;
 
-            // record first keypress in a series, but ignore subsequent
-            // keypresses until debounce clears
-            var timeout = self._keypressTimeout;
-            if (!timeout) {
-                self._breadcrumbEventHandler('input')(evt);
-            }
-            clearTimeout(timeout);
-            self._keypressTimeout = setTimeout(function () {
-                self._keypressTimeout = null;
-            }, debounceDuration);
-        };
-    },
+      // record first keypress in a series, but ignore subsequent
+      // keypresses until debounce clears
+      var timeout = self._keypressTimeout;
+      if (!timeout) {
+        self._breadcrumbEventHandler('input')(evt);
+      }
+      clearTimeout(timeout);
+      self._keypressTimeout = setTimeout(function() {
+        self._keypressTimeout = null;
+      }, debounceDuration);
+    };
+  },
 
-    /**
+  /**
      * Captures a breadcrumb of type "navigation", normalizing input URLs
      * @param to the originating URL
      * @param from the target URL
      * @private
      */
-    _captureUrlChange: function(from, to) {
-        var parsedLoc = parseUrl(this._location.href);
-        var parsedTo = parseUrl(to);
-        var parsedFrom = parseUrl(from);
+  _captureUrlChange: function(from, to) {
+    var parsedLoc = parseUrl(this._location.href);
+    var parsedTo = parseUrl(to);
+    var parsedFrom = parseUrl(from);
 
-        // because onpopstate only tells you the "new" (to) value of location.href, and
-        // not the previous (from) value, we need to track the value of the current URL
-        // state ourselves
-        this._lastHref = to;
+    // because onpopstate only tells you the "new" (to) value of location.href, and
+    // not the previous (from) value, we need to track the value of the current URL
+    // state ourselves
+    this._lastHref = to;
 
-        // Use only the path component of the URL if the URL matches the current
-        // document (almost all the time when using pushState)
-        if (parsedLoc.protocol === parsedTo.protocol && parsedLoc.host === parsedTo.host)
-            to = parsedTo.relative;
-        if (parsedLoc.protocol === parsedFrom.protocol && parsedLoc.host === parsedFrom.host)
-            from = parsedFrom.relative;
+    // Use only the path component of the URL if the URL matches the current
+    // document (almost all the time when using pushState)
+    if (parsedLoc.protocol === parsedTo.protocol && parsedLoc.host === parsedTo.host)
+      to = parsedTo.relative;
+    if (parsedLoc.protocol === parsedFrom.protocol && parsedLoc.host === parsedFrom.host)
+      from = parsedFrom.relative;
 
-        this.captureBreadcrumb({
-            category: 'navigation',
-            data: {
-                to: to,
-                from: from
-            }
-        });
-    },
+    this.captureBreadcrumb({
+      category: 'navigation',
+      data: {
+        to: to,
+        from: from
+      }
+    });
+  },
 
-    /**
+  /**
      * Wrap timer functions and event targets to catch errors and provide
      * better metadata.
      */
-    _instrumentTryCatch: function() {
-        var self = this;
+  _instrumentTryCatch: function() {
+    var self = this;
 
-        var wrappedBuiltIns = self._wrappedBuiltIns;
+    var wrappedBuiltIns = self._wrappedBuiltIns;
 
-        function wrapTimeFn(orig) {
-            return function (fn, t) { // preserve arity
-                // Make a copy of the arguments to prevent deoptimization
-                // https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
-                var args = new Array(arguments.length);
-                for(var i = 0; i < args.length; ++i) {
-                    args[i] = arguments[i];
-                }
-                var originalCallback = args[0];
-                if (isFunction(originalCallback)) {
-                    args[0] = self.wrap(originalCallback);
-                }
-
-                // IE < 9 doesn't support .call/.apply on setInterval/setTimeout, but it
-                // also supports only two arguments and doesn't care what this is, so we
-                // can just call the original function directly.
-                if (orig.apply) {
-                    return orig.apply(this, args);
-                } else {
-                    return orig(args[0], args[1]);
-                }
-            };
+    function wrapTimeFn(orig) {
+      return function(fn, t) {
+        // preserve arity
+        // Make a copy of the arguments to prevent deoptimization
+        // https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
+        var args = new Array(arguments.length);
+        for (var i = 0; i < args.length; ++i) {
+          args[i] = arguments[i];
+        }
+        var originalCallback = args[0];
+        if (isFunction(originalCallback)) {
+          args[0] = self.wrap(originalCallback);
         }
 
-        var autoBreadcrumbs = this._globalOptions.autoBreadcrumbs;
-
-        function wrapEventTarget(global) {
-            var proto = _window[global] && _window[global].prototype;
-            if (proto && proto.hasOwnProperty && proto.hasOwnProperty('addEventListener')) {
-                fill(proto, 'addEventListener', function(orig) {
-                    return function (evtName, fn, capture, secure) { // preserve arity
-                        try {
-                            if (fn && fn.handleEvent) {
-                                fn.handleEvent = self.wrap(fn.handleEvent);
-                            }
-                        } catch (err) {
-                            // can sometimes get 'Permission denied to access property "handle Event'
-                        }
-
-                        // More breadcrumb DOM capture ... done here and not in `_instrumentBreadcrumbs`
-                        // so that we don't have more than one wrapper function
-                        var before,
-                            clickHandler,
-                            keypressHandler;
-
-                        if (autoBreadcrumbs && autoBreadcrumbs.dom && (global === 'EventTarget' || global === 'Node')) {
-                            // NOTE: generating multiple handlers per addEventListener invocation, should
-                            //       revisit and verify we can just use one (almost certainly)
-                            clickHandler = self._breadcrumbEventHandler('click');
-                            keypressHandler = self._keypressEventHandler();
-                            before = function (evt) {
-                                // need to intercept every DOM event in `before` argument, in case that
-                                // same wrapped method is re-used for different events (e.g. mousemove THEN click)
-                                // see #724
-                                if (!evt) return;
-
-                                var eventType;
-                                try {
-                                    eventType = evt.type
-                                } catch (e) {
-                                    // just accessing event properties can throw an exception in some rare circumstances
-                                    // see: https://github.com/getsentry/raven-js/issues/838
-                                    return;
-                                }
-                                if (eventType === 'click')
-                                    return clickHandler(evt);
-                                else if (eventType === 'keypress')
-                                    return keypressHandler(evt);
-                            };
-                        }
-                        return orig.call(this, evtName, self.wrap(fn, undefined, before), capture, secure);
-                    };
-                }, wrappedBuiltIns);
-                fill(proto, 'removeEventListener', function (orig) {
-                    return function (evt, fn, capture, secure) {
-                        try {
-                            fn = fn && (fn.__raven_wrapper__ ? fn.__raven_wrapper__  : fn);
-                        } catch (e) {
-                            // ignore, accessing __raven_wrapper__ will throw in some Selenium environments
-                        }
-                        return orig.call(this, evt, fn, capture, secure);
-                    };
-                }, wrappedBuiltIns);
-            }
+        // IE < 9 doesn't support .call/.apply on setInterval/setTimeout, but it
+        // also supports only two arguments and doesn't care what this is, so we
+        // can just call the original function directly.
+        if (orig.apply) {
+          return orig.apply(this, args);
+        } else {
+          return orig(args[0], args[1]);
         }
+      };
+    }
 
-        fill(_window, 'setTimeout', wrapTimeFn, wrappedBuiltIns);
-        fill(_window, 'setInterval', wrapTimeFn, wrappedBuiltIns);
-        if (_window.requestAnimationFrame) {
-            fill(_window, 'requestAnimationFrame', function (orig) {
-                return function (cb) {
-                    return orig(self.wrap(cb));
+    var autoBreadcrumbs = this._globalOptions.autoBreadcrumbs;
+
+    function wrapEventTarget(global) {
+      var proto = _window[global] && _window[global].prototype;
+      if (proto && proto.hasOwnProperty && proto.hasOwnProperty('addEventListener')) {
+        fill(
+          proto,
+          'addEventListener',
+          function(orig) {
+            return function(evtName, fn, capture, secure) {
+              // preserve arity
+              try {
+                if (fn && fn.handleEvent) {
+                  fn.handleEvent = self.wrap(fn.handleEvent);
+                }
+              } catch (err) {
+                // can sometimes get 'Permission denied to access property "handle Event'
+              }
+
+              // More breadcrumb DOM capture ... done here and not in `_instrumentBreadcrumbs`
+              // so that we don't have more than one wrapper function
+              var before, clickHandler, keypressHandler;
+
+              if (
+                autoBreadcrumbs &&
+                autoBreadcrumbs.dom &&
+                (global === 'EventTarget' || global === 'Node')
+              ) {
+                // NOTE: generating multiple handlers per addEventListener invocation, should
+                //       revisit and verify we can just use one (almost certainly)
+                clickHandler = self._breadcrumbEventHandler('click');
+                keypressHandler = self._keypressEventHandler();
+                before = function(evt) {
+                  // need to intercept every DOM event in `before` argument, in case that
+                  // same wrapped method is re-used for different events (e.g. mousemove THEN click)
+                  // see #724
+                  if (!evt) return;
+
+                  var eventType;
+                  try {
+                    eventType = evt.type;
+                  } catch (e) {
+                    // just accessing event properties can throw an exception in some rare circumstances
+                    // see: https://github.com/getsentry/raven-js/issues/838
+                    return;
+                  }
+                  if (eventType === 'click') return clickHandler(evt);
+                  else if (eventType === 'keypress') return keypressHandler(evt);
                 };
-            }, wrappedBuiltIns);
-        }
+              }
+              return orig.call(
+                this,
+                evtName,
+                self.wrap(fn, undefined, before),
+                capture,
+                secure
+              );
+            };
+          },
+          wrappedBuiltIns
+        );
+        fill(
+          proto,
+          'removeEventListener',
+          function(orig) {
+            return function(evt, fn, capture, secure) {
+              try {
+                fn = fn && (fn.__raven_wrapper__ ? fn.__raven_wrapper__ : fn);
+              } catch (e) {
+                // ignore, accessing __raven_wrapper__ will throw in some Selenium environments
+              }
+              return orig.call(this, evt, fn, capture, secure);
+            };
+          },
+          wrappedBuiltIns
+        );
+      }
+    }
 
-        // event targets borrowed from bugsnag-js:
-        // https://github.com/bugsnag/bugsnag-js/blob/master/src/bugsnag.js#L666
-        var eventTargets = ['EventTarget', 'Window', 'Node', 'ApplicationCache', 'AudioTrackList', 'ChannelMergerNode', 'CryptoOperation', 'EventSource', 'FileReader', 'HTMLUnknownElement', 'IDBDatabase', 'IDBRequest', 'IDBTransaction', 'KeyOperation', 'MediaController', 'MessagePort', 'ModalWindow', 'Notification', 'SVGElementInstance', 'Screen', 'TextTrack', 'TextTrackCue', 'TextTrackList', 'WebSocket', 'WebSocketWorker', 'Worker', 'XMLHttpRequest', 'XMLHttpRequestEventTarget', 'XMLHttpRequestUpload'];
-        for (var i = 0; i < eventTargets.length; i++) {
-            wrapEventTarget(eventTargets[i]);
-        }
-    },
+    fill(_window, 'setTimeout', wrapTimeFn, wrappedBuiltIns);
+    fill(_window, 'setInterval', wrapTimeFn, wrappedBuiltIns);
+    if (_window.requestAnimationFrame) {
+      fill(
+        _window,
+        'requestAnimationFrame',
+        function(orig) {
+          return function(cb) {
+            return orig(self.wrap(cb));
+          };
+        },
+        wrappedBuiltIns
+      );
+    }
 
+    // event targets borrowed from bugsnag-js:
+    // https://github.com/bugsnag/bugsnag-js/blob/master/src/bugsnag.js#L666
+    var eventTargets = [
+      'EventTarget',
+      'Window',
+      'Node',
+      'ApplicationCache',
+      'AudioTrackList',
+      'ChannelMergerNode',
+      'CryptoOperation',
+      'EventSource',
+      'FileReader',
+      'HTMLUnknownElement',
+      'IDBDatabase',
+      'IDBRequest',
+      'IDBTransaction',
+      'KeyOperation',
+      'MediaController',
+      'MessagePort',
+      'ModalWindow',
+      'Notification',
+      'SVGElementInstance',
+      'Screen',
+      'TextTrack',
+      'TextTrackCue',
+      'TextTrackList',
+      'WebSocket',
+      'WebSocketWorker',
+      'Worker',
+      'XMLHttpRequest',
+      'XMLHttpRequestEventTarget',
+      'XMLHttpRequestUpload'
+    ];
+    for (var i = 0; i < eventTargets.length; i++) {
+      wrapEventTarget(eventTargets[i]);
+    }
+  },
 
-    /**
+  /**
      * Instrument browser built-ins w/ breadcrumb capturing
      *  - XMLHttpRequests
      *  - DOM interactions (click/typing)
@@ -993,446 +1071,498 @@ Raven.prototype = {
      *
      * Can be disabled or individually configured via the `autoBreadcrumbs` config option
      */
-    _instrumentBreadcrumbs: function () {
-        var self = this;
-        var autoBreadcrumbs = this._globalOptions.autoBreadcrumbs;
+  _instrumentBreadcrumbs: function() {
+    var self = this;
+    var autoBreadcrumbs = this._globalOptions.autoBreadcrumbs;
 
-        var wrappedBuiltIns = self._wrappedBuiltIns;
+    var wrappedBuiltIns = self._wrappedBuiltIns;
 
-        function wrapProp(prop, xhr) {
-            if (prop in xhr && isFunction(xhr[prop])) {
-                fill(xhr, prop, function (orig) {
-                    return self.wrap(orig);
-                }); // intentionally don't track filled methods on XHR instances
+    function wrapProp(prop, xhr) {
+      if (prop in xhr && isFunction(xhr[prop])) {
+        fill(xhr, prop, function(orig) {
+          return self.wrap(orig);
+        }); // intentionally don't track filled methods on XHR instances
+      }
+    }
+
+    if (autoBreadcrumbs.xhr && 'XMLHttpRequest' in _window) {
+      var xhrproto = XMLHttpRequest.prototype;
+      fill(
+        xhrproto,
+        'open',
+        function(origOpen) {
+          return function(method, url) {
+            // preserve arity
+
+            // if Sentry key appears in URL, don't capture
+            if (isString(url) && url.indexOf(self._globalKey) === -1) {
+              this.__raven_xhr = {
+                method: method,
+                url: url,
+                status_code: null
+              };
             }
-        }
 
-        if (autoBreadcrumbs.xhr && 'XMLHttpRequest' in _window) {
-            var xhrproto = XMLHttpRequest.prototype;
-            fill(xhrproto, 'open', function(origOpen) {
-                return function (method, url) { // preserve arity
+            return origOpen.apply(this, arguments);
+          };
+        },
+        wrappedBuiltIns
+      );
 
-                    // if Sentry key appears in URL, don't capture
-                    if (isString(url) && url.indexOf(self._globalKey) === -1) {
-                        this.__raven_xhr = {
-                            method: method,
-                            url: url,
-                            status_code: null
-                        };
-                    }
+      fill(
+        xhrproto,
+        'send',
+        function(origSend) {
+          return function(data) {
+            // preserve arity
+            var xhr = this;
 
-                    return origOpen.apply(this, arguments);
-                };
-            }, wrappedBuiltIns);
-
-            fill(xhrproto, 'send', function(origSend) {
-                return function (data) { // preserve arity
-                    var xhr = this;
-
-                    function onreadystatechangeHandler() {
-                        if (xhr.__raven_xhr && (xhr.readyState === 1 || xhr.readyState === 4)) {
-                            try {
-                                // touching statusCode in some platforms throws
-                                // an exception
-                                xhr.__raven_xhr.status_code = xhr.status;
-                            } catch (e) { /* do nothing */ }
-                            self.captureBreadcrumb({
-                                type: 'http',
-                                category: 'xhr',
-                                data: xhr.__raven_xhr
-                            });
-                        }
-                    }
-
-                    var props = ['onload', 'onerror', 'onprogress'];
-                    for (var j = 0; j < props.length; j++) {
-                        wrapProp(props[j], xhr);
-                    }
-
-                    if ('onreadystatechange' in xhr && isFunction(xhr.onreadystatechange)) {
-                        fill(xhr, 'onreadystatechange', function (orig) {
-                            return self.wrap(orig, undefined, onreadystatechangeHandler);
-                        } /* intentionally don't track this instrumentation */);
-                    } else {
-                        // if onreadystatechange wasn't actually set by the page on this xhr, we
-                        // are free to set our own and capture the breadcrumb
-                        xhr.onreadystatechange = onreadystatechangeHandler;
-                    }
-
-                    return origSend.apply(this, arguments);
-                };
-            }, wrappedBuiltIns);
-        }
-
-        if (autoBreadcrumbs.xhr && 'fetch' in _window) {
-            fill(_window, 'fetch', function(origFetch) {
-                return function (fn, t) { // preserve arity
-                    // Make a copy of the arguments to prevent deoptimization
-                    // https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
-                    var args = new Array(arguments.length);
-                    for (var i = 0; i < args.length; ++i) {
-                        args[i] = arguments[i];
-                    }
-
-                    var fetchInput = args[0];
-                    var method = 'GET';
-                    var url;
-
-                    if (typeof fetchInput === 'string') {
-                        url = fetchInput;
-                    } else {
-                        url = fetchInput.url;
-                        if (fetchInput.method) {
-                            method = fetchInput.method;
-                        }
-                    }
-
-                    if (args[1] && args[1].method) {
-                        method = args[1].method;
-                    }
-
-                    var fetchData = {
-                        method: method,
-                        url: url,
-                        status_code: null
-                    };
-
-                    self.captureBreadcrumb({
-                        type: 'http',
-                        category: 'fetch',
-                        data: fetchData
-                    });
-
-                    return origFetch.apply(this, args).then(function (response) {
-                        fetchData.status_code = response.status;
-
-                        return response;
-                    });
-                };
-            }, wrappedBuiltIns);
-        }
-
-        // Capture breadcrumbs from any click that is unhandled / bubbled up all the way
-        // to the document. Do this before we instrument addEventListener.
-        if (autoBreadcrumbs.dom && this._hasDocument) {
-            if (_document.addEventListener) {
-                _document.addEventListener('click', self._breadcrumbEventHandler('click'), false);
-                _document.addEventListener('keypress', self._keypressEventHandler(), false);
-            }
-            else {
-                // IE8 Compatibility
-                _document.attachEvent('onclick', self._breadcrumbEventHandler('click'));
-                _document.attachEvent('onkeypress', self._keypressEventHandler());
-            }
-        }
-
-        // record navigation (URL) changes
-        // NOTE: in Chrome App environment, touching history.pushState, *even inside
-        //       a try/catch block*, will cause Chrome to output an error to console.error
-        // borrowed from: https://github.com/angular/angular.js/pull/13945/files
-        var chrome = _window.chrome;
-        var isChromePackagedApp = chrome && chrome.app && chrome.app.runtime;
-        var hasPushState = !isChromePackagedApp && _window.history && history.pushState;
-        if (autoBreadcrumbs.location && hasPushState) {
-            // TODO: remove onpopstate handler on uninstall()
-            var oldOnPopState = _window.onpopstate;
-            _window.onpopstate = function () {
-                var currentHref = self._location.href;
-                self._captureUrlChange(self._lastHref, currentHref);
-
-                if (oldOnPopState) {
-                    return oldOnPopState.apply(this, arguments);
+            function onreadystatechangeHandler() {
+              if (xhr.__raven_xhr && (xhr.readyState === 1 || xhr.readyState === 4)) {
+                try {
+                  // touching statusCode in some platforms throws
+                  // an exception
+                  xhr.__raven_xhr.status_code = xhr.status;
+                } catch (e) {
+                  /* do nothing */
                 }
-            };
-
-            fill(history, 'pushState', function (origPushState) {
-                // note history.pushState.length is 0; intentionally not declaring
-                // params to preserve 0 arity
-                return function (/* state, title, url */) {
-                    var url = arguments.length > 2 ? arguments[2] : undefined;
-
-                    // url argument is optional
-                    if (url) {
-                        // coerce to string (this is what pushState does)
-                        self._captureUrlChange(self._lastHref, url + '');
-                    }
-
-                    return origPushState.apply(this, arguments);
-                };
-            }, wrappedBuiltIns);
-        }
-
-        if (autoBreadcrumbs.console && 'console' in _window && console.log) {
-            // console
-            var consoleMethodCallback = function (msg, data) {
                 self.captureBreadcrumb({
-                    message: msg,
-                    level: data.level,
-                    category: 'console'
+                  type: 'http',
+                  category: 'xhr',
+                  data: xhr.__raven_xhr
                 });
+              }
+            }
+
+            var props = ['onload', 'onerror', 'onprogress'];
+            for (var j = 0; j < props.length; j++) {
+              wrapProp(props[j], xhr);
+            }
+
+            if ('onreadystatechange' in xhr && isFunction(xhr.onreadystatechange)) {
+              fill(
+                xhr,
+                'onreadystatechange',
+                function(orig) {
+                  return self.wrap(orig, undefined, onreadystatechangeHandler);
+                } /* intentionally don't track this instrumentation */
+              );
+            } else {
+              // if onreadystatechange wasn't actually set by the page on this xhr, we
+              // are free to set our own and capture the breadcrumb
+              xhr.onreadystatechange = onreadystatechangeHandler;
+            }
+
+            return origSend.apply(this, arguments);
+          };
+        },
+        wrappedBuiltIns
+      );
+    }
+
+    if (autoBreadcrumbs.xhr && 'fetch' in _window) {
+      fill(
+        _window,
+        'fetch',
+        function(origFetch) {
+          return function(fn, t) {
+            // preserve arity
+            // Make a copy of the arguments to prevent deoptimization
+            // https://github.com/petkaantonov/bluebird/wiki/Optimization-killers#32-leaking-arguments
+            var args = new Array(arguments.length);
+            for (var i = 0; i < args.length; ++i) {
+              args[i] = arguments[i];
+            }
+
+            var fetchInput = args[0];
+            var method = 'GET';
+            var url;
+
+            if (typeof fetchInput === 'string') {
+              url = fetchInput;
+            } else {
+              url = fetchInput.url;
+              if (fetchInput.method) {
+                method = fetchInput.method;
+              }
+            }
+
+            if (args[1] && args[1].method) {
+              method = args[1].method;
+            }
+
+            var fetchData = {
+              method: method,
+              url: url,
+              status_code: null
             };
 
-            each(['debug', 'info', 'warn', 'error', 'log'], function (_, level) {
-                wrapConsoleMethod(console, level, consoleMethodCallback);
-            });
-        }
-
-    },
-
-    _restoreBuiltIns: function () {
-        // restore any wrapped builtins
-        var builtin;
-        while (this._wrappedBuiltIns.length) {
-            builtin = this._wrappedBuiltIns.shift();
-
-            var obj = builtin[0],
-              name = builtin[1],
-              orig = builtin[2];
-
-            obj[name] = orig;
-        }
-    },
-
-    _drainPlugins: function() {
-        var self = this;
-
-        // FIX ME TODO
-        each(this._plugins, function(_, plugin) {
-            var installer = plugin[0];
-            var args = plugin[1];
-            installer.apply(self, [self].concat(args));
-        });
-    },
-
-    _parseDSN: function(str) {
-        var m = dsnPattern.exec(str),
-            dsn = {},
-            i = 7;
-
-        try {
-            while (i--) dsn[dsnKeys[i]] = m[i] || '';
-        } catch(e) {
-            throw new RavenConfigError('Invalid DSN: ' + str);
-        }
-
-        if (dsn.pass && !this._globalOptions.allowSecretKey) {
-            throw new RavenConfigError('Do not specify your secret key in the DSN. See: http://bit.ly/raven-secret-key');
-        }
-
-        return dsn;
-    },
-
-    _getGlobalServer: function(uri) {
-        // assemble the endpoint from the uri pieces
-        var globalServer = '//' + uri.host +
-            (uri.port ? ':' + uri.port : '');
-
-        if (uri.protocol) {
-            globalServer = uri.protocol + ':' + globalServer;
-        }
-        return globalServer;
-    },
-
-    _handleOnErrorStackInfo: function() {
-        // if we are intentionally ignoring errors via onerror, bail out
-        if (!this._ignoreOnError) {
-            this._handleStackInfo.apply(this, arguments);
-        }
-    },
-
-    _handleStackInfo: function(stackInfo, options) {
-        var frames = this._prepareFrames(stackInfo, options);
-
-        this._triggerEvent('handle', {
-            stackInfo: stackInfo,
-            options: options
-        });
-
-        this._processException(
-            stackInfo.name,
-            stackInfo.message,
-            stackInfo.url,
-            stackInfo.lineno,
-            frames,
-            options
-        );
-    },
-
-    _prepareFrames: function(stackInfo, options) {
-        var self = this;
-        var frames = [];
-        if (stackInfo.stack && stackInfo.stack.length) {
-            each(stackInfo.stack, function(i, stack) {
-                var frame = self._normalizeFrame(stack);
-                if (frame) {
-                    frames.push(frame);
-                }
+            self.captureBreadcrumb({
+              type: 'http',
+              category: 'fetch',
+              data: fetchData
             });
 
-            // e.g. frames captured via captureMessage throw
-            if (options && options.trimHeadFrames) {
-                for (var j = 0; j < options.trimHeadFrames && j < frames.length; j++) {
-                    frames[j].in_app = false;
-                }
+            return origFetch.apply(this, args).then(function(response) {
+              fetchData.status_code = response.status;
+
+              return response;
+            });
+          };
+        },
+        wrappedBuiltIns
+      );
+    }
+
+    // Capture breadcrumbs from any click that is unhandled / bubbled up all the way
+    // to the document. Do this before we instrument addEventListener.
+    if (autoBreadcrumbs.dom && this._hasDocument) {
+      if (_document.addEventListener) {
+        _document.addEventListener('click', self._breadcrumbEventHandler('click'), false);
+        _document.addEventListener('keypress', self._keypressEventHandler(), false);
+      } else {
+        // IE8 Compatibility
+        _document.attachEvent('onclick', self._breadcrumbEventHandler('click'));
+        _document.attachEvent('onkeypress', self._keypressEventHandler());
+      }
+    }
+
+    // record navigation (URL) changes
+    // NOTE: in Chrome App environment, touching history.pushState, *even inside
+    //       a try/catch block*, will cause Chrome to output an error to console.error
+    // borrowed from: https://github.com/angular/angular.js/pull/13945/files
+    var chrome = _window.chrome;
+    var isChromePackagedApp = chrome && chrome.app && chrome.app.runtime;
+    var hasPushState = !isChromePackagedApp && _window.history && history.pushState;
+    if (autoBreadcrumbs.location && hasPushState) {
+      // TODO: remove onpopstate handler on uninstall()
+      var oldOnPopState = _window.onpopstate;
+      _window.onpopstate = function() {
+        var currentHref = self._location.href;
+        self._captureUrlChange(self._lastHref, currentHref);
+
+        if (oldOnPopState) {
+          return oldOnPopState.apply(this, arguments);
+        }
+      };
+
+      fill(
+        history,
+        'pushState',
+        function(origPushState) {
+          // note history.pushState.length is 0; intentionally not declaring
+          // params to preserve 0 arity
+          return function(/* state, title, url */) {
+            var url = arguments.length > 2 ? arguments[2] : undefined;
+
+            // url argument is optional
+            if (url) {
+              // coerce to string (this is what pushState does)
+              self._captureUrlChange(self._lastHref, url + '');
             }
+
+            return origPushState.apply(this, arguments);
+          };
+        },
+        wrappedBuiltIns
+      );
+    }
+
+    if (autoBreadcrumbs.console && 'console' in _window && console.log) {
+      // console
+      var consoleMethodCallback = function(msg, data) {
+        self.captureBreadcrumb({
+          message: msg,
+          level: data.level,
+          category: 'console'
+        });
+      };
+
+      each(['debug', 'info', 'warn', 'error', 'log'], function(_, level) {
+        wrapConsoleMethod(console, level, consoleMethodCallback);
+      });
+    }
+  },
+
+  _restoreBuiltIns: function() {
+    // restore any wrapped builtins
+    var builtin;
+    while (this._wrappedBuiltIns.length) {
+      builtin = this._wrappedBuiltIns.shift();
+
+      var obj = builtin[0],
+        name = builtin[1],
+        orig = builtin[2];
+
+      obj[name] = orig;
+    }
+  },
+
+  _drainPlugins: function() {
+    var self = this;
+
+    // FIX ME TODO
+    each(this._plugins, function(_, plugin) {
+      var installer = plugin[0];
+      var args = plugin[1];
+      installer.apply(self, [self].concat(args));
+    });
+  },
+
+  _parseDSN: function(str) {
+    var m = dsnPattern.exec(str),
+      dsn = {},
+      i = 7;
+
+    try {
+      while (i--) dsn[dsnKeys[i]] = m[i] || '';
+    } catch (e) {
+      throw new RavenConfigError('Invalid DSN: ' + str);
+    }
+
+    if (dsn.pass && !this._globalOptions.allowSecretKey) {
+      throw new RavenConfigError(
+        'Do not specify your secret key in the DSN. See: http://bit.ly/raven-secret-key'
+      );
+    }
+
+    return dsn;
+  },
+
+  _getGlobalServer: function(uri) {
+    // assemble the endpoint from the uri pieces
+    var globalServer = '//' + uri.host + (uri.port ? ':' + uri.port : '');
+
+    if (uri.protocol) {
+      globalServer = uri.protocol + ':' + globalServer;
+    }
+    return globalServer;
+  },
+
+  _handleOnErrorStackInfo: function() {
+    // if we are intentionally ignoring errors via onerror, bail out
+    if (!this._ignoreOnError) {
+      this._handleStackInfo.apply(this, arguments);
+    }
+  },
+
+  _handleStackInfo: function(stackInfo, options) {
+    var frames = this._prepareFrames(stackInfo, options);
+
+    this._triggerEvent('handle', {
+      stackInfo: stackInfo,
+      options: options
+    });
+
+    this._processException(
+      stackInfo.name,
+      stackInfo.message,
+      stackInfo.url,
+      stackInfo.lineno,
+      frames,
+      options
+    );
+  },
+
+  _prepareFrames: function(stackInfo, options) {
+    var self = this;
+    var frames = [];
+    if (stackInfo.stack && stackInfo.stack.length) {
+      each(stackInfo.stack, function(i, stack) {
+        var frame = self._normalizeFrame(stack);
+        if (frame) {
+          frames.push(frame);
         }
-        frames = frames.slice(0, this._globalOptions.stackTraceLimit);
-        return frames;
-    },
+      });
 
-
-    _normalizeFrame: function(frame) {
-        if (!frame.url) return;
-
-        // normalize the frames data
-        var normalized = {
-            filename:   frame.url,
-            lineno:     frame.line,
-            colno:      frame.column,
-            'function': frame.func || '?'
-        };
-
-        normalized.in_app = !( // determine if an exception came from outside of our app
-            // first we check the global includePaths list.
-            !!this._globalOptions.includePaths.test && !this._globalOptions.includePaths.test(normalized.filename) ||
-            // Now we check for fun, if the function name is Raven or TraceKit
-            /(Raven|TraceKit)\./.test(normalized['function']) ||
-            // finally, we do a last ditch effort and check for raven.min.js
-            /raven\.(min\.)?js$/.test(normalized.filename)
-        );
-
-        return normalized;
-    },
-
-    _processException: function(type, message, fileurl, lineno, frames, options) {
-        var stacktrace;
-        if (!!this._globalOptions.ignoreErrors.test && this._globalOptions.ignoreErrors.test(message)) return;
-
-        message += '';
-
-        if (frames && frames.length) {
-            fileurl = frames[0].filename || fileurl;
-            // Sentry expects frames oldest to newest
-            // and JS sends them as newest to oldest
-            frames.reverse();
-            stacktrace = {frames: frames};
-        } else if (fileurl) {
-            stacktrace = {
-                frames: [{
-                    filename: fileurl,
-                    lineno: lineno,
-                    in_app: true
-                }]
-            };
+      // e.g. frames captured via captureMessage throw
+      if (options && options.trimHeadFrames) {
+        for (var j = 0; j < options.trimHeadFrames && j < frames.length; j++) {
+          frames[j].in_app = false;
         }
+      }
+    }
+    frames = frames.slice(0, this._globalOptions.stackTraceLimit);
+    return frames;
+  },
 
-        if (!!this._globalOptions.ignoreUrls.test && this._globalOptions.ignoreUrls.test(fileurl)) return;
-        if (!!this._globalOptions.whitelistUrls.test && !this._globalOptions.whitelistUrls.test(fileurl)) return;
+  _normalizeFrame: function(frame) {
+    if (!frame.url) return;
 
-        var data = objectMerge({
-            // sentry.interfaces.Exception
-            exception: {
-                values: [{
-                    type: type,
-                    value: message,
-                    stacktrace: stacktrace
-                }]
-            },
-            culprit: fileurl
-        }, options);
+    // normalize the frames data
+    var normalized = {
+      filename: frame.url,
+      lineno: frame.line,
+      colno: frame.column,
+      function: frame.func || '?'
+    };
 
-        // Fire away!
-        this._send(data);
-    },
+    normalized.in_app = !// determine if an exception came from outside of our app
+    // first we check the global includePaths list.
+    (
+      (!!this._globalOptions.includePaths.test &&
+        !this._globalOptions.includePaths.test(normalized.filename)) ||
+      // Now we check for fun, if the function name is Raven or TraceKit
+      /(Raven|TraceKit)\./.test(normalized['function']) ||
+      // finally, we do a last ditch effort and check for raven.min.js
+      /raven\.(min\.)?js$/.test(normalized.filename)
+    );
 
-    _trimPacket: function(data) {
-        // For now, we only want to truncate the two different messages
-        // but this could/should be expanded to just trim everything
-        var max = this._globalOptions.maxMessageLength;
-        if (data.message) {
-            data.message = truncate(data.message, max);
-        }
-        if (data.exception) {
-            var exception = data.exception.values[0];
-            exception.value = truncate(exception.value, max);
-        }
+    return normalized;
+  },
 
-        var request = data.request;
-        if (request) {
-            if (request.url) {
-                request.url = truncate(request.url, this._globalOptions.maxUrlLength);
+  _processException: function(type, message, fileurl, lineno, frames, options) {
+    var stacktrace;
+    if (
+      !!this._globalOptions.ignoreErrors.test &&
+      this._globalOptions.ignoreErrors.test(message)
+    )
+      return;
+
+    message += '';
+
+    if (frames && frames.length) {
+      fileurl = frames[0].filename || fileurl;
+      // Sentry expects frames oldest to newest
+      // and JS sends them as newest to oldest
+      frames.reverse();
+      stacktrace = {frames: frames};
+    } else if (fileurl) {
+      stacktrace = {
+        frames: [
+          {
+            filename: fileurl,
+            lineno: lineno,
+            in_app: true
+          }
+        ]
+      };
+    }
+
+    if (
+      !!this._globalOptions.ignoreUrls.test &&
+      this._globalOptions.ignoreUrls.test(fileurl)
+    )
+      return;
+    if (
+      !!this._globalOptions.whitelistUrls.test &&
+      !this._globalOptions.whitelistUrls.test(fileurl)
+    )
+      return;
+
+    var data = objectMerge(
+      {
+        // sentry.interfaces.Exception
+        exception: {
+          values: [
+            {
+              type: type,
+              value: message,
+              stacktrace: stacktrace
             }
-            if (request.Referer) {
-                request.Referer = truncate(request.Referer, this._globalOptions.maxUrlLength);
-            }
-        }
+          ]
+        },
+        culprit: fileurl
+      },
+      options
+    );
 
-        if (data.breadcrumbs && data.breadcrumbs.values)
-            this._trimBreadcrumbs(data.breadcrumbs);
+    // Fire away!
+    this._send(data);
+  },
 
-        return data;
-    },
+  _trimPacket: function(data) {
+    // For now, we only want to truncate the two different messages
+    // but this could/should be expanded to just trim everything
+    var max = this._globalOptions.maxMessageLength;
+    if (data.message) {
+      data.message = truncate(data.message, max);
+    }
+    if (data.exception) {
+      var exception = data.exception.values[0];
+      exception.value = truncate(exception.value, max);
+    }
 
-    /**
+    var request = data.request;
+    if (request) {
+      if (request.url) {
+        request.url = truncate(request.url, this._globalOptions.maxUrlLength);
+      }
+      if (request.Referer) {
+        request.Referer = truncate(request.Referer, this._globalOptions.maxUrlLength);
+      }
+    }
+
+    if (data.breadcrumbs && data.breadcrumbs.values)
+      this._trimBreadcrumbs(data.breadcrumbs);
+
+    return data;
+  },
+
+  /**
      * Truncate breadcrumb values (right now just URLs)
      */
-    _trimBreadcrumbs: function (breadcrumbs) {
-        // known breadcrumb properties with urls
-        // TODO: also consider arbitrary prop values that start with (https?)?://
-        var urlProps = ['to', 'from', 'url'],
-            urlProp,
-            crumb,
-            data;
+  _trimBreadcrumbs: function(breadcrumbs) {
+    // known breadcrumb properties with urls
+    // TODO: also consider arbitrary prop values that start with (https?)?://
+    var urlProps = ['to', 'from', 'url'],
+      urlProp,
+      crumb,
+      data;
 
-        for (var i = 0; i < breadcrumbs.values.length; ++i) {
-            crumb = breadcrumbs.values[i];
-            if (!crumb.hasOwnProperty('data') || !isObject(crumb.data) || objectFrozen(crumb.data))
-                continue;
+    for (var i = 0; i < breadcrumbs.values.length; ++i) {
+      crumb = breadcrumbs.values[i];
+      if (
+        !crumb.hasOwnProperty('data') ||
+        !isObject(crumb.data) ||
+        objectFrozen(crumb.data)
+      )
+        continue;
 
-            data = objectMerge({}, crumb.data);
-            for (var j = 0; j < urlProps.length; ++j) {
-                urlProp = urlProps[j];
-                if (data.hasOwnProperty(urlProp) && data[urlProp]) {
-                    data[urlProp] = truncate(data[urlProp], this._globalOptions.maxUrlLength);
-                }
-            }
-            breadcrumbs.values[i].data = data;
+      data = objectMerge({}, crumb.data);
+      for (var j = 0; j < urlProps.length; ++j) {
+        urlProp = urlProps[j];
+        if (data.hasOwnProperty(urlProp) && data[urlProp]) {
+          data[urlProp] = truncate(data[urlProp], this._globalOptions.maxUrlLength);
         }
-    },
+      }
+      breadcrumbs.values[i].data = data;
+    }
+  },
 
-    _getHttpData: function() {
-        if (!this._hasNavigator && !this._hasDocument) return;
-        var httpData = {};
+  _getHttpData: function() {
+    if (!this._hasNavigator && !this._hasDocument) return;
+    var httpData = {};
 
-        if (this._hasNavigator && _navigator.userAgent) {
-            httpData.headers = {
-              'User-Agent': navigator.userAgent
-            };
-        }
+    if (this._hasNavigator && _navigator.userAgent) {
+      httpData.headers = {
+        'User-Agent': navigator.userAgent
+      };
+    }
 
-        if (this._hasDocument) {
-            if (_document.location && _document.location.href) {
-                httpData.url = _document.location.href;
-            }
-            if (_document.referrer) {
-                if (!httpData.headers) httpData.headers = {};
-                httpData.headers.Referer = _document.referrer;
-            }
-        }
+    if (this._hasDocument) {
+      if (_document.location && _document.location.href) {
+        httpData.url = _document.location.href;
+      }
+      if (_document.referrer) {
+        if (!httpData.headers) httpData.headers = {};
+        httpData.headers.Referer = _document.referrer;
+      }
+    }
 
-        return httpData;
-    },
+    return httpData;
+  },
 
-    _resetBackoff: function() {
-        this._backoffDuration = 0;
-        this._backoffStart = null;
-    },
+  _resetBackoff: function() {
+    this._backoffDuration = 0;
+    this._backoffStart = null;
+  },
 
-    _shouldBackoff: function() {
-        return this._backoffDuration && now() - this._backoffStart < this._backoffDuration;
-    },
+  _shouldBackoff: function() {
+    return this._backoffDuration && now() - this._backoffStart < this._backoffDuration;
+  },
 
-    /**
+  /**
      * Returns true if the in-process data payload matches the signature
      * of the previously-sent data
      *
@@ -1441,289 +1571,290 @@ Raven.prototype = {
      *       other old browsers). This can take the form of an "exception"
      *       data object with a single frame (derived from the onerror args).
      */
-    _isRepeatData: function (current) {
-        var last = this._lastData;
+  _isRepeatData: function(current) {
+    var last = this._lastData;
 
-        if (!last ||
-            current.message !== last.message || // defined for captureMessage
-            current.culprit !== last.culprit)   // defined for captureException/onerror
-            return false;
+    if (
+      !last ||
+      current.message !== last.message || // defined for captureMessage
+      current.culprit !== last.culprit // defined for captureException/onerror
+    )
+      return false;
 
-        // Stacktrace interface (i.e. from captureMessage)
-        if (current.stacktrace || last.stacktrace) {
-            return isSameStacktrace(current.stacktrace, last.stacktrace);
-        }
-        // Exception interface (i.e. from captureException/onerror)
-        else if (current.exception || last.exception) {
-            return isSameException(current.exception, last.exception);
-        }
-
-        return true;
-    },
-
-    _setBackoffState: function(request) {
-        // If we are already in a backoff state, don't change anything
-        if (this._shouldBackoff()) {
-            return;
-        }
-
-        var status = request.status;
-
-        // 400 - project_id doesn't exist or some other fatal
-        // 401 - invalid/revoked dsn
-        // 429 - too many requests
-        if (!(status === 400 || status === 401 || status === 429))
-            return;
-
-        var retry;
-        try {
-            // If Retry-After is not in Access-Control-Expose-Headers, most
-            // browsers will throw an exception trying to access it
-            retry = request.getResponseHeader('Retry-After');
-            retry = parseInt(retry, 10) * 1000; // Retry-After is returned in seconds
-        } catch (e) {
-            /* eslint no-empty:0 */
-        }
-
-
-        this._backoffDuration = retry
-            // If Sentry server returned a Retry-After value, use it
-            ? retry
-            // Otherwise, double the last backoff duration (starts at 1 sec)
-            : this._backoffDuration * 2 || 1000;
-
-        this._backoffStart = now();
-    },
-
-    _send: function(data) {
-        var globalOptions = this._globalOptions;
-
-        var baseData = {
-            project: this._globalProject,
-            logger: globalOptions.logger,
-            platform: 'javascript'
-        }, httpData = this._getHttpData();
-
-        if (httpData) {
-            baseData.request = httpData;
-        }
-
-        // HACK: delete `trimHeadFrames` to prevent from appearing in outbound payload
-        if (data.trimHeadFrames) delete data.trimHeadFrames;
-
-        data = objectMerge(baseData, data);
-
-        // Merge in the tags and extra separately since objectMerge doesn't handle a deep merge
-        data.tags = objectMerge(objectMerge({}, this._globalContext.tags), data.tags);
-        data.extra = objectMerge(objectMerge({}, this._globalContext.extra), data.extra);
-
-        // Send along our own collected metadata with extra
-        data.extra['session:duration'] = now() - this._startTime;
-
-        if (this._breadcrumbs && this._breadcrumbs.length > 0) {
-            // intentionally make shallow copy so that additions
-            // to breadcrumbs aren't accidentally sent in this request
-            data.breadcrumbs = {
-                values: [].slice.call(this._breadcrumbs, 0)
-            };
-        }
-
-        // If there are no tags/extra, strip the key from the payload alltogther.
-        if (isEmptyObject(data.tags)) delete data.tags;
-
-        if (this._globalContext.user) {
-            // sentry.interfaces.User
-            data.user = this._globalContext.user;
-        }
-
-        // Include the environment if it's defined in globalOptions
-        if (globalOptions.environment) data.environment = globalOptions.environment;
-
-        // Include the release if it's defined in globalOptions
-        if (globalOptions.release) data.release = globalOptions.release;
-
-        // Include server_name if it's defined in globalOptions
-        if (globalOptions.serverName) data.server_name = globalOptions.serverName;
-
-        if (isFunction(globalOptions.dataCallback)) {
-            data = globalOptions.dataCallback(data) || data;
-        }
-
-        // Why??????????
-        if (!data || isEmptyObject(data)) {
-            return;
-        }
-
-        // Check if the request should be filtered or not
-        if (isFunction(globalOptions.shouldSendCallback) && !globalOptions.shouldSendCallback(data)) {
-            return;
-        }
-
-        // Backoff state: Sentry server previously responded w/ an error (e.g. 429 - too many requests),
-        // so drop requests until "cool-off" period has elapsed.
-        if (this._shouldBackoff()) {
-            this._logDebug('warn', 'Raven dropped error due to backoff: ', data);
-            return;
-        }
-
-        if (typeof globalOptions.sampleRate === 'number') {
-            if (Math.random() < globalOptions.sampleRate) {
-                this._sendProcessedPayload(data);
-            }
-        } else {
-            this._sendProcessedPayload(data);
-        }
-    },
-
-    _getUuid: function () {
-      return uuid4();
-    },
-
-    _sendProcessedPayload: function(data, callback) {
-        var self = this;
-        var globalOptions = this._globalOptions;
-
-        if (!this.isSetup()) return;
-
-        // Send along an event_id if not explicitly passed.
-        // This event_id can be used to reference the error within Sentry itself.
-        // Set lastEventId after we know the error should actually be sent
-        this._lastEventId = data.event_id || (data.event_id = this._getUuid());
-
-        // Try and clean up the packet before sending by truncating long values
-        data = this._trimPacket(data);
-
-        // ideally duplicate error testing should occur *before* dataCallback/shouldSendCallback,
-        // but this would require copying an un-truncated copy of the data packet, which can be
-        // arbitrarily deep (extra_data) -- could be worthwhile? will revisit
-        if (!this._globalOptions.allowDuplicates && this._isRepeatData(data)) {
-            this._logDebug('warn', 'Raven dropped repeat event: ', data);
-            return;
-        }
-
-        // Store outbound payload after trim
-        this._lastData = data;
-
-        this._logDebug('debug', 'Raven about to send:', data);
-
-        var auth = {
-            sentry_version: '7',
-            sentry_client: 'raven-js/' + this.VERSION,
-            sentry_key: this._globalKey
-        };
-        if (this._globalSecret) {
-            auth.sentry_secret = this._globalSecret;
-        }
-
-        var exception = data.exception && data.exception.values[0];
-        this.captureBreadcrumb({
-            category: 'sentry',
-            message: exception
-                ? (exception.type ? exception.type + ': ' : '') + exception.value
-                : data.message,
-            event_id: data.event_id,
-            level: data.level || 'error' // presume error unless specified
-        });
-
-        var url = this._globalEndpoint;
-        (globalOptions.transport || this._makeRequest).call(this, {
-            url: url,
-            auth: auth,
-            data: data,
-            options: globalOptions,
-            onSuccess: function success() {
-                self._resetBackoff();
-
-                self._triggerEvent('success', {
-                    data: data,
-                    src: url
-                });
-                callback && callback();
-            },
-            onError: function failure(error) {
-                self._logDebug('error', 'Raven transport failed to send: ', error);
-
-                if (error.request) {
-                    self._setBackoffState(error.request);
-                }
-
-                self._triggerEvent('failure', {
-                    data: data,
-                    src: url
-                });
-                error = error || new Error('Raven send failed (no additional details provided)');
-                callback && callback(error);
-            }
-        });
-    },
-
-    _makeRequest: function(opts) {
-        var request = new XMLHttpRequest();
-
-        // if browser doesn't support CORS (e.g. IE7), we are out of luck
-        var hasCORS =
-            'withCredentials' in request ||
-            typeof XDomainRequest !== 'undefined';
-
-        if (!hasCORS) return;
-
-        var url = opts.url;
-
-        if ('withCredentials' in request) {
-            request.onreadystatechange = function () {
-                if (request.readyState !== 4) {
-                    return;
-                } else if (request.status === 200) {
-                    opts.onSuccess && opts.onSuccess();
-                } else if (opts.onError) {
-                    var err = new Error('Sentry error code: ' + request.status);
-                    err.request = request;
-                    opts.onError(err);
-                }
-            };
-        } else {
-            request = new XDomainRequest();
-            // xdomainrequest cannot go http -> https (or vice versa),
-            // so always use protocol relative
-            url = url.replace(/^https?:/, '');
-
-            // onreadystatechange not supported by XDomainRequest
-            if (opts.onSuccess) {
-                request.onload = opts.onSuccess;
-            }
-            if (opts.onError) {
-                request.onerror = function () {
-                    var err = new Error('Sentry error code: XDomainRequest');
-                    err.request = request;
-                    opts.onError(err);
-                }
-            }
-        }
-
-        // NOTE: auth is intentionally sent as part of query string (NOT as custom
-        //       HTTP header) so as to avoid preflight CORS requests
-        request.open('POST', url + '?' + urlencode(opts.auth));
-        request.send(stringify(opts.data));
-    },
-
-    _logDebug: function(level) {
-        if (this._originalConsoleMethods[level] && this.debug) {
-            // In IE<10 console methods do not have their own 'apply' method
-            Function.prototype.apply.call(
-                this._originalConsoleMethods[level],
-                this._originalConsole,
-                [].slice.call(arguments, 1)
-            );
-        }
-    },
-
-    _mergeContext: function(key, context) {
-        if (isUndefined(context)) {
-            delete this._globalContext[key];
-        } else {
-            this._globalContext[key] = objectMerge(this._globalContext[key] || {}, context);
-        }
+    // Stacktrace interface (i.e. from captureMessage)
+    if (current.stacktrace || last.stacktrace) {
+      return isSameStacktrace(current.stacktrace, last.stacktrace);
+    } else if (current.exception || last.exception) {
+      // Exception interface (i.e. from captureException/onerror)
+      return isSameException(current.exception, last.exception);
     }
+
+    return true;
+  },
+
+  _setBackoffState: function(request) {
+    // If we are already in a backoff state, don't change anything
+    if (this._shouldBackoff()) {
+      return;
+    }
+
+    var status = request.status;
+
+    // 400 - project_id doesn't exist or some other fatal
+    // 401 - invalid/revoked dsn
+    // 429 - too many requests
+    if (!(status === 400 || status === 401 || status === 429)) return;
+
+    var retry;
+    try {
+      // If Retry-After is not in Access-Control-Expose-Headers, most
+      // browsers will throw an exception trying to access it
+      retry = request.getResponseHeader('Retry-After');
+      retry = parseInt(retry, 10) * 1000; // Retry-After is returned in seconds
+    } catch (e) {
+      /* eslint no-empty:0 */
+    }
+
+    this._backoffDuration = retry
+      ? // If Sentry server returned a Retry-After value, use it
+        retry
+      : // Otherwise, double the last backoff duration (starts at 1 sec)
+        this._backoffDuration * 2 || 1000;
+
+    this._backoffStart = now();
+  },
+
+  _send: function(data) {
+    var globalOptions = this._globalOptions;
+
+    var baseData = {
+        project: this._globalProject,
+        logger: globalOptions.logger,
+        platform: 'javascript'
+      },
+      httpData = this._getHttpData();
+
+    if (httpData) {
+      baseData.request = httpData;
+    }
+
+    // HACK: delete `trimHeadFrames` to prevent from appearing in outbound payload
+    if (data.trimHeadFrames) delete data.trimHeadFrames;
+
+    data = objectMerge(baseData, data);
+
+    // Merge in the tags and extra separately since objectMerge doesn't handle a deep merge
+    data.tags = objectMerge(objectMerge({}, this._globalContext.tags), data.tags);
+    data.extra = objectMerge(objectMerge({}, this._globalContext.extra), data.extra);
+
+    // Send along our own collected metadata with extra
+    data.extra['session:duration'] = now() - this._startTime;
+
+    if (this._breadcrumbs && this._breadcrumbs.length > 0) {
+      // intentionally make shallow copy so that additions
+      // to breadcrumbs aren't accidentally sent in this request
+      data.breadcrumbs = {
+        values: [].slice.call(this._breadcrumbs, 0)
+      };
+    }
+
+    // If there are no tags/extra, strip the key from the payload alltogther.
+    if (isEmptyObject(data.tags)) delete data.tags;
+
+    if (this._globalContext.user) {
+      // sentry.interfaces.User
+      data.user = this._globalContext.user;
+    }
+
+    // Include the environment if it's defined in globalOptions
+    if (globalOptions.environment) data.environment = globalOptions.environment;
+
+    // Include the release if it's defined in globalOptions
+    if (globalOptions.release) data.release = globalOptions.release;
+
+    // Include server_name if it's defined in globalOptions
+    if (globalOptions.serverName) data.server_name = globalOptions.serverName;
+
+    if (isFunction(globalOptions.dataCallback)) {
+      data = globalOptions.dataCallback(data) || data;
+    }
+
+    // Why??????????
+    if (!data || isEmptyObject(data)) {
+      return;
+    }
+
+    // Check if the request should be filtered or not
+    if (
+      isFunction(globalOptions.shouldSendCallback) &&
+      !globalOptions.shouldSendCallback(data)
+    ) {
+      return;
+    }
+
+    // Backoff state: Sentry server previously responded w/ an error (e.g. 429 - too many requests),
+    // so drop requests until "cool-off" period has elapsed.
+    if (this._shouldBackoff()) {
+      this._logDebug('warn', 'Raven dropped error due to backoff: ', data);
+      return;
+    }
+
+    if (typeof globalOptions.sampleRate === 'number') {
+      if (Math.random() < globalOptions.sampleRate) {
+        this._sendProcessedPayload(data);
+      }
+    } else {
+      this._sendProcessedPayload(data);
+    }
+  },
+
+  _getUuid: function() {
+    return uuid4();
+  },
+
+  _sendProcessedPayload: function(data, callback) {
+    var self = this;
+    var globalOptions = this._globalOptions;
+
+    if (!this.isSetup()) return;
+
+    // Send along an event_id if not explicitly passed.
+    // This event_id can be used to reference the error within Sentry itself.
+    // Set lastEventId after we know the error should actually be sent
+    this._lastEventId = data.event_id || (data.event_id = this._getUuid());
+
+    // Try and clean up the packet before sending by truncating long values
+    data = this._trimPacket(data);
+
+    // ideally duplicate error testing should occur *before* dataCallback/shouldSendCallback,
+    // but this would require copying an un-truncated copy of the data packet, which can be
+    // arbitrarily deep (extra_data) -- could be worthwhile? will revisit
+    if (!this._globalOptions.allowDuplicates && this._isRepeatData(data)) {
+      this._logDebug('warn', 'Raven dropped repeat event: ', data);
+      return;
+    }
+
+    // Store outbound payload after trim
+    this._lastData = data;
+
+    this._logDebug('debug', 'Raven about to send:', data);
+
+    var auth = {
+      sentry_version: '7',
+      sentry_client: 'raven-js/' + this.VERSION,
+      sentry_key: this._globalKey
+    };
+    if (this._globalSecret) {
+      auth.sentry_secret = this._globalSecret;
+    }
+
+    var exception = data.exception && data.exception.values[0];
+    this.captureBreadcrumb({
+      category: 'sentry',
+      message: exception
+        ? (exception.type ? exception.type + ': ' : '') + exception.value
+        : data.message,
+      event_id: data.event_id,
+      level: data.level || 'error' // presume error unless specified
+    });
+
+    var url = this._globalEndpoint;
+    (globalOptions.transport || this._makeRequest).call(this, {
+      url: url,
+      auth: auth,
+      data: data,
+      options: globalOptions,
+      onSuccess: function success() {
+        self._resetBackoff();
+
+        self._triggerEvent('success', {
+          data: data,
+          src: url
+        });
+        callback && callback();
+      },
+      onError: function failure(error) {
+        self._logDebug('error', 'Raven transport failed to send: ', error);
+
+        if (error.request) {
+          self._setBackoffState(error.request);
+        }
+
+        self._triggerEvent('failure', {
+          data: data,
+          src: url
+        });
+        error = error || new Error('Raven send failed (no additional details provided)');
+        callback && callback(error);
+      }
+    });
+  },
+
+  _makeRequest: function(opts) {
+    var request = new XMLHttpRequest();
+
+    // if browser doesn't support CORS (e.g. IE7), we are out of luck
+    var hasCORS = 'withCredentials' in request || typeof XDomainRequest !== 'undefined';
+
+    if (!hasCORS) return;
+
+    var url = opts.url;
+
+    if ('withCredentials' in request) {
+      request.onreadystatechange = function() {
+        if (request.readyState !== 4) {
+          return;
+        } else if (request.status === 200) {
+          opts.onSuccess && opts.onSuccess();
+        } else if (opts.onError) {
+          var err = new Error('Sentry error code: ' + request.status);
+          err.request = request;
+          opts.onError(err);
+        }
+      };
+    } else {
+      request = new XDomainRequest();
+      // xdomainrequest cannot go http -> https (or vice versa),
+      // so always use protocol relative
+      url = url.replace(/^https?:/, '');
+
+      // onreadystatechange not supported by XDomainRequest
+      if (opts.onSuccess) {
+        request.onload = opts.onSuccess;
+      }
+      if (opts.onError) {
+        request.onerror = function() {
+          var err = new Error('Sentry error code: XDomainRequest');
+          err.request = request;
+          opts.onError(err);
+        };
+      }
+    }
+
+    // NOTE: auth is intentionally sent as part of query string (NOT as custom
+    //       HTTP header) so as to avoid preflight CORS requests
+    request.open('POST', url + '?' + urlencode(opts.auth));
+    request.send(stringify(opts.data));
+  },
+
+  _logDebug: function(level) {
+    if (this._originalConsoleMethods[level] && this.debug) {
+      // In IE<10 console methods do not have their own 'apply' method
+      Function.prototype.apply.call(
+        this._originalConsoleMethods[level],
+        this._originalConsole,
+        [].slice.call(arguments, 1)
+      );
+    }
+  },
+
+  _mergeContext: function(key, context) {
+    if (isUndefined(context)) {
+      delete this._globalContext[key];
+    } else {
+      this._globalContext[key] = objectMerge(this._globalContext[key] || {}, context);
+    }
+  }
 };
 
 /*------------------------------------------------
@@ -1735,50 +1866,49 @@ Raven.prototype = {
 var objectPrototype = Object.prototype;
 
 function isUndefined(what) {
-    return what === void 0;
+  return what === void 0;
 }
 
 function isFunction(what) {
-    return typeof what === 'function';
+  return typeof what === 'function';
 }
 
 function isString(what) {
-    return objectPrototype.toString.call(what) === '[object String]';
+  return objectPrototype.toString.call(what) === '[object String]';
 }
 
-
 function isEmptyObject(what) {
-    for (var _ in what) return false;  // eslint-disable-line guard-for-in, no-unused-vars
-    return true;
+  for (var _ in what) return false; // eslint-disable-line guard-for-in, no-unused-vars
+  return true;
 }
 
 function each(obj, callback) {
-    var i, j;
+  var i, j;
 
-    if (isUndefined(obj.length)) {
-        for (i in obj) {
-            if (hasKey(obj, i)) {
-                callback.call(null, i, obj[i]);
-            }
-        }
-    } else {
-        j = obj.length;
-        if (j) {
-            for (i = 0; i < j; i++) {
-                callback.call(null, i, obj[i]);
-            }
-        }
+  if (isUndefined(obj.length)) {
+    for (i in obj) {
+      if (hasKey(obj, i)) {
+        callback.call(null, i, obj[i]);
+      }
     }
+  } else {
+    j = obj.length;
+    if (j) {
+      for (i = 0; i < j; i++) {
+        callback.call(null, i, obj[i]);
+      }
+    }
+  }
 }
 
 function objectMerge(obj1, obj2) {
-    if (!obj2) {
-        return obj1;
-    }
-    each(obj2, function(key, value){
-        obj1[key] = value;
-    });
+  if (!obj2) {
     return obj1;
+  }
+  each(obj2, function(key, value) {
+    obj1[key] = value;
+  });
+  return obj1;
 }
 
 /**
@@ -1790,14 +1920,14 @@ function objectMerge(obj1, obj2) {
  * https://github.com/getsentry/react-native-sentry/issues/57
  */
 function objectFrozen(obj) {
-    if (!Object.isFrozen) {
-        return false;
-    }
-    return Object.isFrozen(obj);
+  if (!Object.isFrozen) {
+    return false;
+  }
+  return Object.isFrozen(obj);
 }
 
 function truncate(str, max) {
-    return !max || str.length <= max ? str : str.substr(0, max) + '\u2026';
+  return !max || str.length <= max ? str : str.substr(0, max) + '\u2026';
 }
 
 /**
@@ -1808,88 +1938,97 @@ function truncate(str, max) {
  * @param {string} key to check
  */
 function hasKey(object, key) {
-    return objectPrototype.hasOwnProperty.call(object, key);
+  return objectPrototype.hasOwnProperty.call(object, key);
 }
 
 function joinRegExp(patterns) {
-    // Combine an array of regular expressions and strings into one large regexp
-    // Be mad.
-    var sources = [],
-        i = 0, len = patterns.length,
-        pattern;
+  // Combine an array of regular expressions and strings into one large regexp
+  // Be mad.
+  var sources = [],
+    i = 0,
+    len = patterns.length,
+    pattern;
 
-    for (; i < len; i++) {
-        pattern = patterns[i];
-        if (isString(pattern)) {
-            // If it's a string, we need to escape it
-            // Taken from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
-            sources.push(pattern.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1'));
-        } else if (pattern && pattern.source) {
-            // If it's a regexp already, we want to extract the source
-            sources.push(pattern.source);
-        }
-        // Intentionally skip other cases
+  for (; i < len; i++) {
+    pattern = patterns[i];
+    if (isString(pattern)) {
+      // If it's a string, we need to escape it
+      // Taken from: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions
+      sources.push(pattern.replace(/([.*+?^=!:${}()|\[\]\/\\])/g, '\\$1'));
+    } else if (pattern && pattern.source) {
+      // If it's a regexp already, we want to extract the source
+      sources.push(pattern.source);
     }
-    return new RegExp(sources.join('|'), 'i');
+    // Intentionally skip other cases
+  }
+  return new RegExp(sources.join('|'), 'i');
 }
 
 function urlencode(o) {
-    var pairs = [];
-    each(o, function(key, value) {
-        pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
-    });
-    return pairs.join('&');
+  var pairs = [];
+  each(o, function(key, value) {
+    pairs.push(encodeURIComponent(key) + '=' + encodeURIComponent(value));
+  });
+  return pairs.join('&');
 }
 
 // borrowed from https://tools.ietf.org/html/rfc3986#appendix-B
 // intentionally using regex and not <a/> href parsing trick because React Native and other
 // environments where DOM might not be available
 function parseUrl(url) {
-    var match = url.match(/^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$/);
-    if (!match) return {};
+  var match = url.match(/^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$/);
+  if (!match) return {};
 
-    // coerce to undefined values to empty string so we don't get 'undefined'
-    var query = match[6] || '';
-    var fragment = match[8] || '';
-    return {
-        protocol: match[2],
-        host: match[4],
-        path: match[5],
-        relative: match[5] + query + fragment // everything minus origin
-    };
+  // coerce to undefined values to empty string so we don't get 'undefined'
+  var query = match[6] || '';
+  var fragment = match[8] || '';
+  return {
+    protocol: match[2],
+    host: match[4],
+    path: match[5],
+    relative: match[5] + query + fragment // everything minus origin
+  };
 }
 function uuid4() {
-    var crypto = _window.crypto || _window.msCrypto;
+  var crypto = _window.crypto || _window.msCrypto;
 
-    if (!isUndefined(crypto) && crypto.getRandomValues) {
-        // Use window.crypto API if available
-        // eslint-disable-next-line no-undef
-        var arr = new Uint16Array(8);
-        crypto.getRandomValues(arr);
+  if (!isUndefined(crypto) && crypto.getRandomValues) {
+    // Use window.crypto API if available
+    // eslint-disable-next-line no-undef
+    var arr = new Uint16Array(8);
+    crypto.getRandomValues(arr);
 
-        // set 4 in byte 7
-        arr[3] = arr[3] & 0xFFF | 0x4000;
-        // set 2 most significant bits of byte 9 to '10'
-        arr[4] = arr[4] & 0x3FFF | 0x8000;
+    // set 4 in byte 7
+    arr[3] = (arr[3] & 0xfff) | 0x4000;
+    // set 2 most significant bits of byte 9 to '10'
+    arr[4] = (arr[4] & 0x3fff) | 0x8000;
 
-        var pad = function(num) {
-            var v = num.toString(16);
-            while (v.length < 4) {
-                v = '0' + v;
-            }
-            return v;
-        };
+    var pad = function(num) {
+      var v = num.toString(16);
+      while (v.length < 4) {
+        v = '0' + v;
+      }
+      return v;
+    };
 
-        return pad(arr[0]) + pad(arr[1]) + pad(arr[2]) + pad(arr[3]) + pad(arr[4]) +
-        pad(arr[5]) + pad(arr[6]) + pad(arr[7]);
-    } else {
-        // http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/2117523#2117523
-        return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-            var r = Math.random()*16|0,
-                v = c === 'x' ? r : r&0x3|0x8;
-            return v.toString(16);
-        });
-    }
+    return (
+      pad(arr[0]) +
+      pad(arr[1]) +
+      pad(arr[2]) +
+      pad(arr[3]) +
+      pad(arr[4]) +
+      pad(arr[5]) +
+      pad(arr[6]) +
+      pad(arr[7])
+    );
+  } else {
+    // http://stackoverflow.com/questions/105034/how-to-create-a-guid-uuid-in-javascript/2117523#2117523
+    return 'xxxxxxxxxxxx4xxxyxxxxxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
+      var r = (Math.random() * 16) | 0,
+        v = c === 'x' ? r : (r & 0x3) | 0x8;
+      return v.toString(16);
+    });
+  }
 }
 
 /**
@@ -1900,34 +2039,36 @@ function uuid4() {
  * @returns {string}
  */
 function htmlTreeAsString(elem) {
-    /* eslint no-extra-parens:0*/
-    var MAX_TRAVERSE_HEIGHT = 5,
-        MAX_OUTPUT_LEN = 80,
-        out = [],
-        height = 0,
-        len = 0,
-        separator = ' > ',
-        sepLength = separator.length,
-        nextStr;
+  /* eslint no-extra-parens:0*/
+  var MAX_TRAVERSE_HEIGHT = 5,
+    MAX_OUTPUT_LEN = 80,
+    out = [],
+    height = 0,
+    len = 0,
+    separator = ' > ',
+    sepLength = separator.length,
+    nextStr;
 
-    while (elem && height++ < MAX_TRAVERSE_HEIGHT) {
-
-        nextStr = htmlElementAsString(elem);
-        // bail out if
-        // - nextStr is the 'html' element
-        // - the length of the string that would be created exceeds MAX_OUTPUT_LEN
-        //   (ignore this limit if we are on the first iteration)
-        if (nextStr === 'html' || height > 1 && len + (out.length * sepLength) + nextStr.length >= MAX_OUTPUT_LEN) {
-            break;
-        }
-
-        out.push(nextStr);
-
-        len += nextStr.length;
-        elem = elem.parentNode;
+  while (elem && height++ < MAX_TRAVERSE_HEIGHT) {
+    nextStr = htmlElementAsString(elem);
+    // bail out if
+    // - nextStr is the 'html' element
+    // - the length of the string that would be created exceeds MAX_OUTPUT_LEN
+    //   (ignore this limit if we are on the first iteration)
+    if (
+      nextStr === 'html' ||
+      (height > 1 && len + out.length * sepLength + nextStr.length >= MAX_OUTPUT_LEN)
+    ) {
+      break;
     }
 
-    return out.reverse().join(separator);
+    out.push(nextStr);
+
+    len += nextStr.length;
+    elem = elem.parentNode;
+  }
+
+  return out.reverse().join(separator);
 }
 
 /**
@@ -1937,90 +2078,87 @@ function htmlTreeAsString(elem) {
  * @returns {string}
  */
 function htmlElementAsString(elem) {
-    var out = [],
-        className,
-        classes,
-        key,
-        attr,
-        i;
+  var out = [],
+    className,
+    classes,
+    key,
+    attr,
+    i;
 
-    if (!elem || !elem.tagName) {
-        return '';
-    }
+  if (!elem || !elem.tagName) {
+    return '';
+  }
 
-    out.push(elem.tagName.toLowerCase());
-    if (elem.id) {
-        out.push('#' + elem.id);
-    }
+  out.push(elem.tagName.toLowerCase());
+  if (elem.id) {
+    out.push('#' + elem.id);
+  }
 
-    className = elem.className;
-    if (className && isString(className)) {
-        classes = className.split(/\s+/);
-        for (i = 0; i < classes.length; i++) {
-            out.push('.' + classes[i]);
-        }
+  className = elem.className;
+  if (className && isString(className)) {
+    classes = className.split(/\s+/);
+    for (i = 0; i < classes.length; i++) {
+      out.push('.' + classes[i]);
     }
-    var attrWhitelist = ['type', 'name', 'title', 'alt'];
-    for (i = 0; i < attrWhitelist.length; i++) {
-        key = attrWhitelist[i];
-        attr = elem.getAttribute(key);
-        if (attr) {
-            out.push('[' + key + '="' + attr + '"]');
-        }
+  }
+  var attrWhitelist = ['type', 'name', 'title', 'alt'];
+  for (i = 0; i < attrWhitelist.length; i++) {
+    key = attrWhitelist[i];
+    attr = elem.getAttribute(key);
+    if (attr) {
+      out.push('[' + key + '="' + attr + '"]');
     }
-    return out.join('');
+  }
+  return out.join('');
 }
 
 /**
  * Returns true if either a OR b is truthy, but not both
  */
 function isOnlyOneTruthy(a, b) {
-    return !!(!!a ^ !!b);
+  return !!(!!a ^ !!b);
 }
 
 /**
  * Returns true if the two input exception interfaces have the same content
  */
 function isSameException(ex1, ex2) {
-    if (isOnlyOneTruthy(ex1, ex2))
-        return false;
+  if (isOnlyOneTruthy(ex1, ex2)) return false;
 
-    ex1 = ex1.values[0];
-    ex2 = ex2.values[0];
+  ex1 = ex1.values[0];
+  ex2 = ex2.values[0];
 
-    if (ex1.type !== ex2.type ||
-        ex1.value !== ex2.value)
-        return false;
+  if (ex1.type !== ex2.type || ex1.value !== ex2.value) return false;
 
-    return isSameStacktrace(ex1.stacktrace, ex2.stacktrace);
+  return isSameStacktrace(ex1.stacktrace, ex2.stacktrace);
 }
 
 /**
  * Returns true if the two input stack trace interfaces have the same content
  */
 function isSameStacktrace(stack1, stack2) {
-    if (isOnlyOneTruthy(stack1, stack2))
-        return false;
+  if (isOnlyOneTruthy(stack1, stack2)) return false;
 
-    var frames1 = stack1.frames;
-    var frames2 = stack2.frames;
+  var frames1 = stack1.frames;
+  var frames2 = stack2.frames;
 
-    // Exit early if frame count differs
-    if (frames1.length !== frames2.length)
-        return false;
+  // Exit early if frame count differs
+  if (frames1.length !== frames2.length) return false;
 
-    // Iterate through every frame; bail out if anything differs
-    var a, b;
-    for (var i = 0; i < frames1.length; i++) {
-        a = frames1[i];
-        b = frames2[i];
-        if (a.filename !== b.filename ||
-            a.lineno !== b.lineno ||
-            a.colno !== b.colno ||
-            a['function'] !== b['function'])
-            return false;
-    }
-    return true;
+  // Iterate through every frame; bail out if anything differs
+  var a, b;
+  for (var i = 0; i < frames1.length; i++) {
+    a = frames1[i];
+    b = frames2[i];
+    if (
+      a.filename !== b.filename ||
+      a.lineno !== b.lineno ||
+      a.colno !== b.colno ||
+      a['function'] !== b['function']
+    )
+      return false;
+  }
+  return true;
 }
 
 /**
@@ -2031,34 +2169,34 @@ function isSameStacktrace(stack1, stack2) {
  * @param track {optional} record instrumentation to an array
  */
 function fill(obj, name, replacement, track) {
-    var orig = obj[name];
-    obj[name] = replacement(orig);
-    if (track) {
-        track.push([obj, name, orig]);
-    }
+  var orig = obj[name];
+  obj[name] = replacement(orig);
+  if (track) {
+    track.push([obj, name, orig]);
+  }
 }
 
 if (typeof __DEV__ !== 'undefined' && __DEV__) {
-    Raven.utils = {
-        isUndefined: isUndefined,
-        isFunction: isFunction,
-        isString: isString,
-        isObject: isObject,
-        isEmptyObject: isEmptyObject,
-        isError: isError,
-        each: each,
-        objectMerge: objectMerge,
-        truncate: truncate,
-        hasKey: hasKey,
-        joinRegExp: joinRegExp,
-        urlencode: urlencode,
-        uuid4: uuid4,
-        htmlTreeAsString: htmlTreeAsString,
-        htmlElementAsString: htmlElementAsString,
-        parseUrl: parseUrl,
-        fill: fill
-    };
-};
+  Raven.utils = {
+    isUndefined: isUndefined,
+    isFunction: isFunction,
+    isString: isString,
+    isObject: isObject,
+    isEmptyObject: isEmptyObject,
+    isError: isError,
+    each: each,
+    objectMerge: objectMerge,
+    truncate: truncate,
+    hasKey: hasKey,
+    joinRegExp: joinRegExp,
+    urlencode: urlencode,
+    uuid4: uuid4,
+    htmlTreeAsString: htmlTreeAsString,
+    htmlElementAsString: htmlElementAsString,
+    parseUrl: parseUrl,
+    fill: fill
+  };
+}
 
 // Deprecations
 Raven.prototype.setUser = Raven.prototype.setUserContext;

--- a/src/singleton.js
+++ b/src/singleton.js
@@ -9,10 +9,10 @@
 var RavenConstructor = require('./raven');
 
 // This is to be defensive in environments where window does not exist (see https://github.com/getsentry/raven-js/pull/785)
-var _window = typeof window !== 'undefined' ? window
-            : typeof global !== 'undefined' ? global
-            : typeof self !== 'undefined' ? self
-            : {};
+var _window =
+  typeof window !== 'undefined'
+    ? window
+    : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 var _Raven = _window.Raven;
 
 var Raven = new RavenConstructor();
@@ -23,9 +23,9 @@ var Raven = new RavenConstructor();
  *
  * @return {Raven}
  */
-Raven.noConflict = function () {
-	_window.Raven = _Raven;
-	return Raven;
+Raven.noConflict = function() {
+  _window.Raven = _Raven;
+  return Raven;
 };
 
 Raven.afterLoad();

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,34 +1,38 @@
 'use strict';
 
 function isObject(what) {
-    return typeof what === 'object' && what !== null;
+  return typeof what === 'object' && what !== null;
 }
 
 // Yanked from https://git.io/vS8DV re-used under CC0
 // with some tiny modifications
 function isError(value) {
   switch ({}.toString.call(value)) {
-    case '[object Error]': return true;
-    case '[object Exception]': return true;
-    case '[object DOMException]': return true;
-    default: return value instanceof Error;
+    case '[object Error]':
+      return true;
+    case '[object Exception]':
+      return true;
+    case '[object DOMException]':
+      return true;
+    default:
+      return value instanceof Error;
   }
 }
 
 function wrappedCallback(callback) {
-    function dataCallback(data, original) {
-      var normalizedData = callback(data) || data;
-      if (original) {
-          return original(normalizedData) || normalizedData;
-      }
-      return normalizedData;
+  function dataCallback(data, original) {
+    var normalizedData = callback(data) || data;
+    if (original) {
+      return original(normalizedData) || normalizedData;
     }
+    return normalizedData;
+  }
 
-    return dataCallback;
+  return dataCallback;
 }
 
 module.exports = {
-    isObject: isObject,
-    isError: isError,
-    wrappedCallback: wrappedCallback
+  isObject: isObject,
+  isError: isError,
+  wrappedCallback: wrappedCallback
 };

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -1,1144 +1,1430 @@
 /*global assert*/
 function iframeExecute(iframe, done, execute, assertCallback) {
-    iframe.contentWindow.done = function () {
-        try {
-            assertCallback(iframe);
-            done();
-        } catch (e) {
-            done(e);
-        }
-    };
-    // use setTimeout so stack trace doesn't go all the way back to mocha test runner
-    iframe.contentWindow.eval('window.originalBuiltIns.setTimeout.call(window, ' + execute.toString() + ');');
+  iframe.contentWindow.done = function() {
+    try {
+      assertCallback(iframe);
+      done();
+    } catch (e) {
+      done(e);
+    }
+  };
+  // use setTimeout so stack trace doesn't go all the way back to mocha test runner
+  iframe.contentWindow.eval(
+    'window.originalBuiltIns.setTimeout.call(window, ' + execute.toString() + ');'
+  );
 }
 
 function createIframe(done) {
-    var iframe = document.createElement('iframe');
-    iframe.style.display = 'none';
-    iframe.src = './frame.html';
-    iframe.onload = function () {
-        done();
-    };
-    document.body.appendChild(iframe);
-    return iframe;
+  var iframe = document.createElement('iframe');
+  iframe.style.display = 'none';
+  iframe.src = './frame.html';
+  iframe.onload = function() {
+    done();
+  };
+  document.body.appendChild(iframe);
+  return iframe;
 }
 
 var anchor = document.createElement('a');
 function parseUrl(url) {
-    var out = {pathname: '', origin: '', protocol: ''};
-    if (!url)
-    anchor.href = url;
-    for (var key in out) {
-        out[key] = anchor[key];
-    }
-    return out;
+  var out = {pathname: '', origin: '', protocol: ''};
+  if (!url) anchor.href = url;
+  for (var key in out) {
+    out[key] = anchor[key];
+  }
+  return out;
 }
 
-describe('integration', function () {
+describe('integration', function() {
+  beforeEach(function(done) {
+    this.iframe = createIframe(done);
+  });
 
-    beforeEach(function (done) {
-        this.iframe = createIframe(done);
+  afterEach(function() {
+    document.body.removeChild(this.iframe);
+  });
+
+  describe('API', function() {
+    it('should capture Raven.captureMessage', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          Raven.captureMessage('Hello');
+          done();
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.equal(ravenData.message, 'Hello');
+        }
+      );
     });
 
-    afterEach(function () {
-        document.body.removeChild(this.iframe);
+    it('should capture Raven.captureException', function(done) {
+      var iframe = this.iframe;
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          try {
+            foo();
+          } catch (e) {
+            Raven.captureException(e);
+          }
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 1);
+        }
+      );
     });
 
-    describe('API', function () {
-        it('should capture Raven.captureMessage', function (done) {
-            var iframe = this.iframe;
+    it('should generate a synthetic trace for captureException w/ non-errors', function(
+      done
+    ) {
+      var iframe = this.iframe;
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
 
-            iframeExecute(iframe, done,
-                function () {
-                    Raven.captureMessage('Hello');
-                    done();
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.equal(ravenData.message, 'Hello');
-                }
-            );
-        });
+          Raven.captureException({foo: 'bar'});
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.isAbove(ravenData.stacktrace.frames.length, 1);
 
-        it('should capture Raven.captureException', function (done) {
-            var iframe = this.iframe;
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    try {
-                        foo();
-                    } catch (e) {
-                        Raven.captureException(e);
-                    }
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 1);
-                }
-            );
-        });
-
-        it('should generate a synthetic trace for captureException w/ non-errors', function (done) {
-            var iframe = this.iframe;
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    Raven.captureException({foo:'bar'});
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.isAbove(ravenData.stacktrace.frames.length, 1);
-
-                    // verify trimHeadFrames hasn't slipped into final payload
-                    assert.isUndefined(ravenData.trimHeadFrames);
-                }
-            );
-        });
-
-        it('should capture an Error object passed to Raven.captureException w/ maxMessageLength set (#647)', function (done) {
-            var iframe = this.iframe;
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    Raven._globalOptions.maxMessageLength = 100;
-                    Raven.captureException(new Error('lol'), {
-                      level: 'warning',
-                      extra: {
-                        foo: 'bar'
-                      }
-                    });
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.equal(ravenData.exception.values[0].type, 'Error');
-                    assert.equal(ravenData.exception.values[0].value, 'lol');
-                    assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1);
-                }
-            );
-        });
-
-        it('should reject duplicate, back-to-back errors from captureError', function (done) {
-            var iframe = this.iframe;
-            iframeExecute(iframe, done,
-                function () {
-                    Raven._breadcrumbs = [];
-
-                    var count = 5;
-                    setTimeout(function invoke() {
-                        // use setTimeout to capture new error objects that have
-                        // identical stack traces (can't call sequentially or callsite
-                        // line number will change)
-                        //
-                        // order:
-                        //   Error: foo
-                        //   Error: foo (suppressed)
-                        //   Error: foo (suppressed)
-                        //   Error: bar
-                        //   Error: foo
-                        if (count === 2) {
-                            Raven.captureException(new Error('bar'));
-                        }
-                        else {
-                            Raven.captureException(new Error('foo'));
-                        }
-
-                        if (count-- === 0) return void done();
-                        else setTimeout(invoke);
-                    });
-                },
-                function () {
-                    var breadcrumbs = iframe.contentWindow.Raven._breadcrumbs;
-                    // use breadcrumbs to evaluate which errors were sent
-                    // NOTE: can't use ravenData because duplicate error suppression occurs
-                    //       AFTER dataCallback/shouldSendCallback (dataCallback will record
-                    //       duplicates but they ultimately won't be sent)
-                    assert.equal(breadcrumbs.length, 3);
-                    assert.equal(breadcrumbs[0].message, 'Error: foo');
-                    assert.equal(breadcrumbs[1].message, 'Error: bar');
-                    assert.equal(breadcrumbs[2].message, 'Error: foo');
-                }
-            );
-        });
-
-        it('should not reject back-to-back errors with different stack traces', function (done) {
-            var iframe = this.iframe;
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-                    Raven._breadcrumbs = [];
-
-                    // same error message, but different stacks means that these are considered
-                    // different errors
-                    // NOTE: PhantomJS can't derive function/lineno/colno from evaled frames, must
-                    //       use frames declared in frame.html (foo(), bar())
-
-                    // stack:
-                    //   bar
-                    try {
-                        bar(); // declared in frame.html
-                    } catch (e) {
-                        Raven.captureException(e);
-                    }
-
-                    // stack (different # frames):
-                    //   bar
-                    //   foo
-                    try {
-                        foo(); // declared in frame.html
-                    } catch (e) {
-                        Raven.captureException(e);
-                    }
-
-                    // stack (same # frames, different frames):
-                    //   bar
-                    //   foo2
-                    try {
-                        foo2(); // declared in frame.html
-                    } catch (e) {
-                        Raven.captureException(e);
-                    }
-                },
-                function () {
-                    var breadcrumbs = iframe.contentWindow.Raven._breadcrumbs;
-                    assert.equal(breadcrumbs.length, 3);
-                    // NOTE: regex because exact error message differs per-browser
-                    assert.match(breadcrumbs[0].message, /^ReferenceError.*baz/);
-                    assert.match(breadcrumbs[1].message, /^ReferenceError.*baz/);
-                    assert.match(breadcrumbs[2].message, /^ReferenceError.*baz/);
-                }
-            );
-        });
-
-        it('should reject duplicate, back-to-back messages from captureMessage', function (done) {
-            var iframe = this.iframe;
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    Raven._breadcrumbs = [];
-
-                    Raven.captureMessage('this is fine');
-                    Raven.captureMessage('this is fine'); // suppressed
-                    Raven.captureMessage('this is fine', { stacktrace: true });
-                    Raven.captureMessage('i\'m okay with the events that are unfolding currently');
-                    Raven.captureMessage('that\'s okay, things are going to be okay');
-                },
-                function () {
-                    var breadcrumbs = iframe.contentWindow.Raven._breadcrumbs;
-
-                    assert.equal(breadcrumbs.length, 4);
-                    assert.equal(breadcrumbs[0].message, 'this is fine');
-                    assert.equal(breadcrumbs[1].message, 'this is fine'); // with stacktrace
-                    assert.equal(breadcrumbs[2].message, 'i\'m okay with the events that are unfolding currently');
-                    assert.equal(breadcrumbs[3].message, 'that\'s okay, things are going to be okay');
-                }
-            );
-        });
+          // verify trimHeadFrames hasn't slipped into final payload
+          assert.isUndefined(ravenData.trimHeadFrames);
+        }
+      );
     });
 
-    describe('window.onerror', function () {
-        it('should catch syntax errors', function (done) {
-            var iframe = this.iframe;
+    it('should capture an Error object passed to Raven.captureException w/ maxMessageLength set (#647)', function(
+      done
+    ) {
+      var iframe = this.iframe;
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
 
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-                    eval('foo{};');
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.isTrue(/SyntaxError/.test(ravenData.exception.values[0].type)); // full message differs per-browser
-                    assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1); // just one frame
-                }
-            );
-        });
-
-        it('should catch thrown strings', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    // intentionally loading this error via a script file to make
-                    // sure it is 1) not caught by instrumentation 2) doesn't trigger
-                    // "Script error"
-                    var script = document.createElement('script');
-                    script.src = 'throw-string.js';
-                    script.onload = function () {
-                        done();
-                    };
-                    document.head.appendChild(script);
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.match(ravenData.exception.values[0].value, /stringError$/);
-                    assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1);  // always 1 because thrown strings can't provide > 1 frame
-
-                    // some browsers extract proper url, line, and column for thrown strings
-                    // but not all - falls back to frame url
-                    assert.match(ravenData.exception.values[0].stacktrace.frames[0].filename, /\/test\/integration\//);
-                    assert.match(ravenData.exception.values[0].stacktrace.frames[0]['function'], /\?|global code/);
-                }
-            );
-        });
-
-        it('should catch thrown objects', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    // intentionally loading this error via a script file to make
-                    // sure it is 1) not caught by instrumentation 2) doesn't trigger
-                    // "Script error"
-                    var script = document.createElement('script');
-                    script.src = 'throw-object.js';
-                    script.onload = function () {
-                        done();
-                    };
-                    document.head.appendChild(script);
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.equal(ravenData.exception.values[0].type, undefined);
-                    assert.equal(ravenData.exception.values[0].value, '[object Object]');
-                    assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1); // always 1 because thrown objects can't provide > 1 frame
-
-                    // some browsers extract proper url, line, and column for thrown objects
-                    // but not all - falls back to frame url
-                    assert.match(ravenData.exception.values[0].stacktrace.frames[0].filename, /\/test\/integration\//);
-                    assert.match(ravenData.exception.values[0].stacktrace.frames[0]['function'], /\?|global code/);
-                }
-            );
-        });
-
-        it('should catch thrown errors', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    // intentionally loading this error via a script file to make
-                    // sure it is 1) not caught by instrumentation 2) doesn't trigger
-                    // "Script error"
-                    var script = document.createElement('script');
-                    script.src = 'throw-error.js';
-                    script.onload = function () {
-                        done();
-                    };
-                    document.head.appendChild(script);
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.match(ravenData.exception.values[0].type, /^Error/);
-                    assert.match(ravenData.exception.values[0].value, /realError$/);
-                    assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 0); // 1 or 2 depending on platform
-                    assert.match(ravenData.exception.values[0].stacktrace.frames[0].filename, /\/test\/integration\/throw-error\.js/)
-                    assert.match(ravenData.exception.values[0].stacktrace.frames[0]['function'], /\?|global code/);
-                }
-            );
-        });
-
-        it('should NOT catch an exception already caught via Raven.wrap', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-                    Raven.wrap(function () {
-                        foo();
-                    })();
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData;
-                    assert.equal(ravenData.length, 1); // one caught error
-                }
-            );
-        });
-
-        it('should catch an exception already caught [but rethrown] via Raven.captureException', function (done) {
-            // unlike Raven.wrap which ALWAYS re-throws, we don't know if the user will
-            // re-throw an exception passed to Raven.captureException, and so we cannot
-            // automatically suppress the next error caught through window.onerror
-            var iframe = this.iframe;
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-                    try {
-                        foo();
-                    } catch (e) {
-                        Raven.captureException(e);
-                        throw e; // intentionally re-throw
-                    }
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData;
-                    assert.equal(ravenData.length, 2);
-                }
-            );
-        });
+          Raven._globalOptions.maxMessageLength = 100;
+          Raven.captureException(new Error('lol'), {
+            level: 'warning',
+            extra: {
+              foo: 'bar'
+            }
+          });
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.equal(ravenData.exception.values[0].type, 'Error');
+          assert.equal(ravenData.exception.values[0].value, 'lol');
+          assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1);
+        }
+      );
     });
 
-    describe('wrapped built-ins', function () {
-        it('should capture exceptions from event listeners', function (done) {
-            var iframe = this.iframe;
+    it('should reject duplicate, back-to-back errors from captureError', function(done) {
+      var iframe = this.iframe;
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          Raven._breadcrumbs = [];
 
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
+          var count = 5;
+          setTimeout(function invoke() {
+            // use setTimeout to capture new error objects that have
+            // identical stack traces (can't call sequentially or callsite
+            // line number will change)
+            //
+            // order:
+            //   Error: foo
+            //   Error: foo (suppressed)
+            //   Error: foo (suppressed)
+            //   Error: bar
+            //   Error: foo
+            if (count === 2) {
+              Raven.captureException(new Error('bar'));
+            } else {
+              Raven.captureException(new Error('foo'));
+            }
 
-                    var div = document.createElement('div');
-                    document.body.appendChild(div);
-                    div.addEventListener('click', function () {
-                        foo();
-                    }, false);
-
-                    var evt;
-                    if (document.createEvent) {
-                        evt = document.createEvent('MouseEvents');
-                        evt.initEvent('click', true, false);
-                        div.dispatchEvent(evt);
-                    } else if(document.createEventObject) {
-                        div.fireEvent('onclick');
-                    }
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
-                }
-            );
-        });
-
-        it('should transparently remove event listeners from wrapped functions', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-              function () {
-                  setTimeout(done);
-
-                  var div = document.createElement('div');
-                  document.body.appendChild(div);
-                  var fooFn = function () { foo(); };
-                  div.addEventListener('click', fooFn, false);
-                  div.removeEventListener('click', fooFn);
-
-                  var evt;
-                  if (document.createEvent) {
-                      evt = document.createEvent('MouseEvents');
-                      evt.initEvent('click', true, false);
-                      div.dispatchEvent(evt);
-                  } else if(document.createEventObject) {
-                      div.fireEvent('onclick');
-                  }
-              },
-              function () {
-                  var ravenData = iframe.contentWindow.ravenData[0];
-                  assert.equal(ravenData, null); // should never trigger error
-              }
-            );
-        });
-
-        it('should capture exceptions inside setTimeout', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(function () {
-                        setTimeout(done);
-                        foo();
-                    }, 10);
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
-                }
-            );
-        });
-
-        it('should capture exceptions inside setInterval', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    var exceptionInterval = setInterval(function () {
-                        setTimeout(done);
-                        clearInterval(exceptionInterval);
-                        foo();
-                    }, 10);
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
-                }
-            );
-        });
-
-        it('should capture exceptions inside requestAnimationFrame', function (done) {
-            var iframe = this.iframe;
-            // needs to be visible or requestAnimationFrame won't ever fire
-            iframe.style.display = 'block';
-
-            iframeExecute(iframe, done,
-                function () {
-                    requestAnimationFrame(function () {
-                        setTimeout(done);
-                        foo();
-                    });
-                },
-                function () {
-                    var ravenData = iframe.contentWindow.ravenData[0];
-                    assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
-                }
-            );
-        });
-
-        it('should capture exceptions from XMLHttpRequest event handlers (e.g. onreadystatechange)', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-              function () {
-                  var xhr = new XMLHttpRequest();
-
-                  // intentionally assign event handlers *after* XMLHttpRequest.prototype.open,
-                  // since this is what jQuery does
-                  // https://github.com/jquery/jquery/blob/master/src/ajax/xhr.js#L37
-
-                  xhr.open('GET', 'example.json');
-                  xhr.onreadystatechange = function () {
-                      setTimeout(done);
-                      // replace onreadystatechange with no-op so exception doesn't
-                      // fire more than once as XHR changes loading state
-                      xhr.onreadystatechange = function () {};
-                      foo();
-                  };
-                  xhr.send();
-              },
-              function () {
-                  var ravenData = iframe.contentWindow.ravenData[0];
-                  // # of frames alter significantly between chrome/firefox & safari
-                  assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
-              }
-            );
-        });
+            if (count-- === 0) return void done();
+            else setTimeout(invoke);
+          });
+        },
+        function() {
+          var breadcrumbs = iframe.contentWindow.Raven._breadcrumbs;
+          // use breadcrumbs to evaluate which errors were sent
+          // NOTE: can't use ravenData because duplicate error suppression occurs
+          //       AFTER dataCallback/shouldSendCallback (dataCallback will record
+          //       duplicates but they ultimately won't be sent)
+          assert.equal(breadcrumbs.length, 3);
+          assert.equal(breadcrumbs[0].message, 'Error: foo');
+          assert.equal(breadcrumbs[1].message, 'Error: bar');
+          assert.equal(breadcrumbs[2].message, 'Error: foo');
+        }
+      );
     });
 
-    describe('breadcrumbs', function () {
-
-        it('should record an XMLHttpRequest', function (done) {
-           var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-              function () {
-                  // some browsers trigger onpopstate for load / reset breadcrumb state
-                  Raven._breadcrumbs = [];
-
-                  var xhr = new XMLHttpRequest();
-
-                  xhr.open('GET', '/test/integration/example.json');
-                  xhr.setRequestHeader('Content-type', 'application/json');
-                  xhr.onreadystatechange = function () {
-                      // don't fire `done` handler until at least *one* onreadystatechange
-                      // has occurred (doesn't actually need to finish)
-                      if (xhr.readyState === 4) {
-                          setTimeout(done);
-                      }
-                  };
-                  xhr.send();
-              },
-              function () {
-                  var Raven = iframe.contentWindow.Raven,
-                      breadcrumbs = Raven._breadcrumbs;
-
-                   assert.equal(breadcrumbs.length, 1);
-
-                   assert.equal(breadcrumbs[0].type, 'http');
-                   assert.equal(breadcrumbs[0].data.method, 'GET');
-                   // NOTE: not checking status code because we seem to get
-                   //       statusCode 0/undefined from Phantom when fetching
-                   //       example.json (CORS issue?
-              }
-            );
-        });
-
-        it('should record an XMLHttpRequest without any handlers set', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    // I hate to do a time-based "done" trigger, but unfortunately we can't
-                    // set an onload/onreadystatechange handler on XHR to verify that it finished
-                    // - that's the whole point of this test! :(
-                    setTimeout(done, 1000);
-
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    var xhr = new XMLHttpRequest();
-
-                    xhr.open('GET', '/test/integration/example.json');
-                    xhr.setRequestHeader('Content-type', 'application/json');
-                    xhr.send();
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs;
-
-                    assert.equal(breadcrumbs.length, 1);
-
-                    assert.equal(breadcrumbs[0].type, 'http');
-                    assert.equal(breadcrumbs[0].category, 'xhr');
-                    assert.equal(breadcrumbs[0].data.method, 'GET');
-                    // NOTE: not checking status code because we seem to get
-                    //       statusCode 0/undefined from Phantom when fetching
-                    //       example.json (CORS issue?
-                }
-            );
-        });
-
-        it('should NOT denote XMLHttpRequests to the Sentry store endpoint as requiring breadcrumb capture', function (done) {
-            var iframe = this.iframe;
-            iframeExecute(iframe, done,
-              function () {
-                  var xhr = new XMLHttpRequest();
-                  xhr.open('GET', 'http://example.com/api/1/store/?sentry_key=public');
-
-                  // can't actually transmit an XHR (breadcrumb isnt recorded until
-                  // onreadystatechange fires), so enough to just verify that
-                  // __raven_xhr wasn't set on xhr object
-
-                  window.ravenData = xhr.hasOwnProperty('__raven_xhr');
-                  setTimeout(done);
-              },
-              function () {
-                  assert.isFalse(iframe.contentWindow.ravenData);
-              }
-            );
-        });
-
-        it('should record a fetch request', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    fetch('/test/integration/example.json').then(function () {
-                        setTimeout(done);
-                    }, function () {
-                        setTimeout(done);
-                    });
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs,
-                        breadcrumbUrl = '/test/integration/example.json';
-
-                    if ('fetch' in window) {
-                        assert.equal(breadcrumbs.length, 1);
-
-                        assert.equal(breadcrumbs[0].type, 'http');
-                        assert.equal(breadcrumbs[0].category, 'fetch');
-                        assert.equal(breadcrumbs[0].data.method, 'GET');
-                        assert.equal(breadcrumbs[0].data.url, breadcrumbUrl);
-                    } else {
-                        // otherwise we use a fetch polyfill based on xhr
-                        assert.equal(breadcrumbs.length, 2);
-
-                        assert.equal(breadcrumbs[0].type, 'http');
-                        assert.equal(breadcrumbs[0].category, 'fetch');
-                        assert.equal(breadcrumbs[0].data.method, 'GET');
-                        assert.equal(breadcrumbs[0].data.url, breadcrumbUrl);
-
-                        assert.equal(breadcrumbs[1].type, 'http');
-                        assert.equal(breadcrumbs[1].category, 'xhr');
-                        assert.equal(breadcrumbs[1].data.method, 'GET');
-                        assert.equal(breadcrumbs[1].data.url, breadcrumbUrl);
-                    }
-                }
-            );
-        });
-
-        it('should record a fetch request with Request obj instead of URL string', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    fetch(new Request('/test/integration/example.json')).then(function () {
-                        setTimeout(done);
-                    }, function () {
-                        setTimeout(done);
-                    });
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs,
-                        breadcrumbUrl = '/test/integration/example.json';
-
-                    if ('fetch' in window) {
-                        assert.equal(breadcrumbs.length, 1);
-
-                        assert.equal(breadcrumbs[0].type, 'http');
-                        assert.equal(breadcrumbs[0].category, 'fetch');
-                        assert.equal(breadcrumbs[0].data.method, 'GET');
-                        // Request constructor normalizes the url
-                        assert.ok(breadcrumbs[0].data.url.indexOf(breadcrumbUrl) !== -1);
-                    } else {
-                        // otherwise we use a fetch polyfill based on xhr
-                        assert.equal(breadcrumbs.length, 2);
-
-                        assert.equal(breadcrumbs[0].type, 'http');
-                        assert.equal(breadcrumbs[0].category, 'fetch');
-                        assert.equal(breadcrumbs[0].data.method, 'GET');
-                        assert.ok(breadcrumbs[0].data.url.indexOf(breadcrumbUrl) !== -1);
-
-                        assert.equal(breadcrumbs[1].type, 'http');
-                        assert.equal(breadcrumbs[1].category, 'xhr');
-                        assert.equal(breadcrumbs[1].data.method, 'GET');
-                        assert.ok(breadcrumbs[1].data.url.indexOf(breadcrumbUrl) !== -1);
-                    }
-                }
-            );
-        });
-
-        it('should record a mouse click on element WITH click handler present', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    // add an event listener to the input. we want to make sure that
-                    // our breadcrumbs still work even if the page has an event listener
-                    // on an element that cancels event bubbling
-                    var input = document.getElementsByTagName('input')[0];
-                    var clickHandler = function (evt) {
-                        evt.stopPropagation(); // don't bubble
-                    };
-                    input.addEventListener('click', clickHandler);
-
-                    // click <input/>
-                    var evt = document.createEvent('MouseEvent');
-                    evt.initMouseEvent(
-                        "click",
-                        true /* bubble */,
-                        true /* cancelable */,
-                        window,
-                        null,
-                        0, 0, 0, 0, /* coordinates */
-                        false, false, false, false, /* modifier keys */
-                        0 /*left*/,
-                        null
-                    );
-                    input.dispatchEvent(evt);
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs;
-
-                    assert.equal(breadcrumbs.length, 1);
-
-                    assert.equal(breadcrumbs[0].category, 'ui.click');
-                    assert.equal(breadcrumbs[0].message, 'body > form#foo-form > input[name="foo"]');
-                }
-            );
-        });
-
-        it('should record a mouse click on element WITHOUT click handler present', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    // click <input/>
-                    var evt = document.createEvent('MouseEvent');
-                    evt.initMouseEvent(
-                        "click",
-                        true /* bubble */,
-                        true /* cancelable */,
-                        window,
-                        null,
-                        0, 0, 0, 0, /* coordinates */
-                        false, false, false, false, /* modifier keys */
-                        0 /*left*/,
-                        null
-                    );
-
-                    var input = document.getElementsByTagName('input')[0];
-                    input.dispatchEvent(evt);
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs;
-
-                    assert.equal(breadcrumbs.length, 1);
-
-                    assert.equal(breadcrumbs[0].category, 'ui.click');
-                    assert.equal(breadcrumbs[0].message, 'body > form#foo-form > input[name="foo"]');
-                }
-            );
-        });
-
-        it('should only record a SINGLE mouse click for a tree of elements with event listeners', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    var clickHandler = function (evt) {
-                        //evt.stopPropagation();
-                    };
-
-                    // mousemove event shouldnt clobber subsequent "breadcrumbed" events (see #724)
-                    document.querySelector('.a').addEventListener('mousemove', clickHandler);
-
-                    document.querySelector('.a').addEventListener('click', clickHandler);
-                    document.querySelector('.b').addEventListener('click', clickHandler);
-                    document.querySelector('.c').addEventListener('click', clickHandler);
-
-                    // click <input/>
-                    var evt = document.createEvent('MouseEvent');
-                    evt.initMouseEvent(
-                        "click",
-                        true /* bubble */,
-                        true /* cancelable */,
-                        window,
-                        null,
-                        0, 0, 0, 0, /* coordinates */
-                        false, false, false, false, /* modifier keys */
-                        0 /*left*/,
-                        null
-                    );
-
-                    var input = document.querySelector('.a'); // leaf node
-                    input.dispatchEvent(evt);
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs;
-
-                    assert.equal(breadcrumbs.length, 1);
-
-                    assert.equal(breadcrumbs[0].category, 'ui.click');
-                    assert.equal(breadcrumbs[0].message, 'body > div.c > div.b > div.a');
-                }
-            );
-        });
-
-        // doesn't work in PhantomJS
-        if (!/PhantomJS/.test(window.navigator.userAgent)) {
-            it('should bail out if accessing the `type` and `target` properties of an event throw an exception', function (done) {
-                // see: https://github.com/getsentry/raven-js/issues/768
-                var iframe = this.iframe;
-
-                iframeExecute(iframe, done,
-                    function () {
-                        setTimeout(done);
-
-                        // some browsers trigger onpopstate for load / reset breadcrumb state
-                        Raven._breadcrumbs = [];
-
-                        // click <input/>
-                        var evt = document.createEvent('MouseEvent');
-                        evt.initMouseEvent(evt,
-                            "click",
-                            true /* bubble */,
-                            true /* cancelable */,
-                            window,
-                            null,
-                            0, 0, 0, 0, /* coordinates */
-                            false, false, false, false, /* modifier keys */
-                            0 /*left*/,
-                            null
-                        );
-
-                        function kaboom() { throw new Error('lol'); };
-                        Object.defineProperty(evt, 'type', { get: kaboom });
-                        Object.defineProperty(evt, 'target', { get: kaboom });
-
-                        var input = document.querySelector('.a'); // leaf node
-                        input.dispatchEvent(evt);
-                    },
-                    function () {
-                        var Raven = iframe.contentWindow.Raven,
-                            breadcrumbs = Raven._breadcrumbs;
-
-                        assert.equal(breadcrumbs.length, 1);
-                        assert.equal(breadcrumbs[0].category, 'ui.click');
-                        assert.equal(breadcrumbs[0].message, '<unknown>');
-                    }
-                );
-            });
-        } // if PhantomJS
-
-        it('should record consecutive keypress events into a single "input" breadcrumb', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    // keypress <input/> twice
-                    var keypress1 = document.createEvent('KeyboardEvent');
-                    keypress1.initKeyboardEvent("keypress", true, true, window, "b", 66, 0, "", false);
-
-                    var keypress2 = document.createEvent('KeyboardEvent');
-                    keypress2.initKeyboardEvent("keypress", true, true, window, "a", 65, 0, "", false);
-
-                    var input = document.getElementsByTagName('input')[0];
-                    input.dispatchEvent(keypress1);
-                    input.dispatchEvent(keypress2);
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs;
-
-                    assert.equal(breadcrumbs.length, 1);
-
-                    assert.equal(breadcrumbs[0].category, 'ui.input');
-                    assert.equal(breadcrumbs[0].message, 'body > form#foo-form > input[name="foo"]');
-                }
-            );
-        });
-
-        it('should flush keypress breadcrumbs when an error is thrown', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    // keypress <input/>
-                    var keypress = document.createEvent('KeyboardEvent');
-                    keypress.initKeyboardEvent("keypress", true, true, window, "b", 66, 0, "", false);
-
-                    var input = document.getElementsByTagName('input')[0];
-                    input.dispatchEvent(keypress);
-
-                    foo(); // throw exception
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs;
-
-                    // 2 breadcrumbs: `ui_event`, then `error`
-                    assert.equal(breadcrumbs.length, 2);
-
-                    assert.equal(breadcrumbs[0].category, 'ui.input');
-                    assert.equal(breadcrumbs[0].message, 'body > form#foo-form > input[name="foo"]');
-                }
-            );
-        });
-
-        it('should flush keypress breadcrumb when input event occurs immediately after', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    // 1st keypress <input/>
-                    var keypress1 = document.createEvent('KeyboardEvent');
-                    keypress1.initKeyboardEvent("keypress", true, true, window, "b", 66, 0, "", false);
-
-                    // click <input/>
-                    var click= document.createEvent('MouseEvent');
-                    click.initMouseEvent(
-                        "click",
-                        true /* bubble */,
-                        true /* cancelable */,
-                        window,
-                        null,
-                        0, 0, 0, 0, /* coordinates */
-                        false, false, false, false, /* modifier keys */
-                        0 /*left*/,
-                        null
-                    );
-
-                    // 2nd keypress
-                    var keypress2 = document.createEvent('KeyboardEvent');
-                    keypress2.initKeyboardEvent("keypress", true, true, window, "a", 65, 0, "", false);
-
-                    var input = document.getElementsByTagName('input')[0];
-                    input.dispatchEvent(keypress1);
-                    input.dispatchEvent(click);
-                    input.dispatchEvent(keypress2);
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs;
-
-                    // 2x `ui_event`
-                    assert.equal(breadcrumbs.length, 3);
-
-                    assert.equal(breadcrumbs[0].category, 'ui.input');
-                    assert.equal(breadcrumbs[0].message, 'body > form#foo-form > input[name="foo"]');
-
-                    assert.equal(breadcrumbs[1].category, 'ui.click');
-                    assert.equal(breadcrumbs[1].message, 'body > form#foo-form > input[name="foo"]');
-
-                    assert.equal(breadcrumbs[2].category, 'ui.input');
-                    assert.equal(breadcrumbs[2].message, 'body > form#foo-form > input[name="foo"]');
-
-                }
-            );
-        });
-
-        it('should record consecutive keypress events in a contenteditable into a single "input" breadcrumb', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    // some browsers trigger onpopstate for load / reset breadcrumb state
-                    Raven._breadcrumbs = [];
-
-                    // keypress <input/> twice
-                    var keypress1 = document.createEvent('KeyboardEvent');
-                    keypress1.initKeyboardEvent("keypress", true, true, window, "b", 66, 0, "", false);
-
-                    var keypress2 = document.createEvent('KeyboardEvent');
-                    keypress2.initKeyboardEvent("keypress", true, true, window, "a", 65, 0, "", false);
-
-                    var div = document.querySelector('[contenteditable]');
-                    div.dispatchEvent(keypress1);
-                    div.dispatchEvent(keypress2);
-                },
-                function () {
-                    var Raven = iframe.contentWindow.Raven,
-                        breadcrumbs = Raven._breadcrumbs;
-
-                    assert.equal(breadcrumbs.length, 1);
-
-                    assert.equal(breadcrumbs[0].category, 'ui.input');
-                    assert.equal(breadcrumbs[0].message, 'body > form#foo-form > div.contenteditable');
-                }
-            );
-        });
-
-        it('should record history.[pushState|back] changes as navigation breadcrumbs', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-              function () {
-                  // some browsers trigger onpopstate for load / reset breadcrumb state
-                  Raven._breadcrumbs = [];
-
-                  history.pushState({}, '', '/foo');
-                  history.pushState({}, '', '/bar?a=1#fragment');
-                  history.pushState({}, '', {}); // pushState calls toString on non-string args
-                  history.pushState({}, '', null); // does nothing / no-op
-
-                  // can't call history.back() because it will change url of parent document
-                  // (e.g. document running mocha) ... instead just "emulate" a back button
-                  // press by calling replaceState + onpopstate manually
-                  history.replaceState({}, '', '/bar?a=1#fragment');
-                  window.onpopstate();
-                  done();
-              },
-              function () {
-                  var Raven = iframe.contentWindow.Raven,
-                      breadcrumbs = Raven._breadcrumbs,
-                      from,
-                      to;
-
-                  assert.equal(breadcrumbs.length, 4);
-                  assert.equal(breadcrumbs[0].category, 'navigation'); // (start) => foo
-                  assert.equal(breadcrumbs[1].category, 'navigation'); // foo => bar?a=1#fragment
-                  assert.equal(breadcrumbs[2].category, 'navigation'); // bar?a=1#fragment => [object%20Object]
-                  assert.equal(breadcrumbs[3].category, 'navigation'); // [object%20Object] => bar?a=1#fragment (back button)
-
-                  // assert end of string because PhantomJS uses full system path
-                  assert.ok(/\/test\/integration\/frame\.html$/.test(Raven._breadcrumbs[0].data.from), '\'from\' url is incorrect');
-                  assert.ok(/\/foo$/.test(breadcrumbs[0].data.to), '\'to\' url is incorrect');
-
-                  assert.ok(/\/foo$/.test(breadcrumbs[1].data.from), '\'from\' url is incorrect');
-                  assert.ok(/\/bar\?a=1#fragment$/.test(breadcrumbs[1].data.to), '\'to\' url is incorrect');
-
-                  assert.ok(/\/bar\?a=1#fragment$/.test(breadcrumbs[2].data.from), '\'from\' url is incorrect');
-                  assert.ok(/\[object Object\]$/.test(breadcrumbs[2].data.to), '\'to\' url is incorrect');
-
-                  assert.ok(/\[object Object\]$/.test(breadcrumbs[3].data.from), '\'from\' url is incorrect');
-                  assert.ok(/\/bar\?a=1#fragment/.test(breadcrumbs[3].data.to), '\'to\' url is incorrect');
-              }
-            );
-        });
+    it('should not reject back-to-back errors with different stack traces', function(
+      done
+    ) {
+      var iframe = this.iframe;
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+          Raven._breadcrumbs = [];
+
+          // same error message, but different stacks means that these are considered
+          // different errors
+          // NOTE: PhantomJS can't derive function/lineno/colno from evaled frames, must
+          //       use frames declared in frame.html (foo(), bar())
+
+          // stack:
+          //   bar
+          try {
+            bar(); // declared in frame.html
+          } catch (e) {
+            Raven.captureException(e);
+          }
+
+          // stack (different # frames):
+          //   bar
+          //   foo
+          try {
+            foo(); // declared in frame.html
+          } catch (e) {
+            Raven.captureException(e);
+          }
+
+          // stack (same # frames, different frames):
+          //   bar
+          //   foo2
+          try {
+            foo2(); // declared in frame.html
+          } catch (e) {
+            Raven.captureException(e);
+          }
+        },
+        function() {
+          var breadcrumbs = iframe.contentWindow.Raven._breadcrumbs;
+          assert.equal(breadcrumbs.length, 3);
+          // NOTE: regex because exact error message differs per-browser
+          assert.match(breadcrumbs[0].message, /^ReferenceError.*baz/);
+          assert.match(breadcrumbs[1].message, /^ReferenceError.*baz/);
+          assert.match(breadcrumbs[2].message, /^ReferenceError.*baz/);
+        }
+      );
     });
 
-    describe('uninstall', function () {
-        it('should restore original built-ins', function (done) {
-            var iframe = this.iframe;
+    it('should reject duplicate, back-to-back messages from captureMessage', function(
+      done
+    ) {
+      var iframe = this.iframe;
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
 
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-                    Raven.uninstall();
+          Raven._breadcrumbs = [];
 
-                    window.isRestored = {
-                        setTimeout: originalBuiltIns.setTimeout === setTimeout,
-                        setInterval: originalBuiltIns.setInterval === setInterval,
-                        requestAnimationFrame: originalBuiltIns.requestAnimationFrame === requestAnimationFrame,
-                        xhrProtoOpen: originalBuiltIns.xhrProtoOpen === XMLHttpRequest.prototype.open,
-                        headAddEventListener: originalBuiltIns.headAddEventListener === document.body.addEventListener,
-                        headRemoveEventListener: originalBuiltIns.headRemoveEventListener === document.body.removeEventListener
-                    };
-                },
-                function () {
-                    var isRestored = iframe.contentWindow.isRestored;
-                    assert.isTrue(isRestored.setTimeout);
-                    assert.isTrue(isRestored.setInterval);
-                    assert.isTrue(isRestored.requestAnimationFrame);
-                    assert.isTrue(isRestored.xhrProtoOpen);
-                    assert.isTrue(isRestored.headAddEventListener);
-                    assert.isTrue(isRestored.headRemoveEventListener);
-                }
-            );
-        });
+          Raven.captureMessage('this is fine');
+          Raven.captureMessage('this is fine'); // suppressed
+          Raven.captureMessage('this is fine', {stacktrace: true});
+          Raven.captureMessage("i'm okay with the events that are unfolding currently");
+          Raven.captureMessage("that's okay, things are going to be okay");
+        },
+        function() {
+          var breadcrumbs = iframe.contentWindow.Raven._breadcrumbs;
 
-        it('should not restore XMLHttpRequest instance methods', function (done) {
-            var iframe = this.iframe;
-
-            iframeExecute(iframe, done,
-                function () {
-                    setTimeout(done);
-
-                    var xhr = new XMLHttpRequest();
-                    var origOnReadyStateChange = xhr.onreadystatechange = function () {};
-                    xhr.open('GET', '/foo/');
-                    xhr.abort();
-
-                    Raven.uninstall();
-
-                    window.isOnReadyStateChangeRestored = xhr.onready === origOnReadyStateChange;
-                },
-                function () {
-                    assert.isFalse(iframe.contentWindow.isOnReadyStateChangeRestored);
-                }
-            );
-        });
+          assert.equal(breadcrumbs.length, 4);
+          assert.equal(breadcrumbs[0].message, 'this is fine');
+          assert.equal(breadcrumbs[1].message, 'this is fine'); // with stacktrace
+          assert.equal(
+            breadcrumbs[2].message,
+            "i'm okay with the events that are unfolding currently"
+          );
+          assert.equal(
+            breadcrumbs[3].message,
+            "that's okay, things are going to be okay"
+          );
+        }
+      );
     });
+  });
+
+  describe('window.onerror', function() {
+    it('should catch syntax errors', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+          eval('foo{};');
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.isTrue(/SyntaxError/.test(ravenData.exception.values[0].type)); // full message differs per-browser
+          assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1); // just one frame
+        }
+      );
+    });
+
+    it('should catch thrown strings', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          // intentionally loading this error via a script file to make
+          // sure it is 1) not caught by instrumentation 2) doesn't trigger
+          // "Script error"
+          var script = document.createElement('script');
+          script.src = 'throw-string.js';
+          script.onload = function() {
+            done();
+          };
+          document.head.appendChild(script);
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.match(ravenData.exception.values[0].value, /stringError$/);
+          assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1); // always 1 because thrown strings can't provide > 1 frame
+
+          // some browsers extract proper url, line, and column for thrown strings
+          // but not all - falls back to frame url
+          assert.match(
+            ravenData.exception.values[0].stacktrace.frames[0].filename,
+            /\/test\/integration\//
+          );
+          assert.match(
+            ravenData.exception.values[0].stacktrace.frames[0]['function'],
+            /\?|global code/
+          );
+        }
+      );
+    });
+
+    it('should catch thrown objects', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          // intentionally loading this error via a script file to make
+          // sure it is 1) not caught by instrumentation 2) doesn't trigger
+          // "Script error"
+          var script = document.createElement('script');
+          script.src = 'throw-object.js';
+          script.onload = function() {
+            done();
+          };
+          document.head.appendChild(script);
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.equal(ravenData.exception.values[0].type, undefined);
+          assert.equal(ravenData.exception.values[0].value, '[object Object]');
+          assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1); // always 1 because thrown objects can't provide > 1 frame
+
+          // some browsers extract proper url, line, and column for thrown objects
+          // but not all - falls back to frame url
+          assert.match(
+            ravenData.exception.values[0].stacktrace.frames[0].filename,
+            /\/test\/integration\//
+          );
+          assert.match(
+            ravenData.exception.values[0].stacktrace.frames[0]['function'],
+            /\?|global code/
+          );
+        }
+      );
+    });
+
+    it('should catch thrown errors', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          // intentionally loading this error via a script file to make
+          // sure it is 1) not caught by instrumentation 2) doesn't trigger
+          // "Script error"
+          var script = document.createElement('script');
+          script.src = 'throw-error.js';
+          script.onload = function() {
+            done();
+          };
+          document.head.appendChild(script);
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.match(ravenData.exception.values[0].type, /^Error/);
+          assert.match(ravenData.exception.values[0].value, /realError$/);
+          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 0); // 1 or 2 depending on platform
+          assert.match(
+            ravenData.exception.values[0].stacktrace.frames[0].filename,
+            /\/test\/integration\/throw-error\.js/
+          );
+          assert.match(
+            ravenData.exception.values[0].stacktrace.frames[0]['function'],
+            /\?|global code/
+          );
+        }
+      );
+    });
+
+    it('should NOT catch an exception already caught via Raven.wrap', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+          Raven.wrap(function() {
+            foo();
+          })();
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData;
+          assert.equal(ravenData.length, 1); // one caught error
+        }
+      );
+    });
+
+    it('should catch an exception already caught [but rethrown] via Raven.captureException', function(
+      done
+    ) {
+      // unlike Raven.wrap which ALWAYS re-throws, we don't know if the user will
+      // re-throw an exception passed to Raven.captureException, and so we cannot
+      // automatically suppress the next error caught through window.onerror
+      var iframe = this.iframe;
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+          try {
+            foo();
+          } catch (e) {
+            Raven.captureException(e);
+            throw e; // intentionally re-throw
+          }
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData;
+          assert.equal(ravenData.length, 2);
+        }
+      );
+    });
+  });
+
+  describe('wrapped built-ins', function() {
+    it('should capture exceptions from event listeners', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          var div = document.createElement('div');
+          document.body.appendChild(div);
+          div.addEventListener(
+            'click',
+            function() {
+              foo();
+            },
+            false
+          );
+
+          var evt;
+          if (document.createEvent) {
+            evt = document.createEvent('MouseEvents');
+            evt.initEvent('click', true, false);
+            div.dispatchEvent(evt);
+          } else if (document.createEventObject) {
+            div.fireEvent('onclick');
+          }
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+        }
+      );
+    });
+
+    it('should transparently remove event listeners from wrapped functions', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          var div = document.createElement('div');
+          document.body.appendChild(div);
+          var fooFn = function() {
+            foo();
+          };
+          div.addEventListener('click', fooFn, false);
+          div.removeEventListener('click', fooFn);
+
+          var evt;
+          if (document.createEvent) {
+            evt = document.createEvent('MouseEvents');
+            evt.initEvent('click', true, false);
+            div.dispatchEvent(evt);
+          } else if (document.createEventObject) {
+            div.fireEvent('onclick');
+          }
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.equal(ravenData, null); // should never trigger error
+        }
+      );
+    });
+
+    it('should capture exceptions inside setTimeout', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(function() {
+            setTimeout(done);
+            foo();
+          }, 10);
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+        }
+      );
+    });
+
+    it('should capture exceptions inside setInterval', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          var exceptionInterval = setInterval(function() {
+            setTimeout(done);
+            clearInterval(exceptionInterval);
+            foo();
+          }, 10);
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+        }
+      );
+    });
+
+    it('should capture exceptions inside requestAnimationFrame', function(done) {
+      var iframe = this.iframe;
+      // needs to be visible or requestAnimationFrame won't ever fire
+      iframe.style.display = 'block';
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          requestAnimationFrame(function() {
+            setTimeout(done);
+            foo();
+          });
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+        }
+      );
+    });
+
+    it('should capture exceptions from XMLHttpRequest event handlers (e.g. onreadystatechange)', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          var xhr = new XMLHttpRequest();
+
+          // intentionally assign event handlers *after* XMLHttpRequest.prototype.open,
+          // since this is what jQuery does
+          // https://github.com/jquery/jquery/blob/master/src/ajax/xhr.js#L37
+
+          xhr.open('GET', 'example.json');
+          xhr.onreadystatechange = function() {
+            setTimeout(done);
+            // replace onreadystatechange with no-op so exception doesn't
+            // fire more than once as XHR changes loading state
+            xhr.onreadystatechange = function() {};
+            foo();
+          };
+          xhr.send();
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          // # of frames alter significantly between chrome/firefox & safari
+          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+        }
+      );
+    });
+  });
+
+  describe('breadcrumbs', function() {
+    it('should record an XMLHttpRequest', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          var xhr = new XMLHttpRequest();
+
+          xhr.open('GET', '/test/integration/example.json');
+          xhr.setRequestHeader('Content-type', 'application/json');
+          xhr.onreadystatechange = function() {
+            // don't fire `done` handler until at least *one* onreadystatechange
+            // has occurred (doesn't actually need to finish)
+            if (xhr.readyState === 4) {
+              setTimeout(done);
+            }
+          };
+          xhr.send();
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs;
+
+          assert.equal(breadcrumbs.length, 1);
+
+          assert.equal(breadcrumbs[0].type, 'http');
+          assert.equal(breadcrumbs[0].data.method, 'GET');
+          // NOTE: not checking status code because we seem to get
+          //       statusCode 0/undefined from Phantom when fetching
+          //       example.json (CORS issue?
+        }
+      );
+    });
+
+    it('should record an XMLHttpRequest without any handlers set', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          // I hate to do a time-based "done" trigger, but unfortunately we can't
+          // set an onload/onreadystatechange handler on XHR to verify that it finished
+          // - that's the whole point of this test! :(
+          setTimeout(done, 1000);
+
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          var xhr = new XMLHttpRequest();
+
+          xhr.open('GET', '/test/integration/example.json');
+          xhr.setRequestHeader('Content-type', 'application/json');
+          xhr.send();
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs;
+
+          assert.equal(breadcrumbs.length, 1);
+
+          assert.equal(breadcrumbs[0].type, 'http');
+          assert.equal(breadcrumbs[0].category, 'xhr');
+          assert.equal(breadcrumbs[0].data.method, 'GET');
+          // NOTE: not checking status code because we seem to get
+          //       statusCode 0/undefined from Phantom when fetching
+          //       example.json (CORS issue?
+        }
+      );
+    });
+
+    it('should NOT denote XMLHttpRequests to the Sentry store endpoint as requiring breadcrumb capture', function(
+      done
+    ) {
+      var iframe = this.iframe;
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          var xhr = new XMLHttpRequest();
+          xhr.open('GET', 'http://example.com/api/1/store/?sentry_key=public');
+
+          // can't actually transmit an XHR (breadcrumb isnt recorded until
+          // onreadystatechange fires), so enough to just verify that
+          // __raven_xhr wasn't set on xhr object
+
+          window.ravenData = xhr.hasOwnProperty('__raven_xhr');
+          setTimeout(done);
+        },
+        function() {
+          assert.isFalse(iframe.contentWindow.ravenData);
+        }
+      );
+    });
+
+    it('should record a fetch request', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          fetch('/test/integration/example.json').then(
+            function() {
+              setTimeout(done);
+            },
+            function() {
+              setTimeout(done);
+            }
+          );
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs,
+            breadcrumbUrl = '/test/integration/example.json';
+
+          if ('fetch' in window) {
+            assert.equal(breadcrumbs.length, 1);
+
+            assert.equal(breadcrumbs[0].type, 'http');
+            assert.equal(breadcrumbs[0].category, 'fetch');
+            assert.equal(breadcrumbs[0].data.method, 'GET');
+            assert.equal(breadcrumbs[0].data.url, breadcrumbUrl);
+          } else {
+            // otherwise we use a fetch polyfill based on xhr
+            assert.equal(breadcrumbs.length, 2);
+
+            assert.equal(breadcrumbs[0].type, 'http');
+            assert.equal(breadcrumbs[0].category, 'fetch');
+            assert.equal(breadcrumbs[0].data.method, 'GET');
+            assert.equal(breadcrumbs[0].data.url, breadcrumbUrl);
+
+            assert.equal(breadcrumbs[1].type, 'http');
+            assert.equal(breadcrumbs[1].category, 'xhr');
+            assert.equal(breadcrumbs[1].data.method, 'GET');
+            assert.equal(breadcrumbs[1].data.url, breadcrumbUrl);
+          }
+        }
+      );
+    });
+
+    it('should record a fetch request with Request obj instead of URL string', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          fetch(new Request('/test/integration/example.json')).then(
+            function() {
+              setTimeout(done);
+            },
+            function() {
+              setTimeout(done);
+            }
+          );
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs,
+            breadcrumbUrl = '/test/integration/example.json';
+
+          if ('fetch' in window) {
+            assert.equal(breadcrumbs.length, 1);
+
+            assert.equal(breadcrumbs[0].type, 'http');
+            assert.equal(breadcrumbs[0].category, 'fetch');
+            assert.equal(breadcrumbs[0].data.method, 'GET');
+            // Request constructor normalizes the url
+            assert.ok(breadcrumbs[0].data.url.indexOf(breadcrumbUrl) !== -1);
+          } else {
+            // otherwise we use a fetch polyfill based on xhr
+            assert.equal(breadcrumbs.length, 2);
+
+            assert.equal(breadcrumbs[0].type, 'http');
+            assert.equal(breadcrumbs[0].category, 'fetch');
+            assert.equal(breadcrumbs[0].data.method, 'GET');
+            assert.ok(breadcrumbs[0].data.url.indexOf(breadcrumbUrl) !== -1);
+
+            assert.equal(breadcrumbs[1].type, 'http');
+            assert.equal(breadcrumbs[1].category, 'xhr');
+            assert.equal(breadcrumbs[1].data.method, 'GET');
+            assert.ok(breadcrumbs[1].data.url.indexOf(breadcrumbUrl) !== -1);
+          }
+        }
+      );
+    });
+
+    it('should record a mouse click on element WITH click handler present', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          // add an event listener to the input. we want to make sure that
+          // our breadcrumbs still work even if the page has an event listener
+          // on an element that cancels event bubbling
+          var input = document.getElementsByTagName('input')[0];
+          var clickHandler = function(evt) {
+            evt.stopPropagation(); // don't bubble
+          };
+          input.addEventListener('click', clickHandler);
+
+          // click <input/>
+          var evt = document.createEvent('MouseEvent');
+          evt.initMouseEvent(
+            'click',
+            true /* bubble */,
+            true /* cancelable */,
+            window,
+            null,
+            0,
+            0,
+            0,
+            0 /* coordinates */,
+            false,
+            false,
+            false,
+            false /* modifier keys */,
+            0 /*left*/,
+            null
+          );
+          input.dispatchEvent(evt);
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs;
+
+          assert.equal(breadcrumbs.length, 1);
+
+          assert.equal(breadcrumbs[0].category, 'ui.click');
+          assert.equal(
+            breadcrumbs[0].message,
+            'body > form#foo-form > input[name="foo"]'
+          );
+        }
+      );
+    });
+
+    it('should record a mouse click on element WITHOUT click handler present', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          // click <input/>
+          var evt = document.createEvent('MouseEvent');
+          evt.initMouseEvent(
+            'click',
+            true /* bubble */,
+            true /* cancelable */,
+            window,
+            null,
+            0,
+            0,
+            0,
+            0 /* coordinates */,
+            false,
+            false,
+            false,
+            false /* modifier keys */,
+            0 /*left*/,
+            null
+          );
+
+          var input = document.getElementsByTagName('input')[0];
+          input.dispatchEvent(evt);
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs;
+
+          assert.equal(breadcrumbs.length, 1);
+
+          assert.equal(breadcrumbs[0].category, 'ui.click');
+          assert.equal(
+            breadcrumbs[0].message,
+            'body > form#foo-form > input[name="foo"]'
+          );
+        }
+      );
+    });
+
+    it('should only record a SINGLE mouse click for a tree of elements with event listeners', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          var clickHandler = function(evt) {
+            //evt.stopPropagation();
+          };
+
+          // mousemove event shouldnt clobber subsequent "breadcrumbed" events (see #724)
+          document.querySelector('.a').addEventListener('mousemove', clickHandler);
+
+          document.querySelector('.a').addEventListener('click', clickHandler);
+          document.querySelector('.b').addEventListener('click', clickHandler);
+          document.querySelector('.c').addEventListener('click', clickHandler);
+
+          // click <input/>
+          var evt = document.createEvent('MouseEvent');
+          evt.initMouseEvent(
+            'click',
+            true /* bubble */,
+            true /* cancelable */,
+            window,
+            null,
+            0,
+            0,
+            0,
+            0 /* coordinates */,
+            false,
+            false,
+            false,
+            false /* modifier keys */,
+            0 /*left*/,
+            null
+          );
+
+          var input = document.querySelector('.a'); // leaf node
+          input.dispatchEvent(evt);
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs;
+
+          assert.equal(breadcrumbs.length, 1);
+
+          assert.equal(breadcrumbs[0].category, 'ui.click');
+          assert.equal(breadcrumbs[0].message, 'body > div.c > div.b > div.a');
+        }
+      );
+    });
+
+    // doesn't work in PhantomJS
+    if (!/PhantomJS/.test(window.navigator.userAgent)) {
+      it('should bail out if accessing the `type` and `target` properties of an event throw an exception', function(
+        done
+      ) {
+        // see: https://github.com/getsentry/raven-js/issues/768
+        var iframe = this.iframe;
+
+        iframeExecute(
+          iframe,
+          done,
+          function() {
+            setTimeout(done);
+
+            // some browsers trigger onpopstate for load / reset breadcrumb state
+            Raven._breadcrumbs = [];
+
+            // click <input/>
+            var evt = document.createEvent('MouseEvent');
+            evt.initMouseEvent(
+              evt,
+              'click',
+              true /* bubble */,
+              true /* cancelable */,
+              window,
+              null,
+              0,
+              0,
+              0,
+              0 /* coordinates */,
+              false,
+              false,
+              false,
+              false /* modifier keys */,
+              0 /*left*/,
+              null
+            );
+
+            function kaboom() {
+              throw new Error('lol');
+            }
+            Object.defineProperty(evt, 'type', {get: kaboom});
+            Object.defineProperty(evt, 'target', {get: kaboom});
+
+            var input = document.querySelector('.a'); // leaf node
+            input.dispatchEvent(evt);
+          },
+          function() {
+            var Raven = iframe.contentWindow.Raven,
+              breadcrumbs = Raven._breadcrumbs;
+
+            assert.equal(breadcrumbs.length, 1);
+            assert.equal(breadcrumbs[0].category, 'ui.click');
+            assert.equal(breadcrumbs[0].message, '<unknown>');
+          }
+        );
+      });
+    } // if PhantomJS
+
+    it('should record consecutive keypress events into a single "input" breadcrumb', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          // keypress <input/> twice
+          var keypress1 = document.createEvent('KeyboardEvent');
+          keypress1.initKeyboardEvent(
+            'keypress',
+            true,
+            true,
+            window,
+            'b',
+            66,
+            0,
+            '',
+            false
+          );
+
+          var keypress2 = document.createEvent('KeyboardEvent');
+          keypress2.initKeyboardEvent(
+            'keypress',
+            true,
+            true,
+            window,
+            'a',
+            65,
+            0,
+            '',
+            false
+          );
+
+          var input = document.getElementsByTagName('input')[0];
+          input.dispatchEvent(keypress1);
+          input.dispatchEvent(keypress2);
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs;
+
+          assert.equal(breadcrumbs.length, 1);
+
+          assert.equal(breadcrumbs[0].category, 'ui.input');
+          assert.equal(
+            breadcrumbs[0].message,
+            'body > form#foo-form > input[name="foo"]'
+          );
+        }
+      );
+    });
+
+    it('should flush keypress breadcrumbs when an error is thrown', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          // keypress <input/>
+          var keypress = document.createEvent('KeyboardEvent');
+          keypress.initKeyboardEvent(
+            'keypress',
+            true,
+            true,
+            window,
+            'b',
+            66,
+            0,
+            '',
+            false
+          );
+
+          var input = document.getElementsByTagName('input')[0];
+          input.dispatchEvent(keypress);
+
+          foo(); // throw exception
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs;
+
+          // 2 breadcrumbs: `ui_event`, then `error`
+          assert.equal(breadcrumbs.length, 2);
+
+          assert.equal(breadcrumbs[0].category, 'ui.input');
+          assert.equal(
+            breadcrumbs[0].message,
+            'body > form#foo-form > input[name="foo"]'
+          );
+        }
+      );
+    });
+
+    it('should flush keypress breadcrumb when input event occurs immediately after', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          // 1st keypress <input/>
+          var keypress1 = document.createEvent('KeyboardEvent');
+          keypress1.initKeyboardEvent(
+            'keypress',
+            true,
+            true,
+            window,
+            'b',
+            66,
+            0,
+            '',
+            false
+          );
+
+          // click <input/>
+          var click = document.createEvent('MouseEvent');
+          click.initMouseEvent(
+            'click',
+            true /* bubble */,
+            true /* cancelable */,
+            window,
+            null,
+            0,
+            0,
+            0,
+            0 /* coordinates */,
+            false,
+            false,
+            false,
+            false /* modifier keys */,
+            0 /*left*/,
+            null
+          );
+
+          // 2nd keypress
+          var keypress2 = document.createEvent('KeyboardEvent');
+          keypress2.initKeyboardEvent(
+            'keypress',
+            true,
+            true,
+            window,
+            'a',
+            65,
+            0,
+            '',
+            false
+          );
+
+          var input = document.getElementsByTagName('input')[0];
+          input.dispatchEvent(keypress1);
+          input.dispatchEvent(click);
+          input.dispatchEvent(keypress2);
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs;
+
+          // 2x `ui_event`
+          assert.equal(breadcrumbs.length, 3);
+
+          assert.equal(breadcrumbs[0].category, 'ui.input');
+          assert.equal(
+            breadcrumbs[0].message,
+            'body > form#foo-form > input[name="foo"]'
+          );
+
+          assert.equal(breadcrumbs[1].category, 'ui.click');
+          assert.equal(
+            breadcrumbs[1].message,
+            'body > form#foo-form > input[name="foo"]'
+          );
+
+          assert.equal(breadcrumbs[2].category, 'ui.input');
+          assert.equal(
+            breadcrumbs[2].message,
+            'body > form#foo-form > input[name="foo"]'
+          );
+        }
+      );
+    });
+
+    it('should record consecutive keypress events in a contenteditable into a single "input" breadcrumb', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          // keypress <input/> twice
+          var keypress1 = document.createEvent('KeyboardEvent');
+          keypress1.initKeyboardEvent(
+            'keypress',
+            true,
+            true,
+            window,
+            'b',
+            66,
+            0,
+            '',
+            false
+          );
+
+          var keypress2 = document.createEvent('KeyboardEvent');
+          keypress2.initKeyboardEvent(
+            'keypress',
+            true,
+            true,
+            window,
+            'a',
+            65,
+            0,
+            '',
+            false
+          );
+
+          var div = document.querySelector('[contenteditable]');
+          div.dispatchEvent(keypress1);
+          div.dispatchEvent(keypress2);
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs;
+
+          assert.equal(breadcrumbs.length, 1);
+
+          assert.equal(breadcrumbs[0].category, 'ui.input');
+          assert.equal(
+            breadcrumbs[0].message,
+            'body > form#foo-form > div.contenteditable'
+          );
+        }
+      );
+    });
+
+    it('should record history.[pushState|back] changes as navigation breadcrumbs', function(
+      done
+    ) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          // some browsers trigger onpopstate for load / reset breadcrumb state
+          Raven._breadcrumbs = [];
+
+          history.pushState({}, '', '/foo');
+          history.pushState({}, '', '/bar?a=1#fragment');
+          history.pushState({}, '', {}); // pushState calls toString on non-string args
+          history.pushState({}, '', null); // does nothing / no-op
+
+          // can't call history.back() because it will change url of parent document
+          // (e.g. document running mocha) ... instead just "emulate" a back button
+          // press by calling replaceState + onpopstate manually
+          history.replaceState({}, '', '/bar?a=1#fragment');
+          window.onpopstate();
+          done();
+        },
+        function() {
+          var Raven = iframe.contentWindow.Raven,
+            breadcrumbs = Raven._breadcrumbs,
+            from,
+            to;
+
+          assert.equal(breadcrumbs.length, 4);
+          assert.equal(breadcrumbs[0].category, 'navigation'); // (start) => foo
+          assert.equal(breadcrumbs[1].category, 'navigation'); // foo => bar?a=1#fragment
+          assert.equal(breadcrumbs[2].category, 'navigation'); // bar?a=1#fragment => [object%20Object]
+          assert.equal(breadcrumbs[3].category, 'navigation'); // [object%20Object] => bar?a=1#fragment (back button)
+
+          // assert end of string because PhantomJS uses full system path
+          assert.ok(
+            /\/test\/integration\/frame\.html$/.test(Raven._breadcrumbs[0].data.from),
+            "'from' url is incorrect"
+          );
+          assert.ok(/\/foo$/.test(breadcrumbs[0].data.to), "'to' url is incorrect");
+
+          assert.ok(/\/foo$/.test(breadcrumbs[1].data.from), "'from' url is incorrect");
+          assert.ok(
+            /\/bar\?a=1#fragment$/.test(breadcrumbs[1].data.to),
+            "'to' url is incorrect"
+          );
+
+          assert.ok(
+            /\/bar\?a=1#fragment$/.test(breadcrumbs[2].data.from),
+            "'from' url is incorrect"
+          );
+          assert.ok(
+            /\[object Object\]$/.test(breadcrumbs[2].data.to),
+            "'to' url is incorrect"
+          );
+
+          assert.ok(
+            /\[object Object\]$/.test(breadcrumbs[3].data.from),
+            "'from' url is incorrect"
+          );
+          assert.ok(
+            /\/bar\?a=1#fragment/.test(breadcrumbs[3].data.to),
+            "'to' url is incorrect"
+          );
+        }
+      );
+    });
+  });
+
+  describe('uninstall', function() {
+    it('should restore original built-ins', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+          Raven.uninstall();
+
+          window.isRestored = {
+            setTimeout: originalBuiltIns.setTimeout === setTimeout,
+            setInterval: originalBuiltIns.setInterval === setInterval,
+            requestAnimationFrame:
+              originalBuiltIns.requestAnimationFrame === requestAnimationFrame,
+            xhrProtoOpen: originalBuiltIns.xhrProtoOpen === XMLHttpRequest.prototype.open,
+            headAddEventListener:
+              originalBuiltIns.headAddEventListener === document.body.addEventListener,
+            headRemoveEventListener:
+              originalBuiltIns.headRemoveEventListener ===
+              document.body.removeEventListener
+          };
+        },
+        function() {
+          var isRestored = iframe.contentWindow.isRestored;
+          assert.isTrue(isRestored.setTimeout);
+          assert.isTrue(isRestored.setInterval);
+          assert.isTrue(isRestored.requestAnimationFrame);
+          assert.isTrue(isRestored.xhrProtoOpen);
+          assert.isTrue(isRestored.headAddEventListener);
+          assert.isTrue(isRestored.headRemoveEventListener);
+        }
+      );
+    });
+
+    it('should not restore XMLHttpRequest instance methods', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          var xhr = new XMLHttpRequest();
+          var origOnReadyStateChange = (xhr.onreadystatechange = function() {});
+          xhr.open('GET', '/foo/');
+          xhr.abort();
+
+          Raven.uninstall();
+
+          window.isOnReadyStateChangeRestored = xhr.onready === origOnReadyStateChange;
+        },
+        function() {
+          assert.isFalse(iframe.contentWindow.isOnReadyStateChangeRestored);
+        }
+      );
+    });
+  });
 });

--- a/test/integration/throw-error.js
+++ b/test/integration/throw-error.js
@@ -1,5 +1,5 @@
 function throwRealError() {
-    throw new Error('realError');
+  throw new Error('realError');
 }
 
 throwRealError();

--- a/test/integration/throw-object.js
+++ b/test/integration/throw-object.js
@@ -1,7 +1,7 @@
 function throwStringError() {
-    // never do this; just making sure Raven.js handles this case
-    // gracefully
-    throw {error: 'stuff is broken'};
+  // never do this; just making sure Raven.js handles this case
+  // gracefully
+  throw {error: 'stuff is broken'};
 }
 
 throwStringError();

--- a/test/integration/throw-string.js
+++ b/test/integration/throw-string.js
@@ -1,5 +1,5 @@
 function throwStringError() {
-    throw 'stringError';
+  throw 'stringError';
 }
 
 throwStringError();

--- a/test/plugins/angular.test.js
+++ b/test/plugins/angular.test.js
@@ -2,64 +2,78 @@ var _Raven = require('../../src/raven');
 var angularPlugin = require('../../plugins/angular');
 
 var Raven;
-describe('Angular plugin', function () {
-    beforeEach(function () {
-        Raven = new _Raven();
-        Raven.config('http://abc@example.com:80/2');
+describe('Angular plugin', function() {
+  beforeEach(function() {
+    Raven = new _Raven();
+    Raven.config('http://abc@example.com:80/2');
+  });
+
+  describe('_normalizeData()', function() {
+    it('should extract type, value, and the angularDocs URL from unminified exceptions', function() {
+      var data = {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+
+        culprit: 'http://example.org/app.js',
+        message: 'Error: crap',
+        exception: {
+          type: 'Error',
+          values: [
+            {
+              value:
+                '[ngRepeat:dupes] Duplicates in a repeater are not allowed. Use \'track by\' expression to specify unique keys. Repeater: element in elements | orderBy: \'createdAt\' track by element.id, Duplicate key: 25, Duplicate value: {"id":"booking-40"}\n' +
+                'http://errors.angularjs.org/1.4.3/ngRepeat/dupes?p0=element%20in%20elements…00%3A00%22%2C%22ends_at%22%3A%222016-06-09T23%3A59%3A59%2B00%3A00%22%7D%7D'
+            }
+          ]
+        },
+        extra: {}
+      };
+
+      angularPlugin._normalizeData(data);
+
+      var exception = data.exception.values[0];
+      assert.equal(exception.type, 'ngRepeat:dupes');
+      assert.equal(
+        exception.value,
+        'Duplicates in a repeater are not allowed. Use \'track by\' expression to specify unique keys. Repeater: element in elements | orderBy: \'createdAt\' track by element.id, Duplicate key: 25, Duplicate value: {"id":"booking-40"}'
+      );
+      assert.equal(
+        data.extra.angularDocs,
+        'http://errors.angularjs.org/1.4.3/ngRepeat/dupes?p0=element%20in%20elements…00%3A00%22%2C%22ends_at%22%3A%222016-06-09T23%3A59%3A59%2B00%3A00%22%7D%7D'
+      );
     });
 
-    describe('_normalizeData()', function () {
-        it('should extract type, value, and the angularDocs URL from unminified exceptions', function () {
-            var data = {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
+    it('should extract type and the angularDocs URL minified exceptions', function() {
+      var data = {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
 
-                culprit: 'http://example.org/app.js',
-                message: 'Error: crap',
-                exception: {
-                    type: 'Error',
-                    values: [{
-                        value:
-                          '[ngRepeat:dupes] Duplicates in a repeater are not allowed. Use \'track by\' expression to specify unique keys. Repeater: element in elements | orderBy: \'createdAt\' track by element.id, Duplicate key: 25, Duplicate value: {"id":"booking-40"}\n' +
-                          'http://errors.angularjs.org/1.4.3/ngRepeat/dupes?p0=element%20in%20elements…00%3A00%22%2C%22ends_at%22%3A%222016-06-09T23%3A59%3A59%2B00%3A00%22%7D%7D'
-                    }]
-                },
-                extra: {}
-            };
+        culprit: 'http://example.org/app.js',
+        message: 'Error: crap',
+        exception: {
+          type: 'Error',
+          values: [
+            {
+              // no message, no newlines
+              value:
+                '[ngRepeat:dupes] http://errors.angularjs.org/1.4.3/ngRepeat/dupes?p0=element%20in%20elements…00%3A00%22%2C%22ends_at%22%3A%222016-06-09T23%3A59%3A59%2B00%3A00%22%7D%7D'
+            }
+          ]
+        },
+        extra: {}
+      };
 
-            angularPlugin._normalizeData(data);
+      angularPlugin._normalizeData(data);
 
-            var exception = data.exception.values[0];
-            assert.equal(exception.type, 'ngRepeat:dupes');
-            assert.equal(exception.value, 'Duplicates in a repeater are not allowed. Use \'track by\' expression to specify unique keys. Repeater: element in elements | orderBy: \'createdAt\' track by element.id, Duplicate key: 25, Duplicate value: {"id":"booking-40"}');
-            assert.equal(data.extra.angularDocs, 'http://errors.angularjs.org/1.4.3/ngRepeat/dupes?p0=element%20in%20elements…00%3A00%22%2C%22ends_at%22%3A%222016-06-09T23%3A59%3A59%2B00%3A00%22%7D%7D');
-        });
-
-        it('should extract type and the angularDocs URL minified exceptions', function () {
-            var data = {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-
-                culprit: 'http://example.org/app.js',
-                message: 'Error: crap',
-                exception: {
-                    type: 'Error',
-                    values: [{
-                        // no message, no newlines
-                        value: '[ngRepeat:dupes] http://errors.angularjs.org/1.4.3/ngRepeat/dupes?p0=element%20in%20elements…00%3A00%22%2C%22ends_at%22%3A%222016-06-09T23%3A59%3A59%2B00%3A00%22%7D%7D'
-                    }]
-                },
-                extra: {}
-            };
-
-            angularPlugin._normalizeData(data);
-
-            var exception = data.exception.values[0];
-            assert.equal(exception.type, 'ngRepeat:dupes');
-            assert.equal(exception.value, '');
-            assert.equal(data.extra.angularDocs, 'http://errors.angularjs.org/1.4.3/ngRepeat/dupes?p0=element%20in%20elements…00%3A00%22%2C%22ends_at%22%3A%222016-06-09T23%3A59%3A59%2B00%3A00%22%7D%7D');
-        });
+      var exception = data.exception.values[0];
+      assert.equal(exception.type, 'ngRepeat:dupes');
+      assert.equal(exception.value, '');
+      assert.equal(
+        data.extra.angularDocs,
+        'http://errors.angularjs.org/1.4.3/ngRepeat/dupes?p0=element%20in%20elements…00%3A00%22%2C%22ends_at%22%3A%222016-06-09T23%3A59%3A59%2B00%3A00%22%7D%7D'
+      );
     });
+  });
 });

--- a/test/plugins/console.test.js
+++ b/test/plugins/console.test.js
@@ -2,47 +2,53 @@ var _Raven = require('../../src/raven');
 var consolePlugin = require('../../plugins/console');
 
 var Raven;
-describe('console plugin', function () {
-    beforeEach(function () {
-        Raven = new _Raven();
-        Raven.config('http://abc@example.com:80/2');
+describe('console plugin', function() {
+  beforeEach(function() {
+    Raven = new _Raven();
+    Raven.config('http://abc@example.com:80/2');
+  });
+
+  it('should call Raven.captureMessage', function() {
+    var console = {
+      debug: function() {},
+      info: function() {},
+      warn: function() {},
+      error: function() {}
+    };
+
+    consolePlugin(Raven, console);
+
+    this.sinon.stub(Raven, 'captureMessage');
+    console.error('Raven should capture', 'console.error');
+
+    assert.equal(Raven.captureMessage.callCount, 1);
+    assert.equal(
+      Raven.captureMessage.getCall(0).args[0],
+      'Raven should capture console.error'
+    );
+    assert.deepEqual(Raven.captureMessage.getCall(0).args[1], {
+      level: 'error',
+      logger: 'console',
+      extra: {
+        arguments: ['Raven should capture', 'console.error']
+      }
     });
 
-    it('should call Raven.captureMessage', function () {
-        var console = {
-            debug: function () {},
-            info: function () {},
-            warn: function () {},
-            error: function () {}
-        };
+    Raven.captureMessage.reset();
 
-        consolePlugin(Raven, console);
+    console.warn('Raven should capture console.warn');
 
-        this.sinon.stub(Raven, 'captureMessage');
-        console.error('Raven should capture', 'console.error');
-
-        assert.equal(Raven.captureMessage.callCount, 1);
-        assert.equal(Raven.captureMessage.getCall(0).args[0], 'Raven should capture console.error');
-        assert.deepEqual(Raven.captureMessage.getCall(0).args[1], {
-            level: 'error',
-            logger: 'console',
-            extra: {
-                arguments: ['Raven should capture', 'console.error']
-            }
-        });
-
-        Raven.captureMessage.reset();
-
-        console.warn('Raven should capture console.warn');
-
-        assert.equal(Raven.captureMessage.callCount, 1);
-        assert.equal(Raven.captureMessage.getCall(0).args[0], 'Raven should capture console.warn');
-        assert.deepEqual(Raven.captureMessage.getCall(0).args[1], {
-            level: 'warning', // warn => warning
-            logger: 'console',
-            extra: {
-                arguments: ['Raven should capture console.warn']
-            }
-        });
+    assert.equal(Raven.captureMessage.callCount, 1);
+    assert.equal(
+      Raven.captureMessage.getCall(0).args[0],
+      'Raven should capture console.warn'
+    );
+    assert.deepEqual(Raven.captureMessage.getCall(0).args[1], {
+      level: 'warning', // warn => warning
+      logger: 'console',
+      extra: {
+        arguments: ['Raven should capture console.warn']
+      }
     });
+  });
 });

--- a/test/plugins/react-native.test.js
+++ b/test/plugins/react-native.test.js
@@ -6,301 +6,327 @@ var reactNativePlugin = require('../../plugins/react-native');
 window.ErrorUtils = {};
 
 var Raven;
-describe('React Native plugin', function () {
-    beforeEach(function () {
-        Raven = new _Raven();
-        Raven.config('http://abc@example.com:80/2');
+describe('React Native plugin', function() {
+  beforeEach(function() {
+    Raven = new _Raven();
+    Raven.config('http://abc@example.com:80/2');
 
-        reactNativePlugin._persistPayload = self.sinon.stub().returns(Promise.resolve());
-        reactNativePlugin._restorePayload = self.sinon.stub().returns(Promise.resolve());
-        reactNativePlugin._clearPayload = self.sinon.stub().returns(Promise.resolve());
-    });
+    reactNativePlugin._persistPayload = self.sinon.stub().returns(Promise.resolve());
+    reactNativePlugin._restorePayload = self.sinon.stub().returns(Promise.resolve());
+    reactNativePlugin._clearPayload = self.sinon.stub().returns(Promise.resolve());
+  });
 
-    describe('_normalizeData()', function () {
-        it('should normalize culprit and frame filenames/URLs from .app directory', function () {
-            var data = {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
+  describe('_normalizeData()', function() {
+    it('should normalize culprit and frame filenames/URLs from .app directory', function() {
+      var data = {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
 
-                culprit: 'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/app.js',
-                message: 'Error: crap',
-                exception: {
-                    type: 'Error',
-                    values: [{
-                        stacktrace: {
-                            frames: [{
-                                filename: 'file:///var/containers/Bundle/Application/ABC/123.app/file1.js',
-                                lineno: 10,
-                                colno: 11,
-                                'function': 'broken'
-
-                            }, {
-                                filename: 'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/file2.js',
-                                lineno: 12,
-                                colno: 13,
-                                'function': 'lol'
-                            }]
-                        }
-                    }],
-                }
-            };
-            reactNativePlugin._normalizeData(data);
-
-            assert.equal(data.culprit, '/app.js');
-            var frames = data.exception.values[0].stacktrace.frames;
-            assert.equal(frames[0].filename, '/file1.js');
-            assert.equal(frames[1].filename, '/file2.js');
-        });
-
-        it('should normalize culprit and frame filenames/URLs from stacktrace interface', function () {
-            var data = {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-
-                culprit: 'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/app.js',
-                message: 'Error: crap',
-
-                stacktrace: {
-                    frames: [{
-                        filename: 'file:///var/containers/Bundle/Application/ABC/123.app/file1.js',
-                        lineno: 10,
-                        colno: 11,
-                        'function': 'broken'
-
-                    }, {
-                        filename: 'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/file2.js',
-                        lineno: 12,
-                        colno: 13,
-                        'function': 'lol'
-                    }]
-                }
-            };
-            reactNativePlugin._normalizeData(data);
-
-            assert.equal(data.culprit, '/app.js');
-            var frames = data.stacktrace.frames;
-            assert.equal(frames[0].filename, '/file1.js');
-            assert.equal(frames[1].filename, '/file2.js');
-        });
-
-        it('should normalize culprit and frame filenames/URLs from CodePush', function () {
-            var data = {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-
-                culprit: 'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/app.js',
-                message: 'Error: crap',
-                exception: {
-                    type: 'Error',
-                    values: [{
-                        stacktrace: {
-                            frames: [{
-                                filename: 'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/file1.js',
-                                lineno: 10,
-                                colno: 11,
-                                'function': 'broken'
-
-                            }, {
-                                filename: 'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/file2.js',
-                                lineno: 12,
-                                colno: 13,
-                                'function': 'lol'
-                            }]
-                        }
-                    }],
-                }
-            };
-            reactNativePlugin._normalizeData(data);
-
-            assert.equal(data.culprit, '/app.js');
-            var frames = data.exception.values[0].stacktrace.frames;
-            assert.equal(frames[0].filename, '/file1.js');
-            assert.equal(frames[1].filename, '/file2.js');
-        });
-    });
-
-    describe('_transport()', function () {
-        beforeEach(function () {
-            this.xhr = sinon.useFakeXMLHttpRequest();
-            var requests = this.requests = [];
-
-            this.xhr.onCreate = function (xhr) {
-              requests.push(xhr);
-            };
-        });
-
-        afterEach(function () {
-            this.xhr.restore();
-        });
-
-        it('should open and send a new XHR POST with urlencoded auth, fake origin', function () {
-            reactNativePlugin._transport({
-                url: 'https://example.org/1',
-                auth: {
-                    sentry_version: '7',
-                    sentry_client: 'raven-js/2.2.0',
-                    sentry_key: 'abc123'
-                },
-                data: {foo: 'bar'}
-            });
-
-            var lastXhr = this.requests.shift();
-            lastXhr.respond(200);
-
-            assert.equal(
-                lastXhr.url,
-                'https://example.org/1?sentry_version=7&sentry_client=raven-js%2F2.2.0&sentry_key=abc123'
-            );
-            assert.equal(lastXhr.method, 'POST');
-            assert.equal(lastXhr.requestBody, '{"foo":"bar"}');
-            assert.equal(lastXhr.requestHeaders['Content-type'], 'application/json');
-            assert.equal(lastXhr.requestHeaders['Origin'], 'react-native://');
-        });
-
-        it('should call onError callback on failure', function () {
-            var onError = this.sinon.stub();
-            var onSuccess = this.sinon.stub();
-            reactNativePlugin._transport({
-                url: 'https://example.org/1',
-                auth: {},
-                data: {foo: 'bar'},
-                onError: onError,
-                onSuccess: onSuccess
-            });
-
-            var lastXhr = this.requests.shift();
-            lastXhr.respond(401);
-
-            assert.isFalse(onSuccess.calledOnce);
-            assert.isTrue(onError.calledOnce);
-            assert.isTrue(onError.lastCall.args[0] instanceof Error);
-            assert.equal(onError.lastCall.args[0].request.status, 401);
-        });
-
-        it('should call onSuccess callback on success', function () {
-            var onError = this.sinon.stub();
-            var onSuccess = this.sinon.stub();
-            reactNativePlugin._transport({
-                url: 'https://example.org/1',
-                auth: {},
-                data: {foo: 'bar'},
-                onError: onError,
-                onSuccess: onSuccess
-            });
-
-            var lastXhr = this.requests.shift();
-            lastXhr.respond(200);
-
-            assert.isTrue(onSuccess.calledOnce);
-            assert.isFalse(onError.calledOnce);
-        });
-    });
-
-    describe('ErrorUtils global error handler', function () {
-        beforeEach(function () {
-            var self = this;
-            ErrorUtils.setGlobalHandler = function(fn) {
-                self.globalErrorHandler = fn;
-            };
-            self.defaultErrorHandler = self.sinon.stub();
-            ErrorUtils.getGlobalHandler = function () {
-                return self.defaultErrorHandler;
+        culprit: 'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/app.js',
+        message: 'Error: crap',
+        exception: {
+          type: 'Error',
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'file:///var/containers/Bundle/Application/ABC/123.app/file1.js',
+                    lineno: 10,
+                    colno: 11,
+                    function: 'broken'
+                  },
+                  {
+                    filename:
+                      'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/file2.js',
+                    lineno: 12,
+                    colno: 13,
+                    function: 'lol'
+                  }
+                ]
+              }
             }
-        });
+          ]
+        }
+      };
+      reactNativePlugin._normalizeData(data);
 
-        it('checks for persisted errors when starting', function () {
-            var onInit = self.sinon.stub();
-            reactNativePlugin(Raven, {onInitialize: onInit});
-            assert.isTrue(reactNativePlugin._restorePayload.calledOnce);
-
-            return Promise.resolve().then(function () {
-                assert.isTrue(onInit.calledOnce);
-            });
-        });
-
-        it('reports persisted errors', function () {
-            var payload = {abc: 123};
-            self.sinon.stub(Raven, '_sendProcessedPayload');
-            reactNativePlugin._restorePayload = self.sinon.stub().returns(Promise.resolve(payload));
-            var onInit = self.sinon.stub();
-            reactNativePlugin(Raven, {onInitialize: onInit});
-
-            return Promise.resolve().then(function () {
-                assert.isTrue(onInit.calledOnce);
-                assert.equal(onInit.getCall(0).args[0], payload);
-                assert.isTrue(Raven._sendProcessedPayload.calledOnce);
-                assert.equal(Raven._sendProcessedPayload.getCall(0).args[0], payload);
-            });
-        });
-
-        it('clears persisted errors after they are reported', function () {
-            var payload = {abc: 123};
-            var callback;
-            self.sinon.stub(Raven, '_sendProcessedPayload', function(p, cb) { callback = cb; });
-            reactNativePlugin._restorePayload = self.sinon.stub().returns(Promise.resolve(payload));
-
-            reactNativePlugin(Raven);
-
-            return Promise.resolve().then(function () {
-                assert.isFalse(reactNativePlugin._clearPayload.called);
-                callback();
-                assert.isTrue(reactNativePlugin._clearPayload.called);
-            });
-        });
-
-        it('does not clear persisted errors if there is an error reporting', function () {
-            var payload = {abc: 123};
-            var callback;
-            self.sinon.stub(Raven, '_sendProcessedPayload', function(p, cb) { callback = cb; });
-            reactNativePlugin._restorePayload = self.sinon.stub().returns(Promise.resolve(payload));
-
-            reactNativePlugin(Raven);
-
-            return Promise.resolve().then(function () {
-                assert.isFalse(reactNativePlugin._clearPayload.called);
-                callback(new Error('nope'));
-                assert.isFalse(reactNativePlugin._clearPayload.called);
-            });
-        });
-
-        describe('in development mode', function () {
-            beforeEach(function () {
-                global.__DEV__ = true;
-            });
-
-            it('should call the default React Native handler and Raven.captureException', function () {
-                reactNativePlugin(Raven);
-                var err = new Error();
-                this.sinon.stub(Raven, 'captureException');
-
-                this.globalErrorHandler(err, true);
-
-                assert.isTrue(this.defaultErrorHandler.calledOnce);
-                assert.isTrue(Raven.captureException.calledOnce);
-                assert.equal(Raven.captureException.getCall(0).args[0], err);
-            });
-        });
-
-        describe('in production mode', function () {
-            beforeEach(function () {
-                global.__DEV__ = false;
-            });
-
-            it('should call the default React Native handler after persisting the error', function () {
-                reactNativePlugin(Raven);
-                var err = new Error();
-                this.globalErrorHandler(err, true);
-
-                assert.isTrue(reactNativePlugin._persistPayload.calledOnce);
-
-                var defaultErrorHandler = this.defaultErrorHandler;
-                return Promise.resolve().then(function () {
-                    assert.isTrue(defaultErrorHandler.calledOnce);
-                });
-            });
-        });
+      assert.equal(data.culprit, '/app.js');
+      var frames = data.exception.values[0].stacktrace.frames;
+      assert.equal(frames[0].filename, '/file1.js');
+      assert.equal(frames[1].filename, '/file2.js');
     });
+
+    it('should normalize culprit and frame filenames/URLs from stacktrace interface', function() {
+      var data = {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+
+        culprit: 'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/app.js',
+        message: 'Error: crap',
+
+        stacktrace: {
+          frames: [
+            {
+              filename: 'file:///var/containers/Bundle/Application/ABC/123.app/file1.js',
+              lineno: 10,
+              colno: 11,
+              function: 'broken'
+            },
+            {
+              filename:
+                'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/file2.js',
+              lineno: 12,
+              colno: 13,
+              function: 'lol'
+            }
+          ]
+        }
+      };
+      reactNativePlugin._normalizeData(data);
+
+      assert.equal(data.culprit, '/app.js');
+      var frames = data.stacktrace.frames;
+      assert.equal(frames[0].filename, '/file1.js');
+      assert.equal(frames[1].filename, '/file2.js');
+    });
+
+    it('should normalize culprit and frame filenames/URLs from CodePush', function() {
+      var data = {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+
+        culprit:
+          'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/app.js',
+        message: 'Error: crap',
+        exception: {
+          type: 'Error',
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/file1.js',
+                    lineno: 10,
+                    colno: 11,
+                    function: 'broken'
+                  },
+                  {
+                    filename:
+                      'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/file2.js',
+                    lineno: 12,
+                    colno: 13,
+                    function: 'lol'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      };
+      reactNativePlugin._normalizeData(data);
+
+      assert.equal(data.culprit, '/app.js');
+      var frames = data.exception.values[0].stacktrace.frames;
+      assert.equal(frames[0].filename, '/file1.js');
+      assert.equal(frames[1].filename, '/file2.js');
+    });
+  });
+
+  describe('_transport()', function() {
+    beforeEach(function() {
+      this.xhr = sinon.useFakeXMLHttpRequest();
+      var requests = (this.requests = []);
+
+      this.xhr.onCreate = function(xhr) {
+        requests.push(xhr);
+      };
+    });
+
+    afterEach(function() {
+      this.xhr.restore();
+    });
+
+    it('should open and send a new XHR POST with urlencoded auth, fake origin', function() {
+      reactNativePlugin._transport({
+        url: 'https://example.org/1',
+        auth: {
+          sentry_version: '7',
+          sentry_client: 'raven-js/2.2.0',
+          sentry_key: 'abc123'
+        },
+        data: {foo: 'bar'}
+      });
+
+      var lastXhr = this.requests.shift();
+      lastXhr.respond(200);
+
+      assert.equal(
+        lastXhr.url,
+        'https://example.org/1?sentry_version=7&sentry_client=raven-js%2F2.2.0&sentry_key=abc123'
+      );
+      assert.equal(lastXhr.method, 'POST');
+      assert.equal(lastXhr.requestBody, '{"foo":"bar"}');
+      assert.equal(lastXhr.requestHeaders['Content-type'], 'application/json');
+      assert.equal(lastXhr.requestHeaders['Origin'], 'react-native://');
+    });
+
+    it('should call onError callback on failure', function() {
+      var onError = this.sinon.stub();
+      var onSuccess = this.sinon.stub();
+      reactNativePlugin._transport({
+        url: 'https://example.org/1',
+        auth: {},
+        data: {foo: 'bar'},
+        onError: onError,
+        onSuccess: onSuccess
+      });
+
+      var lastXhr = this.requests.shift();
+      lastXhr.respond(401);
+
+      assert.isFalse(onSuccess.calledOnce);
+      assert.isTrue(onError.calledOnce);
+      assert.isTrue(onError.lastCall.args[0] instanceof Error);
+      assert.equal(onError.lastCall.args[0].request.status, 401);
+    });
+
+    it('should call onSuccess callback on success', function() {
+      var onError = this.sinon.stub();
+      var onSuccess = this.sinon.stub();
+      reactNativePlugin._transport({
+        url: 'https://example.org/1',
+        auth: {},
+        data: {foo: 'bar'},
+        onError: onError,
+        onSuccess: onSuccess
+      });
+
+      var lastXhr = this.requests.shift();
+      lastXhr.respond(200);
+
+      assert.isTrue(onSuccess.calledOnce);
+      assert.isFalse(onError.calledOnce);
+    });
+  });
+
+  describe('ErrorUtils global error handler', function() {
+    beforeEach(function() {
+      var self = this;
+      ErrorUtils.setGlobalHandler = function(fn) {
+        self.globalErrorHandler = fn;
+      };
+      self.defaultErrorHandler = self.sinon.stub();
+      ErrorUtils.getGlobalHandler = function() {
+        return self.defaultErrorHandler;
+      };
+    });
+
+    it('checks for persisted errors when starting', function() {
+      var onInit = self.sinon.stub();
+      reactNativePlugin(Raven, {onInitialize: onInit});
+      assert.isTrue(reactNativePlugin._restorePayload.calledOnce);
+
+      return Promise.resolve().then(function() {
+        assert.isTrue(onInit.calledOnce);
+      });
+    });
+
+    it('reports persisted errors', function() {
+      var payload = {abc: 123};
+      self.sinon.stub(Raven, '_sendProcessedPayload');
+      reactNativePlugin._restorePayload = self.sinon
+        .stub()
+        .returns(Promise.resolve(payload));
+      var onInit = self.sinon.stub();
+      reactNativePlugin(Raven, {onInitialize: onInit});
+
+      return Promise.resolve().then(function() {
+        assert.isTrue(onInit.calledOnce);
+        assert.equal(onInit.getCall(0).args[0], payload);
+        assert.isTrue(Raven._sendProcessedPayload.calledOnce);
+        assert.equal(Raven._sendProcessedPayload.getCall(0).args[0], payload);
+      });
+    });
+
+    it('clears persisted errors after they are reported', function() {
+      var payload = {abc: 123};
+      var callback;
+      self.sinon.stub(Raven, '_sendProcessedPayload', function(p, cb) {
+        callback = cb;
+      });
+      reactNativePlugin._restorePayload = self.sinon
+        .stub()
+        .returns(Promise.resolve(payload));
+
+      reactNativePlugin(Raven);
+
+      return Promise.resolve().then(function() {
+        assert.isFalse(reactNativePlugin._clearPayload.called);
+        callback();
+        assert.isTrue(reactNativePlugin._clearPayload.called);
+      });
+    });
+
+    it('does not clear persisted errors if there is an error reporting', function() {
+      var payload = {abc: 123};
+      var callback;
+      self.sinon.stub(Raven, '_sendProcessedPayload', function(p, cb) {
+        callback = cb;
+      });
+      reactNativePlugin._restorePayload = self.sinon
+        .stub()
+        .returns(Promise.resolve(payload));
+
+      reactNativePlugin(Raven);
+
+      return Promise.resolve().then(function() {
+        assert.isFalse(reactNativePlugin._clearPayload.called);
+        callback(new Error('nope'));
+        assert.isFalse(reactNativePlugin._clearPayload.called);
+      });
+    });
+
+    describe('in development mode', function() {
+      beforeEach(function() {
+        global.__DEV__ = true;
+      });
+
+      it('should call the default React Native handler and Raven.captureException', function() {
+        reactNativePlugin(Raven);
+        var err = new Error();
+        this.sinon.stub(Raven, 'captureException');
+
+        this.globalErrorHandler(err, true);
+
+        assert.isTrue(this.defaultErrorHandler.calledOnce);
+        assert.isTrue(Raven.captureException.calledOnce);
+        assert.equal(Raven.captureException.getCall(0).args[0], err);
+      });
+    });
+
+    describe('in production mode', function() {
+      beforeEach(function() {
+        global.__DEV__ = false;
+      });
+
+      it('should call the default React Native handler after persisting the error', function() {
+        reactNativePlugin(Raven);
+        var err = new Error();
+        this.globalErrorHandler(err, true);
+
+        assert.isTrue(reactNativePlugin._persistPayload.calledOnce);
+
+        var defaultErrorHandler = this.defaultErrorHandler;
+        return Promise.resolve().then(function() {
+          assert.isTrue(defaultErrorHandler.calledOnce);
+        });
+      });
+    });
+  });
 });

--- a/test/plugins/vue.test.js
+++ b/test/plugins/vue.test.js
@@ -2,56 +2,60 @@ var _Raven = require('../../src/raven');
 var vuePlugin = require('../../plugins/vue');
 
 var Raven;
-describe('Vue plugin', function () {
-    beforeEach(function () {
-        Raven = new _Raven();
-        Raven.config('http://abc@example.com:80/2');
+describe('Vue plugin', function() {
+  beforeEach(function() {
+    Raven = new _Raven();
+    Raven.config('http://abc@example.com:80/2');
+  });
+
+  describe('errorHandler', function() {
+    beforeEach(function() {
+      this.sinon.stub(Raven, 'captureException');
+      this.MockVue = {
+        config: {}
+      };
     });
 
-    describe('errorHandler', function () {
-        beforeEach(function () {
-            this.sinon.stub(Raven, 'captureException');
-            this.MockVue = {
-                config: {}
-            };
-        });
+    it('should capture component name and propsData', function() {
+      vuePlugin(Raven, this.MockVue);
 
-        it('should capture component name and propsData', function () {
-            vuePlugin(Raven, this.MockVue);
+      this.MockVue.config.errorHandler(
+        new Error('foo'),
+        {
+          $options: {
+            propsData: {
+              foo: 'bar'
+            }
+          }
+        },
+        {} /* vm */
+      );
 
-            this.MockVue.config.errorHandler(new Error('foo'), {
-                $options: {
-                    propsData: {
-                        foo: 'bar'
-                    }
-                }
-            }, {} /* vm */);
+      assert.isTrue(Raven.captureException.calledOnce);
 
-            assert.isTrue(Raven.captureException.calledOnce);
-
-            assert.deepEqual(Raven.captureException.args[0][1].extra, {
-                propsData: {
-                    foo: 'bar'
-                },
-                componentName: 'anonymous component'
-            });
-        });
-
-        it('should call the existing error handler', function () {
-            var errorHandler = this.sinon.stub();
-            this.MockVue.config.errorHandler = errorHandler;
-            vuePlugin(Raven, this.MockVue); // should override errorHandler
-
-            var err = new Error('foo');
-            var vm = {
-                $options: { propsData: {} }
-            };
-            this.MockVue.config.errorHandler(err, vm);
-
-            assert.isTrue(Raven.captureException.calledOnce);
-            assert.isTrue(errorHandler.calledOnce);
-            assert.equal(errorHandler.args[0][0], err);
-            assert.equal(errorHandler.args[0][1], vm);
-        });
+      assert.deepEqual(Raven.captureException.args[0][1].extra, {
+        propsData: {
+          foo: 'bar'
+        },
+        componentName: 'anonymous component'
+      });
     });
+
+    it('should call the existing error handler', function() {
+      var errorHandler = this.sinon.stub();
+      this.MockVue.config.errorHandler = errorHandler;
+      vuePlugin(Raven, this.MockVue); // should override errorHandler
+
+      var err = new Error('foo');
+      var vm = {
+        $options: {propsData: {}}
+      };
+      this.MockVue.config.errorHandler(err, vm);
+
+      assert.isTrue(Raven.captureException.calledOnce);
+      assert.isTrue(errorHandler.calledOnce);
+      assert.equal(errorHandler.args[0][0], err);
+      assert.equal(errorHandler.args[0][1], vm);
+    });
+  });
 });

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -7,1581 +7,1723 @@ var proxyquire = require('proxyquireify')(require);
 var TraceKit = require('../vendor/TraceKit/tracekit');
 
 var _Raven = proxyquire('../src/raven', {
-    // Ensure same TraceKit obj is shared (without specifying this, proxyquire
-    // seems to clone dependencies or something weird)
-    '../vendor/TraceKit/tracekit': TraceKit
+  // Ensure same TraceKit obj is shared (without specifying this, proxyquire
+  // seems to clone dependencies or something weird)
+  '../vendor/TraceKit/tracekit': TraceKit
 });
 
-_Raven.prototype._getUuid = function () {
-    return 'abc123';
+_Raven.prototype._getUuid = function() {
+  return 'abc123';
 };
 
 var joinRegExp = _Raven.utils.joinRegExp;
 
 // window.console must be stubbed in for browsers that don't have it
 if (typeof window.console === 'undefined') {
-    console = {error: function(){}};
+  console = {error: function() {}};
 }
 
 var SENTRY_DSN = 'http://abc@example.com:80/2';
 
 function setupRaven() {
-    Raven.config(SENTRY_DSN, {
-        allowDuplicates: true
-    });
+  Raven.config(SENTRY_DSN, {
+    allowDuplicates: true
+  });
 }
 
 var Raven;
 
 describe('globals', function() {
+  beforeEach(function() {
+    this.clock = sinon.useFakeTimers();
+    this.clock.tick(0); // Raven initialized at time "0"
+    Raven = new _Raven();
+    setupRaven();
+
+    this.clock.tick(100); // tick 100 ms
+  });
+
+  afterEach(function() {
+    this.clock.restore();
+  });
+
+  describe('getHttpData', function() {
+    var data;
+
+    describe('with document and navigator', function() {
+      beforeEach(function() {
+        data = Raven._getHttpData();
+      });
+
+      it('should have a url', function() {
+        assert.equal(data.url, window.location.href);
+      });
+
+      it('should have the user-agent header', function() {
+        assert.equal(data.headers['User-Agent'], navigator.userAgent);
+      });
+
+      it('should have referer header when available', function() {
+        // lol this test is awful
+        if (window.document.referrer) {
+          assert.equal(data.headers.Referer, window.document.referrer);
+        } else {
+          assert.isUndefined(data.headers.Referer);
+        }
+      });
+    });
+
+    it('without document but with navigator should return user-agent', function() {
+      Raven._hasDocument = false;
+      data = Raven._getHttpData();
+      assert.equal(data.headers['User-Agent'], navigator.userAgent);
+    });
+
+    it('with neither document nor navigator should return undefined', function() {
+      Raven._hasDocument = false;
+      Raven._hasNavigator = false;
+      assert.isUndefined(Raven._getHttpData());
+    });
+  });
+
+  describe('trimPacket', function() {
+    it('should work as advertised', function() {
+      // message/excepion value (maxMessageLength)
+      Raven._globalOptions.maxMessageLength = 3;
+      assert.deepEqual(Raven._trimPacket({message: 'lol'}), {message: 'lol'});
+      assert.deepEqual(Raven._trimPacket({message: 'lolol'}), {message: 'lol\u2026'});
+      assert.deepEqual(
+        Raven._trimPacket({message: 'lol', exception: {values: [{value: 'lol'}]}}),
+        {message: 'lol', exception: {values: [{value: 'lol'}]}}
+      );
+      assert.deepEqual(
+        Raven._trimPacket({message: 'lolol', exception: {values: [{value: 'lolol'}]}}),
+        {message: 'lol\u2026', exception: {values: [{value: 'lol\u2026'}]}}
+      );
+
+      // request URLs (maxUrlLength)
+      Raven._globalOptions.maxUrlLength = 20;
+      assert.deepEqual(
+        Raven._trimPacket({
+          request: {
+            url: 'http://example.com/foo/bar/baz.js',
+            Referer: 'http://example.com/f\u2026'
+          }
+        }),
+        {
+          request: {
+            url: 'http://example.com/f\u2026',
+            Referer: 'http://example.com/f\u2026'
+          }
+        }
+      );
+    });
+  });
+
+  describe('_trimBreadcrumbs', function() {
+    it('should work as expected', function() {
+      Raven._globalOptions.maxUrlLength = 20;
+
+      var breadcrumbs = {
+        values: [
+          {
+            data: {
+              donttouch: 'this-is-not-a-url-field-and-should-not-be-touched',
+              to: 'http://example.com/foo/bar/baz.js',
+              from: 'http://example.com/foo/bar/baz.js'
+            }
+          },
+          {
+            data: {
+              donttouch: 'this-is-not-a-url-field-and-should-not-be-touched',
+              url: 'http://example.com/foo/bar/baz.js'
+            }
+          }
+        ]
+      };
+
+      // NOTE: _trimBreadcrumbs mutates data in-place
+      Raven._trimBreadcrumbs(breadcrumbs);
+      assert.deepEqual(breadcrumbs, {
+        values: [
+          {
+            data: {
+              donttouch: 'this-is-not-a-url-field-and-should-not-be-touched',
+              to: 'http://example.com/f\u2026', // 20 chars
+              from: 'http://example.com/f\u2026'
+            }
+          },
+          {
+            data: {
+              donttouch: 'this-is-not-a-url-field-and-should-not-be-touched',
+              url: 'http://example.com/f\u2026'
+            }
+          }
+        ]
+      });
+
+      breadcrumbs = {
+        values: [
+          {
+            data: undefined
+          }
+        ]
+      };
+
+      // see: https://github.com/getsentry/raven-js/issues/925
+      Raven._trimBreadcrumbs(breadcrumbs);
+      assert.deepEqual(breadcrumbs, {
+        values: [
+          {
+            data: undefined
+          }
+        ]
+      });
+    });
+  });
+
+  describe('isSetup', function() {
     beforeEach(function() {
-        this.clock = sinon.useFakeTimers();
-        this.clock.tick(0); // Raven initialized at time "0"
-        Raven = new _Raven();
-        setupRaven();
-
-        this.clock.tick(100); // tick 100 ms
+      this.sinon.stub(Raven, '_logDebug');
     });
 
-    afterEach(function () {
-        this.clock.restore();
+    it('should return false with no JSON support', function() {
+      Raven._globalServer = 'http://localhost/';
+      Raven._hasJSON = false;
+
+      assert.isFalse(Raven.isSetup());
     });
 
-    describe('getHttpData', function() {
-        var data;
+    describe('when Raven is not configured', function() {
+      it('should return false when Raven is not configured', function() {
+        Raven._hasJSON = true; // be explicit
+        Raven._globalServer = undefined;
 
-        describe('with document and navigator', function() {
-            beforeEach(function () {
-                data = Raven._getHttpData();
-            });
+        assert.isFalse(Raven.isSetup());
+      });
 
-            it('should have a url', function() {
-                assert.equal(data.url, window.location.href);
-            });
+      it('should log an error message, the first time it is called', function() {
+        Raven._hasJSON = true;
+        Raven._globalServer = undefined;
 
-            it('should have the user-agent header', function() {
-                assert.equal(data.headers['User-Agent'], navigator.userAgent);
-            });
+        Raven.isSetup();
+        Raven.isSetup();
+        assert.isTrue(
+          Raven._logDebug.calledWith('error', 'Error: Raven has not been configured.')
+        );
+        assert.isTrue(Raven._logDebug.calledOnce);
+      });
+    });
 
-            it('should have referer header when available', function() {
-                // lol this test is awful
-                if (window.document.referrer) {
-                    assert.equal(data.headers.Referer, window.document.referrer);
-                } else {
-                    assert.isUndefined(data.headers.Referer);
+    it('should return true when everything is all gravy', function() {
+      Raven._hasJSON = true;
+
+      assert.isTrue(Raven.isSetup());
+    });
+  });
+
+  describe('logDebug', function() {
+    var level = 'error',
+      message = 'foobar',
+      originalConsoleMethods;
+
+    beforeEach(function() {
+      originalConsoleMethods = Raven._originalConsoleMethods;
+    });
+
+    it('should not write to console when Raven.debug is false', function() {
+      Raven.debug = false;
+      this.sinon.stub(originalConsoleMethods, level);
+      Raven._logDebug(level, message);
+      assert.isFalse(originalConsoleMethods[level].called);
+    });
+
+    it('should write to console when Raven.debug is true', function() {
+      Raven.debug = true;
+      this.sinon.stub(originalConsoleMethods, level);
+      Raven._logDebug(level, message);
+      assert.isTrue(originalConsoleMethods[level].calledOnce);
+    });
+
+    it('should handle variadic arguments', function() {
+      Raven.debug = true;
+      this.sinon.stub(originalConsoleMethods, level);
+      Raven._logDebug(level, message, {}, 'foo');
+    });
+
+    it('should be unaffected by monkeypatches to the console built-in', function() {
+      Raven.debug = true;
+      this.sinon.stub(console, level).throws("can't touch this");
+      this.sinon.stub(originalConsoleMethods, level);
+      Raven._logDebug(level, message);
+      assert.isTrue(originalConsoleMethods[level].calledOnce);
+      assert.isFalse(console[level].called);
+      console[level].restore();
+    });
+  });
+
+  describe('parseDSN', function() {
+    it('should do what it advertises', function() {
+      var pieces = Raven._parseDSN('http://abc@example.com:80/2');
+      assert.strictEqual(pieces.protocol, 'http');
+      assert.strictEqual(pieces.user, 'abc');
+      assert.strictEqual(pieces.port, '80');
+      assert.strictEqual(pieces.path, '/2');
+      assert.strictEqual(pieces.host, 'example.com');
+    });
+
+    it('should parse protocol relative', function() {
+      var pieces = Raven._parseDSN('//user@mattrobenolt.com/');
+      assert.strictEqual(pieces.protocol, '');
+      assert.strictEqual(pieces.user, 'user');
+      assert.strictEqual(pieces.port, '');
+      assert.strictEqual(pieces.path, '/');
+      assert.strictEqual(pieces.host, 'mattrobenolt.com');
+    });
+
+    it('should parse domain with hyphen', function() {
+      var pieces = Raven._parseDSN('http://user@matt-robenolt.com/1');
+      assert.strictEqual(pieces.protocol, 'http');
+      assert.strictEqual(pieces.user, 'user');
+      assert.strictEqual(pieces.port, '');
+      assert.strictEqual(pieces.path, '/1');
+      assert.strictEqual(pieces.host, 'matt-robenolt.com');
+    });
+
+    it('should parse domain without user', function() {
+      var pieces = Raven._parseDSN('http://matt-robenolt.com/1');
+      assert.strictEqual(pieces.protocol, 'http');
+      assert.strictEqual(pieces.user, '');
+      assert.strictEqual(pieces.port, '');
+      assert.strictEqual(pieces.path, '/1');
+      assert.strictEqual(pieces.host, 'matt-robenolt.com');
+    });
+
+    it('should raise a RavenConfigError when setting a password', function() {
+      try {
+        Raven._parseDSN('http://user:pass@example.com/2');
+      } catch (e) {
+        return assert.equal(e.name, 'RavenConfigError');
+      }
+      // shouldn't hit this
+      assert.isTrue(false);
+    });
+
+    it('should raise a RavenConfigError with an invalid DSN', function() {
+      try {
+        Raven._parseDSN('lol');
+      } catch (e) {
+        return assert.equal(e.name, 'RavenConfigError');
+      }
+      // shouldn't hit this
+      assert.isTrue(false);
+    });
+  });
+
+  describe('normalizeFrame', function() {
+    it('should handle a normal frame', function() {
+      var frame = {
+        url: 'http://example.com/path/file.js',
+        line: 10,
+        column: 11,
+        func: 'lol'
+        // context: []    context is stubbed
+      };
+
+      assert.deepEqual(Raven._normalizeFrame(frame), {
+        filename: 'http://example.com/path/file.js',
+        lineno: 10,
+        colno: 11,
+        function: 'lol',
+        in_app: true
+      });
+    });
+
+    it('should handle a frame without context', function() {
+      var frame = {
+        url: 'http://example.com/path/file.js',
+        line: 10,
+        column: 11,
+        func: 'lol'
+      };
+
+      assert.deepEqual(Raven._normalizeFrame(frame), {
+        filename: 'http://example.com/path/file.js',
+        lineno: 10,
+        colno: 11,
+        function: 'lol',
+        in_app: true
+      });
+    });
+
+    it('should not mark `in_app` if rules match', function() {
+      var frame = {
+        url: 'http://example.com/path/file.js',
+        line: 10,
+        column: 11,
+        func: 'lol'
+      };
+
+      Raven._globalOptions.includePaths = /^http:\/\/example\.com/;
+
+      assert.deepEqual(Raven._normalizeFrame(frame), {
+        filename: 'http://example.com/path/file.js',
+        lineno: 10,
+        colno: 11,
+        function: 'lol',
+        in_app: true
+      });
+    });
+
+    it('should mark `in_app` if rules do not match', function() {
+      var frame = {
+        url: 'http://lol.com/path/file.js',
+        line: 10,
+        column: 11,
+        func: 'lol'
+      };
+
+      Raven._globalOptions.includePaths = /^http:\/\/example\.com/;
+
+      assert.deepEqual(Raven._normalizeFrame(frame), {
+        filename: 'http://lol.com/path/file.js',
+        lineno: 10,
+        colno: 11,
+        function: 'lol',
+        in_app: false
+      });
+    });
+
+    it('should mark `in_app` for raven.js', function() {
+      var frame = {
+        url: 'http://lol.com/path/raven.js',
+        line: 10,
+        column: 11,
+        func: 'lol'
+      };
+
+      assert.deepEqual(Raven._normalizeFrame(frame), {
+        filename: 'http://lol.com/path/raven.js',
+        lineno: 10,
+        colno: 11,
+        function: 'lol',
+        in_app: false
+      });
+    });
+
+    it('should mark `in_app` for raven.min.js', function() {
+      var frame = {
+        url: 'http://lol.com/path/raven.min.js',
+        line: 10,
+        column: 11,
+        func: 'lol'
+      };
+
+      assert.deepEqual(Raven._normalizeFrame(frame), {
+        filename: 'http://lol.com/path/raven.min.js',
+        lineno: 10,
+        colno: 11,
+        function: 'lol',
+        in_app: false
+      });
+    });
+
+    it('should mark `in_app` for Raven', function() {
+      var frame = {
+        url: 'http://lol.com/path/file.js',
+        line: 10,
+        column: 11,
+        func: 'Raven.wrap'
+      };
+
+      assert.deepEqual(Raven._normalizeFrame(frame), {
+        filename: 'http://lol.com/path/file.js',
+        lineno: 10,
+        colno: 11,
+        function: 'Raven.wrap',
+        in_app: false
+      });
+    });
+
+    it('should mark `in_app` for TraceKit', function() {
+      var frame = {
+        url: 'http://lol.com/path/file.js',
+        line: 10,
+        column: 11,
+        func: 'TraceKit.lol'
+      };
+
+      assert.deepEqual(Raven._normalizeFrame(frame), {
+        filename: 'http://lol.com/path/file.js',
+        lineno: 10,
+        colno: 11,
+        function: 'TraceKit.lol',
+        in_app: false
+      });
+    });
+
+    it('should not blow up if includePaths is empty, regression for #377', function() {
+      var frame = {
+        url: 'http://lol.com/path/file.js',
+        line: 10,
+        column: 11,
+        func: 'TraceKit.lol'
+      };
+      Raven._globalOptions.includePaths = [];
+      Raven._normalizeFrame(frame);
+    });
+  });
+
+  describe('processException', function() {
+    it('should respect `ignoreErrors`', function() {
+      this.sinon.stub(Raven, '_send');
+
+      Raven._globalOptions.ignoreErrors = joinRegExp(['e1', 'e2']);
+      Raven._processException('Error', 'e1', 'http://example.com', []);
+      assert.isFalse(Raven._send.called);
+      Raven._processException('Error', 'e2', 'http://example.com', []);
+      assert.isFalse(Raven._send.called);
+      Raven._processException('Error', 'error', 'http://example.com', []);
+      assert.isTrue(Raven._send.calledOnce);
+    });
+
+    it('should handle empty `ignoreErrors`', function() {
+      this.sinon.stub(Raven, '_send');
+
+      Raven._globalOptions.ignoreErrors = [];
+      Raven._processException('Error', 'e1', 'http://example.com', []);
+      assert.isTrue(Raven._send.calledOnce);
+    });
+
+    it('should respect `ignoreUrls`', function() {
+      this.sinon.stub(Raven, '_send');
+
+      Raven._globalOptions.ignoreUrls = joinRegExp([/.+?host1.+/, /.+?host2.+/]);
+      Raven._processException('Error', 'error', 'http://host1/', []);
+      assert.isFalse(Raven._send.called);
+      Raven._processException('Error', 'error', 'http://host2/', []);
+      assert.isFalse(Raven._send.called);
+      Raven._processException('Error', 'error', 'http://host3/', []);
+      assert.isTrue(Raven._send.calledOnce);
+    });
+
+    it('should handle empty `ignoreUrls`', function() {
+      this.sinon.stub(Raven, '_send');
+
+      Raven._globalOptions.ignoreUrls = [];
+      Raven._processException('Error', 'e1', 'http://example.com', []);
+      assert.isTrue(Raven._send.calledOnce);
+    });
+
+    it('should respect `whitelistUrls`', function() {
+      this.sinon.stub(Raven, '_send');
+
+      Raven._globalOptions.whitelistUrls = joinRegExp([/.+?host1.+/, /.+?host2.+/]);
+      Raven._processException('Error', 'error', 'http://host1/', []);
+      assert.equal(Raven._send.callCount, 1);
+      Raven._processException('Error', 'error', 'http://host2/', []);
+      assert.equal(Raven._send.callCount, 2);
+      Raven._processException('Error', 'error', 'http://host3/', []);
+      assert.equal(Raven._send.callCount, 2);
+    });
+
+    it('should handle empty `whitelistUrls`', function() {
+      this.sinon.stub(Raven, '_send');
+
+      Raven._globalOptions.whitelistUrls = [];
+      Raven._processException('Error', 'e1', 'http://example.com', []);
+      assert.isTrue(Raven._send.calledOnce);
+    });
+
+    it('should send a proper payload with frames', function() {
+      this.sinon.stub(Raven, '_send');
+
+      var frames = [
+          {
+            filename: 'http://example.com/file1.js'
+          },
+          {
+            filename: 'http://example.com/file2.js'
+          }
+        ],
+        framesFlipped = frames.slice(0);
+
+      framesFlipped.reverse();
+
+      Raven._processException(
+        'Error',
+        'lol',
+        'http://example.com/override.js',
+        10,
+        frames.slice(0),
+        {}
+      );
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'lol',
+                stacktrace: {
+                  frames: framesFlipped
                 }
-            });
-        });
+              }
+            ]
+          },
+          culprit: 'http://example.com/file1.js'
+        }
+      ]);
 
-        it('without document but with navigator should return user-agent', function () {
-            Raven._hasDocument = false;
-            data = Raven._getHttpData();
-            assert.equal(data.headers['User-Agent'], navigator.userAgent);
-        });
-
-        it('with neither document nor navigator should return undefined', function () {
-          Raven._hasDocument = false;
-          Raven._hasNavigator = false;
-          assert.isUndefined(Raven._getHttpData());
-        });
-    });
-
-    describe('trimPacket', function() {
-        it('should work as advertised', function() {
-            // message/excepion value (maxMessageLength)
-            Raven._globalOptions.maxMessageLength = 3;
-            assert.deepEqual(
-                Raven._trimPacket({message: 'lol'}),
-                {message: 'lol'}
-            );
-            assert.deepEqual(
-                Raven._trimPacket({message: 'lolol'}),
-                {message: 'lol\u2026'}
-            );
-            assert.deepEqual(
-                Raven._trimPacket({message: 'lol', exception: {values: [{value: 'lol'}]}}),
-                {message: 'lol', exception: {values: [{value: 'lol'}]}}
-            );
-            assert.deepEqual(
-                Raven._trimPacket({message: 'lolol', exception: {values: [{value: 'lolol'}]}}),
-                {message: 'lol\u2026', exception: {values: [{value: 'lol\u2026'}]}}
-            );
-
-            // request URLs (maxUrlLength)
-            Raven._globalOptions.maxUrlLength = 20;
-            assert.deepEqual(
-                Raven._trimPacket({request: {url: 'http://example.com/foo/bar/baz.js', Referer: 'http://example.com/f\u2026'}}),
-                {request: {url: 'http://example.com/f\u2026', Referer: 'http://example.com/f\u2026'}}
-            )
-        });
-    });
-
-    describe('_trimBreadcrumbs', function() {
-        it('should work as expected', function() {
-            Raven._globalOptions.maxUrlLength = 20;
-
-            var breadcrumbs = {
-                values: [{
-                    data: {
-                        donttouch: 'this-is-not-a-url-field-and-should-not-be-touched',
-                        to: 'http://example.com/foo/bar/baz.js',
-                        from: 'http://example.com/foo/bar/baz.js'
-                    }
-                }, {
-                    data: {
-                        donttouch: 'this-is-not-a-url-field-and-should-not-be-touched',
-                        url: 'http://example.com/foo/bar/baz.js'
-                    }
-                }]
-            };
-
-            // NOTE: _trimBreadcrumbs mutates data in-place
-            Raven._trimBreadcrumbs(breadcrumbs);
-            assert.deepEqual(breadcrumbs, {
-                values: [{
-                    data: {
-                        donttouch: 'this-is-not-a-url-field-and-should-not-be-touched',
-                        to: 'http://example.com/f\u2026', // 20 chars
-                        from: 'http://example.com/f\u2026'
-                    }
-                }, {
-                    data: {
-                        donttouch: 'this-is-not-a-url-field-and-should-not-be-touched',
-                        url: 'http://example.com/f\u2026'
-                    }
-                }]
-            });
-
-           breadcrumbs = {
-               values: [{
-                   data: undefined
-               }]
-           };
-
-           // see: https://github.com/getsentry/raven-js/issues/925
-           Raven._trimBreadcrumbs(breadcrumbs);
-           assert.deepEqual(breadcrumbs, {
-              values: [{
-                   data: undefined
-               }]
-            });
-        });
-    });
-
-    describe('isSetup', function() {
-        beforeEach(function () {
-          this.sinon.stub(Raven, '_logDebug');
-        });
-
-        it('should return false with no JSON support', function() {
-            Raven._globalServer = 'http://localhost/';
-            Raven._hasJSON = false;
-
-            assert.isFalse(Raven.isSetup());
-        });
-
-        describe('when Raven is not configured', function () {
-            it('should return false when Raven is not configured', function() {
-                Raven._hasJSON = true;    // be explicit
-                Raven._globalServer = undefined;
-
-                assert.isFalse(Raven.isSetup());
-            });
-
-            it('should log an error message, the first time it is called', function () {
-                Raven._hasJSON = true;
-                Raven._globalServer = undefined;
-
-                Raven.isSetup();
-                Raven.isSetup();
-                assert.isTrue(Raven._logDebug.calledWith('error', 'Error: Raven has not been configured.'));
-                assert.isTrue(Raven._logDebug.calledOnce);
-            });
-        });
-
-        it('should return true when everything is all gravy', function() {
-            Raven._hasJSON = true;
-
-            assert.isTrue(Raven.isSetup());
-        });
-    });
-
-    describe('logDebug', function() {
-        var level = 'error',
-            message = 'foobar',
-            originalConsoleMethods;
-
-        beforeEach(function () {
-            originalConsoleMethods = Raven._originalConsoleMethods;
-        });
-
-        it('should not write to console when Raven.debug is false', function() {
-            Raven.debug = false;
-            this.sinon.stub(originalConsoleMethods, level);
-            Raven._logDebug(level, message);
-            assert.isFalse(originalConsoleMethods[level].called);
-        });
-
-        it('should write to console when Raven.debug is true', function() {
-            Raven.debug = true;
-            this.sinon.stub(originalConsoleMethods, level);
-            Raven._logDebug(level, message);
-            assert.isTrue(originalConsoleMethods[level].calledOnce);
-        });
-
-        it('should handle variadic arguments', function() {
-            Raven.debug = true;
-            this.sinon.stub(originalConsoleMethods, level);
-            Raven._logDebug(level, message, {}, 'foo');
-        });
-
-        it('should be unaffected by monkeypatches to the console built-in', function() {
-            Raven.debug = true;
-            this.sinon.stub(console, level).throws("can't touch this");
-            this.sinon.stub(originalConsoleMethods, level);
-            Raven._logDebug(level, message);
-            assert.isTrue(originalConsoleMethods[level].calledOnce);
-            assert.isFalse(console[level].called);
-            console[level].restore();
-        });
-    });
-
-    describe('parseDSN', function() {
-        it('should do what it advertises', function() {
-            var pieces = Raven._parseDSN('http://abc@example.com:80/2');
-            assert.strictEqual(pieces.protocol, 'http');
-            assert.strictEqual(pieces.user, 'abc');
-            assert.strictEqual(pieces.port, '80');
-            assert.strictEqual(pieces.path, '/2');
-            assert.strictEqual(pieces.host, 'example.com');
-        });
-
-        it('should parse protocol relative', function() {
-            var pieces = Raven._parseDSN('//user@mattrobenolt.com/');
-            assert.strictEqual(pieces.protocol, '');
-            assert.strictEqual(pieces.user, 'user');
-            assert.strictEqual(pieces.port, '');
-            assert.strictEqual(pieces.path, '/');
-            assert.strictEqual(pieces.host, 'mattrobenolt.com');
-        });
-
-        it('should parse domain with hyphen', function() {
-            var pieces = Raven._parseDSN('http://user@matt-robenolt.com/1');
-            assert.strictEqual(pieces.protocol, 'http');
-            assert.strictEqual(pieces.user, 'user');
-            assert.strictEqual(pieces.port, '');
-            assert.strictEqual(pieces.path, '/1');
-            assert.strictEqual(pieces.host, 'matt-robenolt.com');
-        });
-
-        it('should parse domain without user', function() {
-            var pieces = Raven._parseDSN('http://matt-robenolt.com/1');
-            assert.strictEqual(pieces.protocol, 'http');
-            assert.strictEqual(pieces.user, '');
-            assert.strictEqual(pieces.port, '');
-            assert.strictEqual(pieces.path, '/1');
-            assert.strictEqual(pieces.host, 'matt-robenolt.com');
-        });
-
-        it('should raise a RavenConfigError when setting a password', function() {
-            try {
-                Raven._parseDSN('http://user:pass@example.com/2');
-            } catch(e) {
-                return assert.equal(e.name, 'RavenConfigError');
-            }
-            // shouldn't hit this
-            assert.isTrue(false);
-        });
-
-        it('should raise a RavenConfigError with an invalid DSN', function() {
-            try {
-                Raven._parseDSN('lol');
-            } catch(e) {
-                return assert.equal(e.name, 'RavenConfigError');
-            }
-            // shouldn't hit this
-            assert.isTrue(false);
-        });
-    });
-
-    describe('normalizeFrame', function() {
-        it('should handle a normal frame', function() {
-            var frame = {
-                url: 'http://example.com/path/file.js',
-                line: 10,
-                column: 11,
-                func: 'lol'
-                // context: []    context is stubbed
-            };
-
-            assert.deepEqual(Raven._normalizeFrame(frame), {
-                filename: 'http://example.com/path/file.js',
-                lineno: 10,
-                colno: 11,
-                'function': 'lol',
-                in_app: true
-            });
-        });
-
-        it('should handle a frame without context', function() {
-            var frame = {
-                url: 'http://example.com/path/file.js',
-                line: 10,
-                column: 11,
-                func: 'lol'
-            };
-
-            assert.deepEqual(Raven._normalizeFrame(frame), {
-                filename: 'http://example.com/path/file.js',
-                lineno: 10,
-                colno: 11,
-                'function': 'lol',
-                in_app: true
-            });
-        });
-
-        it('should not mark `in_app` if rules match', function() {
-            var frame = {
-                url: 'http://example.com/path/file.js',
-                line: 10,
-                column: 11,
-                func: 'lol'
-            };
-
-            Raven._globalOptions.includePaths = /^http:\/\/example\.com/;
-
-            assert.deepEqual(Raven._normalizeFrame(frame), {
-                filename: 'http://example.com/path/file.js',
-                lineno: 10,
-                colno: 11,
-                'function': 'lol',
-                in_app: true
-            });
-        });
-
-        it('should mark `in_app` if rules do not match', function() {
-            var frame = {
-                url: 'http://lol.com/path/file.js',
-                line: 10,
-                column: 11,
-                func: 'lol'
-            };
-
-            Raven._globalOptions.includePaths = /^http:\/\/example\.com/;
-
-            assert.deepEqual(Raven._normalizeFrame(frame), {
-                filename: 'http://lol.com/path/file.js',
-                lineno: 10,
-                colno: 11,
-                'function': 'lol',
-                in_app: false
-            });
-        });
-
-        it('should mark `in_app` for raven.js', function() {
-            var frame = {
-                url: 'http://lol.com/path/raven.js',
-                line: 10,
-                column: 11,
-                func: 'lol'
-            };
-
-            assert.deepEqual(Raven._normalizeFrame(frame), {
-                filename: 'http://lol.com/path/raven.js',
-                lineno: 10,
-                colno: 11,
-                'function': 'lol',
-                in_app: false
-            });
-        });
-
-        it('should mark `in_app` for raven.min.js', function() {
-            var frame = {
-                url: 'http://lol.com/path/raven.min.js',
-                line: 10,
-                column: 11,
-                func: 'lol'
-            };
-
-            assert.deepEqual(Raven._normalizeFrame(frame), {
-                filename: 'http://lol.com/path/raven.min.js',
-                lineno: 10,
-                colno: 11,
-                'function': 'lol',
-                in_app: false
-            });
-        });
-
-        it('should mark `in_app` for Raven', function() {
-            var frame = {
-                url: 'http://lol.com/path/file.js',
-                line: 10,
-                column: 11,
-                func: 'Raven.wrap'
-            };
-
-            assert.deepEqual(Raven._normalizeFrame(frame), {
-                filename: 'http://lol.com/path/file.js',
-                lineno: 10,
-                colno: 11,
-                'function': 'Raven.wrap',
-                in_app: false
-            });
-        });
-
-        it('should mark `in_app` for TraceKit', function() {
-            var frame = {
-                url: 'http://lol.com/path/file.js',
-                line: 10,
-                column: 11,
-                func: 'TraceKit.lol'
-            };
-
-            assert.deepEqual(Raven._normalizeFrame(frame), {
-                filename: 'http://lol.com/path/file.js',
-                lineno: 10,
-                colno: 11,
-                'function': 'TraceKit.lol',
-                in_app: false
-            });
-        });
-
-        it('should not blow up if includePaths is empty, regression for #377', function() {
-            var frame = {
-                url: 'http://lol.com/path/file.js',
-                line: 10,
-                column: 11,
-                func: 'TraceKit.lol'
-            };
-            Raven._globalOptions.includePaths = [];
-            Raven._normalizeFrame(frame);
-        });
-    });
-
-    describe('processException', function() {
-        it('should respect `ignoreErrors`', function() {
-            this.sinon.stub(Raven, '_send');
-
-            Raven._globalOptions.ignoreErrors = joinRegExp(['e1', 'e2']);
-            Raven._processException('Error', 'e1', 'http://example.com', []);
-            assert.isFalse(Raven._send.called);
-            Raven._processException('Error', 'e2', 'http://example.com', []);
-            assert.isFalse(Raven._send.called);
-            Raven._processException('Error', 'error', 'http://example.com', []);
-            assert.isTrue(Raven._send.calledOnce);
-        });
-
-        it('should handle empty `ignoreErrors`', function() {
-            this.sinon.stub(Raven, '_send');
-
-            Raven._globalOptions.ignoreErrors = [];
-            Raven._processException('Error', 'e1', 'http://example.com', []);
-            assert.isTrue(Raven._send.calledOnce);
-        });
-
-        it('should respect `ignoreUrls`', function() {
-            this.sinon.stub(Raven, '_send');
-
-            Raven._globalOptions.ignoreUrls = joinRegExp([/.+?host1.+/, /.+?host2.+/]);
-            Raven._processException('Error', 'error', 'http://host1/', []);
-            assert.isFalse(Raven._send.called);
-            Raven._processException('Error', 'error', 'http://host2/', []);
-            assert.isFalse(Raven._send.called);
-            Raven._processException('Error', 'error', 'http://host3/', []);
-            assert.isTrue(Raven._send.calledOnce);
-        });
-
-        it('should handle empty `ignoreUrls`', function() {
-            this.sinon.stub(Raven, '_send');
-
-            Raven._globalOptions.ignoreUrls = [];
-            Raven._processException('Error', 'e1', 'http://example.com', []);
-            assert.isTrue(Raven._send.calledOnce);
-        });
-
-        it('should respect `whitelistUrls`', function() {
-            this.sinon.stub(Raven, '_send');
-
-            Raven._globalOptions.whitelistUrls = joinRegExp([/.+?host1.+/, /.+?host2.+/]);
-            Raven._processException('Error', 'error', 'http://host1/', []);
-            assert.equal(Raven._send.callCount, 1);
-            Raven._processException('Error', 'error', 'http://host2/', []);
-            assert.equal(Raven._send.callCount, 2);
-            Raven._processException('Error', 'error', 'http://host3/', []);
-            assert.equal(Raven._send.callCount, 2);
-        });
-
-        it('should handle empty `whitelistUrls`', function() {
-            this.sinon.stub(Raven, '_send');
-
-            Raven._globalOptions.whitelistUrls = [];
-            Raven._processException('Error', 'e1', 'http://example.com', []);
-            assert.isTrue(Raven._send.calledOnce);
-        });
-
-        it('should send a proper payload with frames', function() {
-            this.sinon.stub(Raven, '_send');
-
-            var frames = [
-                {
-                    filename: 'http://example.com/file1.js'
-                },
-                {
-                    filename: 'http://example.com/file2.js'
+      Raven._processException('Error', 'lol', '', 10, frames.slice(0), {});
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'lol',
+                stacktrace: {
+                  frames: framesFlipped
                 }
-            ], framesFlipped = frames.slice(0);
+              }
+            ]
+          },
+          culprit: 'http://example.com/file1.js'
+        }
+      ]);
 
-            framesFlipped.reverse();
-
-            Raven._processException('Error', 'lol', 'http://example.com/override.js', 10, frames.slice(0), {});
-            assert.deepEqual(Raven._send.lastCall.args, [{
-                exception: {
-                    values: [{
-                        type: 'Error',
-                        value: 'lol',
-                        stacktrace: {
-                            frames: framesFlipped
-                        }
-                    }]
-                },
-                culprit: 'http://example.com/file1.js'
-            }]);
-
-            Raven._processException('Error', 'lol', '', 10, frames.slice(0), {});
-            assert.deepEqual(Raven._send.lastCall.args, [{
-                exception: {
-                    values: [{
-                        type: 'Error',
-                        value: 'lol',
-                        stacktrace: {
-                            frames: framesFlipped
-                        }
-                    }]
-                },
-                culprit: 'http://example.com/file1.js'
-            }]);
-
-            Raven._processException('Error', 'lol', '', 10, frames.slice(0), {extra: 'awesome'});
-            assert.deepEqual(Raven._send.lastCall.args, [{
-                exception: {
-                    values: [{
-                        type: 'Error',
-                        value: 'lol',
-                        stacktrace: {
-                            frames: framesFlipped
-                        }
-                    }]
-                },
-                culprit: 'http://example.com/file1.js',
-                extra: 'awesome'
-            }]);
-        });
-
-        it('should send a proper payload without frames', function() {
-            this.sinon.stub(Raven, '_send');
-
-            Raven._processException('Error', 'lol', 'http://example.com/override.js', 10, [], {});
-            assert.deepEqual(Raven._send.lastCall.args, [{
-                exception: {
-                    values: [{
-                        type: 'Error',
-                        value: 'lol',
-                        stacktrace: {
-                            frames: [{
-                                filename: 'http://example.com/override.js',
-                                lineno: 10,
-                                in_app: true
-                            }]
-                        }
-                    }]
-                },
-                culprit: 'http://example.com/override.js'
-            }]);
-
-            Raven._processException('Error', 'lol', 'http://example.com/override.js', 10, [], {});
-            assert.deepEqual(Raven._send.lastCall.args, [{
-                exception: {
-                    values: [{
-                        type: 'Error',
-                        value: 'lol',
-                        stacktrace: {
-                            frames: [{
-                                filename: 'http://example.com/override.js',
-                                lineno: 10,
-                                in_app: true
-                            }]
-                        }
-                    }]
-                },
-                culprit: 'http://example.com/override.js'
-            }]);
-
-            Raven._processException('Error', 'lol', 'http://example.com/override.js', 10, [], {extra: 'awesome'});
-            assert.deepEqual(Raven._send.lastCall.args, [{
-                exception: {
-                    values: [{
-                        type: 'Error',
-                        value: 'lol',
-                        stacktrace: {
-                            frames: [{
-                                filename: 'http://example.com/override.js',
-                                lineno: 10,
-                                in_app: true
-                            }]
-                        }
-                    }]
-                },
-                culprit: 'http://example.com/override.js',
-                extra: 'awesome'
-            }]);
-        });
-
-        it('should not blow up with `undefined` message', function() {
-            this.sinon.stub(Raven, '_send');
-
-            Raven._processException('TypeError', undefined, 'http://example.com', []);
-            assert.isTrue(Raven._send.called);
-        });
+      Raven._processException('Error', 'lol', '', 10, frames.slice(0), {
+        extra: 'awesome'
+      });
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'lol',
+                stacktrace: {
+                  frames: framesFlipped
+                }
+              }
+            ]
+          },
+          culprit: 'http://example.com/file1.js',
+          extra: 'awesome'
+        }
+      ]);
     });
 
-    describe('send', function() {
-        it('should build a good data payload', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100
-            };
-            Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: {method: 'POST', url: 'http://example.org/api/0/auth/'}}];
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100},
-                breadcrumbs: {
-                    values: [
-                        { type: 'request', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }}
-                    ]
-                }
-            });
-        });
-
-        it('should create and append \'sentry\' breadcrumb', function () {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100
-            };
-            Raven._breadcrumbs = [{type: 'http', timestamp: 0.1, data: {method: 'POST', url: 'http://example.org/api/0/auth/'}}];
-
-            Raven._send({message: 'bar'});
-
-            assert.deepEqual(Raven._breadcrumbs, [
-                { type: 'http', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }},
-                { category: 'sentry', message: 'bar', timestamp: 0.1, /* 100ms */ event_id: 'abc123', level: 'error' }
-            ]);
-
-            Raven._send({message: 'foo', level: 'warning' });
-            assert.deepEqual(Raven._breadcrumbs, [
-                { type: 'http', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }},
-                { category: 'sentry', message: 'bar', timestamp: 0.1, /* 100ms */ event_id: 'abc123', level: 'error' },
-                { category: 'sentry', message: 'foo', timestamp: 0.1, /* 100ms */ event_id: 'abc123', level: 'warning' }
-            ]);
-
-            Raven._send({
-                exception: {
-                    values: [{
-                        type: 'ReferenceError',
-                        value: 'foo is not defined'
-                    }]
-                }
-            });
-            assert.deepEqual(Raven._breadcrumbs, [
-                { type: 'http', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/' }},
-                { category: 'sentry', message: 'bar', timestamp: 0.1, /* 100ms */ event_id: 'abc123', level: 'error' },
-                { category: 'sentry', message: 'foo', timestamp: 0.1, /* 100ms */ event_id: 'abc123', level: 'warning' },
-                { category: 'sentry', message: 'ReferenceError: foo is not defined', timestamp: 0.1, /* 100ms */ event_id: 'abc123', level: 'error' }
-            ]);
-
-        });
-
-        it('should build a good data payload with a User', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100
-            };
-            Raven._globalContext = {user: {name: 'Matt'}};
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                user: {
-                    name: 'Matt'
-                },
-                message: 'bar',
-                extra: {'session:duration': 100}
-            });
-        });
-
-        it('should merge in global tags', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100
-            };
-            Raven._globalContext = {tags: {tag1: 'value1'}};
-
-            Raven._send({message: 'bar', tags: {tag2: 'value2'}});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                tags: {tag1: 'value1', tag2: 'value2'},
-                extra: {'session:duration': 100},
-            });
-
-
-            assert.deepEqual(Raven._globalOptions, {
-                logger: 'javascript',
-                maxMessageLength: 100
-            });
-            assert.deepEqual(Raven._globalContext, {
-                tags: {tag1: 'value1'}
-            });
-        });
-
-        it('should merge in global extra', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100
-            };
-            Raven._globalContext = {extra: {key1: 'value1'}};
-
-            Raven._send({message: 'bar', extra: {key2: 'value2'}});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {key1: 'value1', key2: 'value2', 'session:duration': 100},
-            });
-
-            assert.deepEqual(Raven._globalOptions, {
-                logger: 'javascript',
-                maxMessageLength: 100
-            });
-            assert.deepEqual(Raven._globalContext, {
-                extra: {key1: 'value1'}
-            });
-        });
-
-        it('should let dataCallback override everything', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-
-            Raven._globalOptions = {
-                projectId: 2,
-                logger: 'javascript',
-                maxMessageLength: 100,
-                dataCallback: function() {
-                    return {message: 'ibrokeit'};
-                }
-            };
-            Raven._globalContext = {user: {name: 'Matt'}};
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                message: 'ibrokeit',
-                event_id: 'abc123'
-            });
-        });
-
-        it('should ignore dataCallback if it does not return anything', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100,
-                dataCallback: function() {
-                    return;
-                }
-            };
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100}
-            });
-        });
-
-        it('should respect `globalOptions.sampleRate` to omit event', function() {
-            Raven._globalOptions.sampleRate = 0.5;
-            this.sinon.stub(Math, 'random').returns(0.8);
-            this.sinon.stub(Raven, '_sendProcessedPayload');
-            Raven._send({message: 'bar'});
-            assert.isFalse(Raven._sendProcessedPayload.called);
-        });
-
-        it('should respect `globalOptions.sampleRate` to include event', function() {
-            Raven._globalOptions.sampleRate = 0.5;
-            this.sinon.stub(Math, 'random').returns(0.3);
-            this.sinon.stub(Raven, '_sendProcessedPayload');
-            Raven._send({message: 'bar'});
-            assert.isTrue(Raven._sendProcessedPayload.called);
-        });
-
-        it('should always send if `globalOptions.sampleRate` is omitted', function() {
-            this.sinon.stub(Raven, '_makeRequest');
-            Raven._send({message: 'bar'});
-            assert.isTrue(Raven._makeRequest.called);
-        });
-
-        it('should strip empty tags', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalOptions = {
-                projectId: 2,
-                logger: 'javascript',
-                maxMessageLength: 100,
-                tags: {}
-            };
-
-            Raven._send({message: 'bar', tags: {}, extra: {}});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100}
-            });
-        });
-
-        it('should attach environment if available', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalOptions = {
-                projectId: 2,
-                logger: 'javascript',
-                maxMessageLength: 100,
-                environment: 'abc123'
-            };
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                environment: 'abc123',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100}
-            });
-        });
-
-        it('should attach release if available', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalOptions = {
-                projectId: 2,
-                logger: 'javascript',
-                maxMessageLength: 100,
-                release: 'abc123'
-            };
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                release: 'abc123',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100}
-            });
-        });
-
-        it('should attach server_name if available', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalOptions = {
-                projectId: 2,
-                logger: 'javascript',
-                maxMessageLength: 100,
-                serverName: 'abc123',
-            };
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                server_name: 'abc123',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100}
-            });
-        });
-
-        it('should pass correct opts to makeRequest', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            var globalOptions = {
-                projectId: 2,
-                logger: 'javascript',
-                maxMessageLength: 100,
-                release: 'abc123',
-            };
-            Raven._globalEndpoint = 'http://localhost/store/';
-            Raven._globalOptions = globalOptions;
-
-            Raven._send({message: 'bar'});
-            var args = Raven._makeRequest.lastCall.args;
-            assert.equal(args.length, 1);
-            var opts = args[0];
-            assert.equal(opts.url, 'http://localhost/store/');
-            assert.deepEqual(opts.data, {
-                project: '2',
-                release: 'abc123',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100},
-            });
-            assert.deepEqual(opts.auth, {
-                sentry_client: 'raven-js/3.17.0',
-                sentry_key: 'abc',
-                sentry_version: '7'
-            });
-            assert.deepEqual(opts.options, globalOptions);
-            assert.isFunction(opts.onSuccess);
-            assert.isFunction(opts.onError);
-        });
-
-        it('should pass sentry_secret as part of auth params if specified', function () {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalEndpoint = 'http://localhost/store/';
-            Raven._globalOptions = {
-                projectId: 2,
-                logger: 'javascript',
-                maxMessageLength: 100,
-                release: 'abc123'
-            };;
-            Raven._globalSecret = 'def'; // <-- secret
-
-            Raven._send({message: 'bar'});
-            var args = Raven._makeRequest.lastCall.args;
-            assert.equal(args.length, 1);
-            var opts = args[0];
-            assert.equal(opts.url, 'http://localhost/store/');
-            assert.deepEqual(opts.data, {
-                project: '2',
-                release: 'abc123',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100},
-            });
-            assert.deepEqual(opts.auth, {
-                sentry_client: 'raven-js/3.17.0',
-                sentry_key: 'abc',
-                sentry_secret: 'def',
-                sentry_version: '7'
-            });
-        });
-
-        it('should call globalOptions.transport if specified', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            var globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100,
-                transport: sinon.stub()
-            };
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = globalOptions;
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(globalOptions.transport.lastCall.args[0].data, {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100}
-            });
-        });
-
-        it('should check `Raven.isSetup`', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(false);
-            this.sinon.stub(Raven, '_makeRequest');
-            Raven._send({message: 'bar'});
-            assert.isTrue(Raven.isSetup.called);
-        });
-
-        it('should not makeRequest if `Raven.isSetup` is false', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(false);
-            this.sinon.stub(Raven, '_makeRequest');
-            Raven._send({message: 'bar'});
-            assert.isFalse(Raven._makeRequest.called);
-        });
-
-        it('should log to console', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_logDebug');
-            this.sinon.stub(Raven, '_makeRequest');
-            Raven._send({message: 'bar'});
-            assert.isTrue(Raven._logDebug.called);
-        });
-
-        it('should truncate messages to the specified length', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-
-            Raven._globalOptions.maxMessageLength = 150;
-
-            var message = new Array(500).join('a');
-            var shortMessage = new Array(151).join('a')+'\u2026';
-
-            Raven._send({
-                message: message,
-                exception: {
-                    values: [{
-                        value: message
-                    }]
-                }
-            });
-
-            var args = Raven._makeRequest.lastCall.args;
-            assert.equal(args.length, 1);
-            var data = args[0].data;
-            assert.equal(data.message, shortMessage);
-            assert.equal(data.exception.values[0].value, shortMessage);
-        });
-
-        it('should bail out if time elapsed does not exceed backoffDuration', function () {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-
-            Raven._backoffDuration = 1000;
-            Raven._backoffStart = 100;
-            this.clock.tick(100); // tick 100 ms - NOT past backoff duration
-
-            Raven._send({message: 'bar'});
-            assert.isFalse(Raven._makeRequest.called);
-        });
-
-        it('should proceed if time elapsed exceeds backoffDuration', function () {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-
-            Raven._backoffDuration = 1000;
-            Raven._backoffStart = 100;
-            this.clock.tick(1000); // advance clock 1000 ms - past backoff duration
-
-            Raven._send({message: 'bar'});
-            assert.isTrue(Raven._makeRequest.called);
-        });
-
-        it('should set backoffDuration and backoffStart if onError is fired w/ 429 response', function () {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-
-            Raven._send({message: 'bar'});
-            var opts = Raven._makeRequest.lastCall.args[0];
-            var mockError = new Error('429: Too many requests');
-            mockError.request = {
-                status: 429
-            };
-            opts.onError(mockError);
-
-            assert.equal(Raven._backoffStart, 100); // clock is at 100ms
-            assert.equal(Raven._backoffDuration, 1000);
-
-            this.clock.tick(1); // only 1ms
-            opts.onError(mockError);
-
-            // since the backoff has started, a subsequent 429 within the backoff period
-            // should not not the start/duration
-            assert.equal(Raven._backoffStart, 100);
-            assert.equal(Raven._backoffDuration, 1000);
-
-            this.clock.tick(1000); // move past backoff period
-            opts.onError(mockError);
-
-            // another failure has occurred, this time *after* the backoff period - should increase
-            assert.equal(Raven._backoffStart, 1101);
-            assert.equal(Raven._backoffDuration, 2000);
-        });
-
-
-        it('should set backoffDuration to value of Retry-If header if present', function () {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-
-            Raven._send({message: 'bar'});
-            var opts = Raven._makeRequest.lastCall.args[0];
-            var mockError = new Error('401: Unauthorized');
-            mockError.request = {
-                status: 401,
-                getResponseHeader: sinon.stub().withArgs('Retry-After').returns('2')
-            };
-            opts.onError(mockError);
-
-            assert.equal(Raven._backoffStart, 100); // clock is at 100ms
-            assert.equal(Raven._backoffDuration, 2000); // converted to ms, int
-        });
-
-        it('should reset backoffDuration and backoffStart if onSuccess is fired (200)', function () {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-
-            Raven._backoffDuration = 1000;
-            Raven._backoffStart = 0;
-            this.clock.tick(1001); // tick clock just past time necessary
-
-            Raven._send({message: 'bar'});
-            var opts = Raven._makeRequest.lastCall.args[0];
-            opts.onSuccess({});
-
-            assert.equal(Raven._backoffStart, null); // clock is at 100ms
-            assert.equal(Raven._backoffDuration, 0);
-        });
-        it('should truncate url in breadcrumb', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100
-            };
-            Raven._globalOptions.maxUrlLength = 30;
-
-            var longUrl = new Array(50).join('a');
-            var obj = {method: 'POST', url: 'http://example.org/api/0/auth/' + longUrl};
-            Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: obj}];
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100},
-                breadcrumbs: {
-                    values: [
-                        { type: 'request', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/…' }}
-                    ]
-                }
-            });
-        });
-
-        it('should skip truncating url in breadcrumb if object is frozen', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100
-            };
-            Raven._globalOptions.maxUrlLength = 35;
-
-            var longUrl = new Array(50).join('a');
-            var obj = {method: 'POST', url: 'http://example.org/api/0/auth/' + longUrl};
-            Object.freeze(obj);
-
-            Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: obj}];
-
-            Raven._send({message: 'bar'});
-            assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
-                project: '2',
-                logger: 'javascript',
-                platform: 'javascript',
-                request: {
-                    url: 'http://localhost/?a=b',
-                    headers: {
-                        'User-Agent': 'lolbrowser'
-                    }
-                },
-                event_id: 'abc123',
-                message: 'bar',
-                extra: {'session:duration': 100},
-                breadcrumbs: {
-                    values: [
-                        { type: 'request', timestamp: 0.1, data: { method: 'POST', url: 'http://example.org/api/0/auth/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }}
-                    ]
-                }
-            });
-        });
-
-        it('should not throw error when url in breadcrumb is undefined', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_makeRequest');
-            this.sinon.stub(Raven, '_getHttpData').returns({
-                url: 'http://localhost/?a=b',
-                headers: {'User-Agent': 'lolbrowser'}
-            });
-
-            Raven._globalProject = '2';
-            Raven._globalOptions = {
-                logger: 'javascript',
-                maxMessageLength: 100
-            };
-            Raven._globalOptions.maxUrlLength = 35;
-
-            var obj = {method: 'POST', url: undefined};
-            // Do not freeze crumb data
-
-            Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: obj}];
-
-            assert.doesNotThrow(function() {
-              Raven._send({message: 'bar'});
-            }, TypeError)
-        });
-
-    });
-
-    describe('makeRequest', function() {
-        beforeEach(function() {
-            // NOTE: can't seem to call useFakeXMLHttpRequest via sandbox; must
-            //       restore manually
-            this.xhr = sinon.useFakeXMLHttpRequest();
-            var requests = this.requests = [];
-
-            this.xhr.onCreate = function (xhr) {
-                requests.push(xhr);
-            };
-        });
-
-        afterEach(function() {
-            this.xhr.restore();
-        });
-
-        it('should create an XMLHttpRequest object with body as JSON payload', function() {
-            XMLHttpRequest.prototype.withCredentials = true;
-
-            Raven._makeRequest({
-                url: 'http://localhost/',
-                auth: {a: '1', b: '2'},
-                data: {foo: 'bar'},
-                options: Raven._globalOptions
-            });
-
-            var lastXhr = this.requests[this.requests.length - 1];
-            assert.equal(lastXhr.requestBody, '{"foo":"bar"}');
-            assert.equal(lastXhr.url, 'http://localhost/?a=1&b=2');
-        });
-
-        it('should no-op if CORS is not supported', function () {
-            delete XMLHttpRequest.prototype.withCredentials;
-
-            var oldXDR = window.XDomainRequest;
-            window.XDomainRequest = undefined;
-
-            Raven._makeRequest({
-                url: 'http://localhost/',
-                auth: {a: '1', b: '2'},
-                data: {foo: 'bar'},
-                options: Raven._globalOptions
-            });
-
-            assert.equal(this.requests.length, 1); // the "test" xhr
-            assert.equal(this.requests[0].readyState, 0);
-
-            window.XDomainRequest = oldXDR
-        });
-
-        it('should pass a request object to onError', function (done) {
-            XMLHttpRequest.prototype.withCredentials = true;
-
-            Raven._makeRequest({
-                url: 'http://localhost/',
-                auth: {a: '1', b: '2'},
-                data: {foo: 'bar'},
-                options: Raven._globalOptions,
-                onError: function (error) {
-                    assert.equal(error.request.status, 429);
-                    done();
-                }
-            });
-
-            var lastXhr = this.requests[this.requests.length - 1];
-            lastXhr.respond(429, {'Content-Type': 'text/html'}, 'Too many requests');
-        });
-    });
-
-    describe('handleOnErrorStackInfo', function () {
-        it('should call handleStackInfo if ignoreOnError is falsy', function () {
-            var frame = {url: 'http://example.com'};
-            this.sinon.stub(Raven, '_handleStackInfo');
-
-            var stackInfo = {
-                name: 'Matt',
-                message: 'hey',
-                url: 'http://example.com',
-                lineno: 10,
-                stack: [
-                    frame, frame
-                ]
-            };
-
-            Raven._ignoreOnError = 1;
-            Raven._handleOnErrorStackInfo(stackInfo, {foo: 'bar'});
-
-            assert.equal(Raven._handleStackInfo.callCount, 0);
-
-            Raven._ignoreOnError = 0;
-            Raven._handleOnErrorStackInfo(stackInfo, {foo: 'bar'});
-
-            assert.equal(Raven._handleStackInfo.callCount, 1);
-            assert.deepEqual(Raven._handleStackInfo.lastCall.args, [
-                stackInfo, {foo: 'bar'}
-            ]);
-        });
-    });
-
-    describe('handleStackInfo', function() {
-        it('should work as advertised', function() {
-            var frame = {url: 'http://example.com'};
-            this.sinon.stub(Raven, '_normalizeFrame').returns(frame);
-            this.sinon.stub(Raven, '_processException');
-
-            var stackInfo = {
-                name: 'Matt',
-                message: 'hey',
-                url: 'http://example.com',
-                lineno: 10,
-                stack: [
-                    frame, frame
-                ]
-            };
-
-            Raven._handleStackInfo(stackInfo, {foo: 'bar'});
-            assert.deepEqual(Raven._processException.lastCall.args, [
-                'Matt', 'hey', 'http://example.com', 10, [frame, frame], {foo: 'bar'}
-            ]);
-        });
-
-        it('should work as advertised #integration', function() {
-            this.sinon.stub(Raven, '_makeRequest');
-            var stackInfo = {
-                name: 'Error',
-                message: 'crap',
-                url: 'http://example.com',
-                lineno: 10,
-                stack: [
+    it('should send a proper payload without frames', function() {
+      this.sinon.stub(Raven, '_send');
+
+      Raven._processException(
+        'Error',
+        'lol',
+        'http://example.com/override.js',
+        10,
+        [],
+        {}
+      );
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'lol',
+                stacktrace: {
+                  frames: [
                     {
-                        url: 'http://example.com/file1.js',
-                        line: 10,
-                        column: 11,
-                        func: 'broken',
-                        context: [
-                            'line1',
-                            'line2',
-                            'line3'
-                        ]
-                    },
-                    {
-                        url: 'http://example.com/file2.js',
-                        line: 12,
-                        column: 13,
-                        func: 'lol',
-                        context: [
-                            'line4',
-                            'line5',
-                            'line6'
-                        ]
+                      filename: 'http://example.com/override.js',
+                      lineno: 10,
+                      in_app: true
                     }
-                ]
-            };
+                  ]
+                }
+              }
+            ]
+          },
+          culprit: 'http://example.com/override.js'
+        }
+      ]);
 
-            Raven._handleStackInfo(stackInfo, {foo: 'bar'});
-            assert.isTrue(Raven._makeRequest.calledOnce);
-            /* This is commented out because chai is broken.
+      Raven._processException(
+        'Error',
+        'lol',
+        'http://example.com/override.js',
+        10,
+        [],
+        {}
+      );
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'lol',
+                stacktrace: {
+                  frames: [
+                    {
+                      filename: 'http://example.com/override.js',
+                      lineno: 10,
+                      in_app: true
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          culprit: 'http://example.com/override.js'
+        }
+      ]);
+
+      Raven._processException('Error', 'lol', 'http://example.com/override.js', 10, [], {
+        extra: 'awesome'
+      });
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          exception: {
+            values: [
+              {
+                type: 'Error',
+                value: 'lol',
+                stacktrace: {
+                  frames: [
+                    {
+                      filename: 'http://example.com/override.js',
+                      lineno: 10,
+                      in_app: true
+                    }
+                  ]
+                }
+              }
+            ]
+          },
+          culprit: 'http://example.com/override.js',
+          extra: 'awesome'
+        }
+      ]);
+    });
+
+    it('should not blow up with `undefined` message', function() {
+      this.sinon.stub(Raven, '_send');
+
+      Raven._processException('TypeError', undefined, 'http://example.com', []);
+      assert.isTrue(Raven._send.called);
+    });
+  });
+
+  describe('send', function() {
+    it('should build a good data payload', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100
+      };
+      Raven._breadcrumbs = [
+        {
+          type: 'request',
+          timestamp: 0.1,
+          data: {method: 'POST', url: 'http://example.org/api/0/auth/'}
+        }
+      ];
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100},
+        breadcrumbs: {
+          values: [
+            {
+              type: 'request',
+              timestamp: 0.1,
+              data: {method: 'POST', url: 'http://example.org/api/0/auth/'}
+            }
+          ]
+        }
+      });
+    });
+
+    it("should create and append 'sentry' breadcrumb", function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100
+      };
+      Raven._breadcrumbs = [
+        {
+          type: 'http',
+          timestamp: 0.1,
+          data: {method: 'POST', url: 'http://example.org/api/0/auth/'}
+        }
+      ];
+
+      Raven._send({message: 'bar'});
+
+      assert.deepEqual(Raven._breadcrumbs, [
+        {
+          type: 'http',
+          timestamp: 0.1,
+          data: {method: 'POST', url: 'http://example.org/api/0/auth/'}
+        },
+        {
+          category: 'sentry',
+          message: 'bar',
+          timestamp: 0.1,
+          /* 100ms */ event_id: 'abc123',
+          level: 'error'
+        }
+      ]);
+
+      Raven._send({message: 'foo', level: 'warning'});
+      assert.deepEqual(Raven._breadcrumbs, [
+        {
+          type: 'http',
+          timestamp: 0.1,
+          data: {method: 'POST', url: 'http://example.org/api/0/auth/'}
+        },
+        {
+          category: 'sentry',
+          message: 'bar',
+          timestamp: 0.1,
+          /* 100ms */ event_id: 'abc123',
+          level: 'error'
+        },
+        {
+          category: 'sentry',
+          message: 'foo',
+          timestamp: 0.1,
+          /* 100ms */ event_id: 'abc123',
+          level: 'warning'
+        }
+      ]);
+
+      Raven._send({
+        exception: {
+          values: [
+            {
+              type: 'ReferenceError',
+              value: 'foo is not defined'
+            }
+          ]
+        }
+      });
+      assert.deepEqual(Raven._breadcrumbs, [
+        {
+          type: 'http',
+          timestamp: 0.1,
+          data: {method: 'POST', url: 'http://example.org/api/0/auth/'}
+        },
+        {
+          category: 'sentry',
+          message: 'bar',
+          timestamp: 0.1,
+          /* 100ms */ event_id: 'abc123',
+          level: 'error'
+        },
+        {
+          category: 'sentry',
+          message: 'foo',
+          timestamp: 0.1,
+          /* 100ms */ event_id: 'abc123',
+          level: 'warning'
+        },
+        {
+          category: 'sentry',
+          message: 'ReferenceError: foo is not defined',
+          timestamp: 0.1,
+          /* 100ms */ event_id: 'abc123',
+          level: 'error'
+        }
+      ]);
+    });
+
+    it('should build a good data payload with a User', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100
+      };
+      Raven._globalContext = {user: {name: 'Matt'}};
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        user: {
+          name: 'Matt'
+        },
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+    });
+
+    it('should merge in global tags', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100
+      };
+      Raven._globalContext = {tags: {tag1: 'value1'}};
+
+      Raven._send({message: 'bar', tags: {tag2: 'value2'}});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        tags: {tag1: 'value1', tag2: 'value2'},
+        extra: {'session:duration': 100}
+      });
+
+      assert.deepEqual(Raven._globalOptions, {
+        logger: 'javascript',
+        maxMessageLength: 100
+      });
+      assert.deepEqual(Raven._globalContext, {
+        tags: {tag1: 'value1'}
+      });
+    });
+
+    it('should merge in global extra', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100
+      };
+      Raven._globalContext = {extra: {key1: 'value1'}};
+
+      Raven._send({message: 'bar', extra: {key2: 'value2'}});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {key1: 'value1', key2: 'value2', 'session:duration': 100}
+      });
+
+      assert.deepEqual(Raven._globalOptions, {
+        logger: 'javascript',
+        maxMessageLength: 100
+      });
+      assert.deepEqual(Raven._globalContext, {
+        extra: {key1: 'value1'}
+      });
+    });
+
+    it('should let dataCallback override everything', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+
+      Raven._globalOptions = {
+        projectId: 2,
+        logger: 'javascript',
+        maxMessageLength: 100,
+        dataCallback: function() {
+          return {message: 'ibrokeit'};
+        }
+      };
+      Raven._globalContext = {user: {name: 'Matt'}};
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        message: 'ibrokeit',
+        event_id: 'abc123'
+      });
+    });
+
+    it('should ignore dataCallback if it does not return anything', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100,
+        dataCallback: function() {
+          return;
+        }
+      };
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+    });
+
+    it('should respect `globalOptions.sampleRate` to omit event', function() {
+      Raven._globalOptions.sampleRate = 0.5;
+      this.sinon.stub(Math, 'random').returns(0.8);
+      this.sinon.stub(Raven, '_sendProcessedPayload');
+      Raven._send({message: 'bar'});
+      assert.isFalse(Raven._sendProcessedPayload.called);
+    });
+
+    it('should respect `globalOptions.sampleRate` to include event', function() {
+      Raven._globalOptions.sampleRate = 0.5;
+      this.sinon.stub(Math, 'random').returns(0.3);
+      this.sinon.stub(Raven, '_sendProcessedPayload');
+      Raven._send({message: 'bar'});
+      assert.isTrue(Raven._sendProcessedPayload.called);
+    });
+
+    it('should always send if `globalOptions.sampleRate` is omitted', function() {
+      this.sinon.stub(Raven, '_makeRequest');
+      Raven._send({message: 'bar'});
+      assert.isTrue(Raven._makeRequest.called);
+    });
+
+    it('should strip empty tags', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalOptions = {
+        projectId: 2,
+        logger: 'javascript',
+        maxMessageLength: 100,
+        tags: {}
+      };
+
+      Raven._send({message: 'bar', tags: {}, extra: {}});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+    });
+
+    it('should attach environment if available', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalOptions = {
+        projectId: 2,
+        logger: 'javascript',
+        maxMessageLength: 100,
+        environment: 'abc123'
+      };
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        environment: 'abc123',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+    });
+
+    it('should attach release if available', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalOptions = {
+        projectId: 2,
+        logger: 'javascript',
+        maxMessageLength: 100,
+        release: 'abc123'
+      };
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        release: 'abc123',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+    });
+
+    it('should attach server_name if available', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalOptions = {
+        projectId: 2,
+        logger: 'javascript',
+        maxMessageLength: 100,
+        serverName: 'abc123'
+      };
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        server_name: 'abc123',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+    });
+
+    it('should pass correct opts to makeRequest', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      var globalOptions = {
+        projectId: 2,
+        logger: 'javascript',
+        maxMessageLength: 100,
+        release: 'abc123'
+      };
+      Raven._globalEndpoint = 'http://localhost/store/';
+      Raven._globalOptions = globalOptions;
+
+      Raven._send({message: 'bar'});
+      var args = Raven._makeRequest.lastCall.args;
+      assert.equal(args.length, 1);
+      var opts = args[0];
+      assert.equal(opts.url, 'http://localhost/store/');
+      assert.deepEqual(opts.data, {
+        project: '2',
+        release: 'abc123',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+      assert.deepEqual(opts.auth, {
+        sentry_client: 'raven-js/3.17.0',
+        sentry_key: 'abc',
+        sentry_version: '7'
+      });
+      assert.deepEqual(opts.options, globalOptions);
+      assert.isFunction(opts.onSuccess);
+      assert.isFunction(opts.onError);
+    });
+
+    it('should pass sentry_secret as part of auth params if specified', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalEndpoint = 'http://localhost/store/';
+      Raven._globalOptions = {
+        projectId: 2,
+        logger: 'javascript',
+        maxMessageLength: 100,
+        release: 'abc123'
+      };
+      Raven._globalSecret = 'def'; // <-- secret
+
+      Raven._send({message: 'bar'});
+      var args = Raven._makeRequest.lastCall.args;
+      assert.equal(args.length, 1);
+      var opts = args[0];
+      assert.equal(opts.url, 'http://localhost/store/');
+      assert.deepEqual(opts.data, {
+        project: '2',
+        release: 'abc123',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+      assert.deepEqual(opts.auth, {
+        sentry_client: 'raven-js/3.17.0',
+        sentry_key: 'abc',
+        sentry_secret: 'def',
+        sentry_version: '7'
+      });
+    });
+
+    it('should call globalOptions.transport if specified', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      var globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100,
+        transport: sinon.stub()
+      };
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = globalOptions;
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(globalOptions.transport.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+    });
+
+    it('should check `Raven.isSetup`', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(false);
+      this.sinon.stub(Raven, '_makeRequest');
+      Raven._send({message: 'bar'});
+      assert.isTrue(Raven.isSetup.called);
+    });
+
+    it('should not makeRequest if `Raven.isSetup` is false', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(false);
+      this.sinon.stub(Raven, '_makeRequest');
+      Raven._send({message: 'bar'});
+      assert.isFalse(Raven._makeRequest.called);
+    });
+
+    it('should log to console', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_logDebug');
+      this.sinon.stub(Raven, '_makeRequest');
+      Raven._send({message: 'bar'});
+      assert.isTrue(Raven._logDebug.called);
+    });
+
+    it('should truncate messages to the specified length', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+
+      Raven._globalOptions.maxMessageLength = 150;
+
+      var message = new Array(500).join('a');
+      var shortMessage = new Array(151).join('a') + '\u2026';
+
+      Raven._send({
+        message: message,
+        exception: {
+          values: [
+            {
+              value: message
+            }
+          ]
+        }
+      });
+
+      var args = Raven._makeRequest.lastCall.args;
+      assert.equal(args.length, 1);
+      var data = args[0].data;
+      assert.equal(data.message, shortMessage);
+      assert.equal(data.exception.values[0].value, shortMessage);
+    });
+
+    it('should bail out if time elapsed does not exceed backoffDuration', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+
+      Raven._backoffDuration = 1000;
+      Raven._backoffStart = 100;
+      this.clock.tick(100); // tick 100 ms - NOT past backoff duration
+
+      Raven._send({message: 'bar'});
+      assert.isFalse(Raven._makeRequest.called);
+    });
+
+    it('should proceed if time elapsed exceeds backoffDuration', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+
+      Raven._backoffDuration = 1000;
+      Raven._backoffStart = 100;
+      this.clock.tick(1000); // advance clock 1000 ms - past backoff duration
+
+      Raven._send({message: 'bar'});
+      assert.isTrue(Raven._makeRequest.called);
+    });
+
+    it('should set backoffDuration and backoffStart if onError is fired w/ 429 response', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+
+      Raven._send({message: 'bar'});
+      var opts = Raven._makeRequest.lastCall.args[0];
+      var mockError = new Error('429: Too many requests');
+      mockError.request = {
+        status: 429
+      };
+      opts.onError(mockError);
+
+      assert.equal(Raven._backoffStart, 100); // clock is at 100ms
+      assert.equal(Raven._backoffDuration, 1000);
+
+      this.clock.tick(1); // only 1ms
+      opts.onError(mockError);
+
+      // since the backoff has started, a subsequent 429 within the backoff period
+      // should not not the start/duration
+      assert.equal(Raven._backoffStart, 100);
+      assert.equal(Raven._backoffDuration, 1000);
+
+      this.clock.tick(1000); // move past backoff period
+      opts.onError(mockError);
+
+      // another failure has occurred, this time *after* the backoff period - should increase
+      assert.equal(Raven._backoffStart, 1101);
+      assert.equal(Raven._backoffDuration, 2000);
+    });
+
+    it('should set backoffDuration to value of Retry-If header if present', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+
+      Raven._send({message: 'bar'});
+      var opts = Raven._makeRequest.lastCall.args[0];
+      var mockError = new Error('401: Unauthorized');
+      mockError.request = {
+        status: 401,
+        getResponseHeader: sinon
+          .stub()
+          .withArgs('Retry-After')
+          .returns('2')
+      };
+      opts.onError(mockError);
+
+      assert.equal(Raven._backoffStart, 100); // clock is at 100ms
+      assert.equal(Raven._backoffDuration, 2000); // converted to ms, int
+    });
+
+    it('should reset backoffDuration and backoffStart if onSuccess is fired (200)', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+
+      Raven._backoffDuration = 1000;
+      Raven._backoffStart = 0;
+      this.clock.tick(1001); // tick clock just past time necessary
+
+      Raven._send({message: 'bar'});
+      var opts = Raven._makeRequest.lastCall.args[0];
+      opts.onSuccess({});
+
+      assert.equal(Raven._backoffStart, null); // clock is at 100ms
+      assert.equal(Raven._backoffDuration, 0);
+    });
+    it('should truncate url in breadcrumb', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100
+      };
+      Raven._globalOptions.maxUrlLength = 30;
+
+      var longUrl = new Array(50).join('a');
+      var obj = {method: 'POST', url: 'http://example.org/api/0/auth/' + longUrl};
+      Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: obj}];
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100},
+        breadcrumbs: {
+          values: [
+            {
+              type: 'request',
+              timestamp: 0.1,
+              data: {method: 'POST', url: 'http://example.org/api/0/auth/…'}
+            }
+          ]
+        }
+      });
+    });
+
+    it('should skip truncating url in breadcrumb if object is frozen', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100
+      };
+      Raven._globalOptions.maxUrlLength = 35;
+
+      var longUrl = new Array(50).join('a');
+      var obj = {method: 'POST', url: 'http://example.org/api/0/auth/' + longUrl};
+      Object.freeze(obj);
+
+      Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: obj}];
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(Raven._makeRequest.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100},
+        breadcrumbs: {
+          values: [
+            {
+              type: 'request',
+              timestamp: 0.1,
+              data: {
+                method: 'POST',
+                url:
+                  'http://example.org/api/0/auth/aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa'
+              }
+            }
+          ]
+        }
+      });
+    });
+
+    it('should not throw error when url in breadcrumb is undefined', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100
+      };
+      Raven._globalOptions.maxUrlLength = 35;
+
+      var obj = {method: 'POST', url: undefined};
+      // Do not freeze crumb data
+
+      Raven._breadcrumbs = [{type: 'request', timestamp: 0.1, data: obj}];
+
+      assert.doesNotThrow(function() {
+        Raven._send({message: 'bar'});
+      }, TypeError);
+    });
+  });
+
+  describe('makeRequest', function() {
+    beforeEach(function() {
+      // NOTE: can't seem to call useFakeXMLHttpRequest via sandbox; must
+      //       restore manually
+      this.xhr = sinon.useFakeXMLHttpRequest();
+      var requests = (this.requests = []);
+
+      this.xhr.onCreate = function(xhr) {
+        requests.push(xhr);
+      };
+    });
+
+    afterEach(function() {
+      this.xhr.restore();
+    });
+
+    it('should create an XMLHttpRequest object with body as JSON payload', function() {
+      XMLHttpRequest.prototype.withCredentials = true;
+
+      Raven._makeRequest({
+        url: 'http://localhost/',
+        auth: {a: '1', b: '2'},
+        data: {foo: 'bar'},
+        options: Raven._globalOptions
+      });
+
+      var lastXhr = this.requests[this.requests.length - 1];
+      assert.equal(lastXhr.requestBody, '{"foo":"bar"}');
+      assert.equal(lastXhr.url, 'http://localhost/?a=1&b=2');
+    });
+
+    it('should no-op if CORS is not supported', function() {
+      delete XMLHttpRequest.prototype.withCredentials;
+
+      var oldXDR = window.XDomainRequest;
+      window.XDomainRequest = undefined;
+
+      Raven._makeRequest({
+        url: 'http://localhost/',
+        auth: {a: '1', b: '2'},
+        data: {foo: 'bar'},
+        options: Raven._globalOptions
+      });
+
+      assert.equal(this.requests.length, 1); // the "test" xhr
+      assert.equal(this.requests[0].readyState, 0);
+
+      window.XDomainRequest = oldXDR;
+    });
+
+    it('should pass a request object to onError', function(done) {
+      XMLHttpRequest.prototype.withCredentials = true;
+
+      Raven._makeRequest({
+        url: 'http://localhost/',
+        auth: {a: '1', b: '2'},
+        data: {foo: 'bar'},
+        options: Raven._globalOptions,
+        onError: function(error) {
+          assert.equal(error.request.status, 429);
+          done();
+        }
+      });
+
+      var lastXhr = this.requests[this.requests.length - 1];
+      lastXhr.respond(429, {'Content-Type': 'text/html'}, 'Too many requests');
+    });
+  });
+
+  describe('handleOnErrorStackInfo', function() {
+    it('should call handleStackInfo if ignoreOnError is falsy', function() {
+      var frame = {url: 'http://example.com'};
+      this.sinon.stub(Raven, '_handleStackInfo');
+
+      var stackInfo = {
+        name: 'Matt',
+        message: 'hey',
+        url: 'http://example.com',
+        lineno: 10,
+        stack: [frame, frame]
+      };
+
+      Raven._ignoreOnError = 1;
+      Raven._handleOnErrorStackInfo(stackInfo, {foo: 'bar'});
+
+      assert.equal(Raven._handleStackInfo.callCount, 0);
+
+      Raven._ignoreOnError = 0;
+      Raven._handleOnErrorStackInfo(stackInfo, {foo: 'bar'});
+
+      assert.equal(Raven._handleStackInfo.callCount, 1);
+      assert.deepEqual(Raven._handleStackInfo.lastCall.args, [stackInfo, {foo: 'bar'}]);
+    });
+  });
+
+  describe('handleStackInfo', function() {
+    it('should work as advertised', function() {
+      var frame = {url: 'http://example.com'};
+      this.sinon.stub(Raven, '_normalizeFrame').returns(frame);
+      this.sinon.stub(Raven, '_processException');
+
+      var stackInfo = {
+        name: 'Matt',
+        message: 'hey',
+        url: 'http://example.com',
+        lineno: 10,
+        stack: [frame, frame]
+      };
+
+      Raven._handleStackInfo(stackInfo, {foo: 'bar'});
+      assert.deepEqual(Raven._processException.lastCall.args, [
+        'Matt',
+        'hey',
+        'http://example.com',
+        10,
+        [frame, frame],
+        {foo: 'bar'}
+      ]);
+    });
+
+    it('should work as advertised #integration', function() {
+      this.sinon.stub(Raven, '_makeRequest');
+      var stackInfo = {
+        name: 'Error',
+        message: 'crap',
+        url: 'http://example.com',
+        lineno: 10,
+        stack: [
+          {
+            url: 'http://example.com/file1.js',
+            line: 10,
+            column: 11,
+            func: 'broken',
+            context: ['line1', 'line2', 'line3']
+          },
+          {
+            url: 'http://example.com/file2.js',
+            line: 12,
+            column: 13,
+            func: 'lol',
+            context: ['line4', 'line5', 'line6']
+          }
+        ]
+      };
+
+      Raven._handleStackInfo(stackInfo, {foo: 'bar'});
+      assert.isTrue(Raven._makeRequest.calledOnce);
+      /* This is commented out because chai is broken.
 
             assert.deepEqual(Raven._makeRequest.lastCall.args, [{
                 project: '2',
@@ -1621,1518 +1763,1599 @@ describe('globals', function() {
                 foo: 'bar'
             }]);
             */
-        });
-
-        it('should ignore frames that dont have a url', function() {
-            this.sinon.stub(Raven, '_normalizeFrame').returns(undefined);
-            this.sinon.stub(Raven, '_processException');
-
-            var stackInfo = {
-                name: 'Matt',
-                message: 'hey',
-                url: 'http://example.com',
-                lineno: 10,
-                stack: new Array(2)
-            };
-
-            Raven._handleStackInfo(stackInfo, {foo: 'bar'});
-            assert.deepEqual(Raven._processException.lastCall.args, [
-                'Matt', 'hey', 'http://example.com', 10, [], {foo: 'bar'}
-            ]);
-        });
-
-        it('should not shit when there is no stack object from TK', function() {
-            this.sinon.stub(Raven, '_normalizeFrame').returns(undefined);
-            this.sinon.stub(Raven, '_processException');
-
-            var stackInfo = {
-                name: 'Matt',
-                message: 'hey',
-                url: 'http://example.com',
-                lineno: 10
-                // stack: new Array(2)
-            };
-
-            Raven._handleStackInfo(stackInfo);
-            assert.isFalse(Raven._normalizeFrame.called);
-            assert.deepEqual(Raven._processException.lastCall.args, [
-                'Matt', 'hey', 'http://example.com', 10, [], undefined
-            ]);
-        });
-
-        it('should detect 2-words patterns (angularjs frequent case)', function() {
-            this.sinon.stub(Raven, '_normalizeFrame').returns(undefined);
-            this.sinon.stub(Raven, '_processException');
-
-            var stackInfo = {
-                name: 'new <anonymous>',
-                message: 'hey',
-                url: 'http://example.com',
-                lineno: 10
-                // stack: new Array(2)
-            };
-
-            Raven._handleStackInfo(stackInfo);
-            assert.isFalse(Raven._normalizeFrame.called);
-            assert.deepEqual(Raven._processException.lastCall.args, [
-                'new <anonymous>', 'hey', 'http://example.com', 10, [], undefined
-            ]);
-        });
-
-        it('should trim number of frames based on stackTraceLimit', function() {
-            var frame = {url: 'http://example.com'};
-            this.sinon.stub(Raven, '_normalizeFrame').returns(frame);
-            this.sinon.stub(Raven, '_processException');
-
-            var stackInfo = {
-                name: 'Matt',
-                message: 'hey',
-                url: 'http://example.com',
-                lineno: 10,
-                stack: [
-                  frame, frame
-                ]
-            };
-
-            Raven._globalOptions.stackTraceLimit = 1;
-
-            Raven._handleStackInfo(stackInfo);
-            assert.deepEqual(Raven._processException.lastCall.args, [
-                'Matt', 'hey', 'http://example.com', 10, [frame], undefined
-            ]);
-        });
     });
+
+    it('should ignore frames that dont have a url', function() {
+      this.sinon.stub(Raven, '_normalizeFrame').returns(undefined);
+      this.sinon.stub(Raven, '_processException');
+
+      var stackInfo = {
+        name: 'Matt',
+        message: 'hey',
+        url: 'http://example.com',
+        lineno: 10,
+        stack: new Array(2)
+      };
+
+      Raven._handleStackInfo(stackInfo, {foo: 'bar'});
+      assert.deepEqual(Raven._processException.lastCall.args, [
+        'Matt',
+        'hey',
+        'http://example.com',
+        10,
+        [],
+        {foo: 'bar'}
+      ]);
+    });
+
+    it('should not shit when there is no stack object from TK', function() {
+      this.sinon.stub(Raven, '_normalizeFrame').returns(undefined);
+      this.sinon.stub(Raven, '_processException');
+
+      var stackInfo = {
+        name: 'Matt',
+        message: 'hey',
+        url: 'http://example.com',
+        lineno: 10
+        // stack: new Array(2)
+      };
+
+      Raven._handleStackInfo(stackInfo);
+      assert.isFalse(Raven._normalizeFrame.called);
+      assert.deepEqual(Raven._processException.lastCall.args, [
+        'Matt',
+        'hey',
+        'http://example.com',
+        10,
+        [],
+        undefined
+      ]);
+    });
+
+    it('should detect 2-words patterns (angularjs frequent case)', function() {
+      this.sinon.stub(Raven, '_normalizeFrame').returns(undefined);
+      this.sinon.stub(Raven, '_processException');
+
+      var stackInfo = {
+        name: 'new <anonymous>',
+        message: 'hey',
+        url: 'http://example.com',
+        lineno: 10
+        // stack: new Array(2)
+      };
+
+      Raven._handleStackInfo(stackInfo);
+      assert.isFalse(Raven._normalizeFrame.called);
+      assert.deepEqual(Raven._processException.lastCall.args, [
+        'new <anonymous>',
+        'hey',
+        'http://example.com',
+        10,
+        [],
+        undefined
+      ]);
+    });
+
+    it('should trim number of frames based on stackTraceLimit', function() {
+      var frame = {url: 'http://example.com'};
+      this.sinon.stub(Raven, '_normalizeFrame').returns(frame);
+      this.sinon.stub(Raven, '_processException');
+
+      var stackInfo = {
+        name: 'Matt',
+        message: 'hey',
+        url: 'http://example.com',
+        lineno: 10,
+        stack: [frame, frame]
+      };
+
+      Raven._globalOptions.stackTraceLimit = 1;
+
+      Raven._handleStackInfo(stackInfo);
+      assert.deepEqual(Raven._processException.lastCall.args, [
+        'Matt',
+        'hey',
+        'http://example.com',
+        10,
+        [frame],
+        undefined
+      ]);
+    });
+  });
 });
 
 describe('Raven (public API)', function() {
+  beforeEach(function() {
+    this.clock = sinon.useFakeTimers();
+    this.clock.tick(0); // Raven initialized at time "0"
+    Raven = new _Raven();
 
-    beforeEach(function () {
-        this.clock = sinon.useFakeTimers();
-        this.clock.tick(0); // Raven initialized at time "0"
-        Raven = new _Raven();
+    this.clock.tick(100); // tick 100 ms
+  });
 
-        this.clock.tick(100); // tick 100 ms
+  afterEach(function() {
+    this.clock.restore();
+  });
+
+  describe('.VERSION', function() {
+    it('should have a version', function() {
+      assert.isString(Raven.VERSION);
+    });
+  });
+
+  describe('ignore errors', function() {
+    it('should install default ignore errors', function() {
+      Raven.config('//abc@example.com/2');
+
+      assert.isTrue(
+        Raven._globalOptions.ignoreErrors.test('Script error'),
+        'it should install "Script error" by default'
+      );
+      assert.isTrue(
+        Raven._globalOptions.ignoreErrors.test('Script error.'),
+        'it should install "Script error." by default'
+      );
+      assert.isTrue(
+        Raven._globalOptions.ignoreErrors.test(
+          'Javascript error: Script error on line 0'
+        ),
+        'it should install "Javascript error: Script error on line 0" by default'
+      );
+      assert.isTrue(
+        Raven._globalOptions.ignoreErrors.test(
+          'Javascript error: Script error. on line 0'
+        ),
+        'it should install "Javascript error: Script error. on line 0" by default'
+      );
+    });
+  });
+
+  describe('callback function', function() {
+    it('should callback a function if it is global', function() {
+      window.RavenConfig = {
+        dsn: 'http://random@some.other.server:80/2',
+        config: {some: 'config'}
+      };
+
+      this.sinon.stub(Raven, 'isSetup').returns(false);
+      this.sinon.stub(TraceKit.report, 'subscribe');
+
+      Raven.afterLoad();
+
+      assert.equal(Raven._globalKey, 'random');
+      assert.equal(Raven._globalEndpoint, 'http://some.other.server:80/api/2/store/');
+
+      assert.equal(Raven._globalOptions.some, 'config');
+      assert.equal(Raven._globalProject, '2');
+
+      assert.isTrue(Raven.isSetup.calledOnce);
+      assert.isFalse(TraceKit.report.subscribe.calledOnce);
+
+      delete window.RavenConfig;
+    });
+  });
+
+  describe('.setDSN', function() {
+    it('should work with a DSN after Raven has been configured', function() {
+      Raven.config('//def@lol.com/3');
+      Raven.setDSN(SENTRY_DSN);
+
+      assert.equal(Raven._globalKey, 'abc');
+      assert.equal(Raven._globalSecret, '');
+      assert.equal(Raven._globalEndpoint, 'http://example.com:80/api/2/store/');
+      assert.equal(Raven._globalProject, '2');
     });
 
-    afterEach(function () {
-        this.clock.restore();
+    it('should reset the backoff state', function() {
+      Raven.config('//def@lol.com/3');
+
+      Raven._backoffStart = 100;
+      Raven._backoffDuration = 2000;
+
+      Raven.setDSN(SENTRY_DSN);
+
+      assert.equal(Raven._backoffStart, null);
+      assert.equal(Raven._backoffDuration, 0);
+    });
+  });
+
+  describe('.config', function() {
+    it('should work with a DSN', function() {
+      assert.equal(
+        Raven,
+        Raven.config(SENTRY_DSN, {foo: 'bar'}),
+        'it should return Raven'
+      );
+
+      assert.equal(Raven._globalKey, 'abc');
+      assert.equal(Raven._globalSecret, '');
+      assert.equal(Raven._globalEndpoint, 'http://example.com:80/api/2/store/');
+      assert.equal(Raven._globalOptions.foo, 'bar');
+      assert.equal(Raven._globalProject, '2');
+      assert.isTrue(Raven.isSetup());
     });
 
-    describe('.VERSION', function() {
-        it('should have a version', function() {
-            assert.isString(Raven.VERSION);
-        });
+    it('throw an Error if the DSN contains a private/secret key', function() {
+      assert.throws(function() {
+        Raven.config('http://abc:def@example.com:80/2');
+      }, Error);
     });
 
-    describe('ignore errors', function() {
-        it('should install default ignore errors', function() {
-            Raven.config('//abc@example.com/2');
+    it('will NOT throw an Error if the DSN contains a private/secret key AND allowSecretKey is true', function() {
+      assert.equal(
+        Raven,
+        Raven.config('http://abc:def@example.com:80/2', {allowSecretKey: true}),
+        'it should return Raven'
+      );
 
-            assert.isTrue(Raven._globalOptions.ignoreErrors.test('Script error'), 'it should install "Script error" by default');
-            assert.isTrue(Raven._globalOptions.ignoreErrors.test('Script error.'), 'it should install "Script error." by default');
-            assert.isTrue(Raven._globalOptions.ignoreErrors.test('Javascript error: Script error on line 0'), 'it should install "Javascript error: Script error on line 0" by default');
-            assert.isTrue(Raven._globalOptions.ignoreErrors.test('Javascript error: Script error. on line 0'), 'it should install "Javascript error: Script error. on line 0" by default');
-        });
+      assert.equal(Raven._globalKey, 'abc');
+      assert.equal(Raven._globalSecret, 'def');
+      assert.equal(Raven._globalEndpoint, 'http://example.com:80/api/2/store/');
+      assert.equal(Raven._globalProject, '2');
+      assert.isTrue(Raven.isSetup());
     });
 
-    describe('callback function', function() {
-        it('should callback a function if it is global', function() {
-            window.RavenConfig = {
-                dsn: "http://random@some.other.server:80/2",
-                config: {some: 'config'}
-            };
+    it('should work with a protocol relative DSN', function() {
+      Raven.config('//abc@example.com/2');
 
-            this.sinon.stub(Raven, 'isSetup').returns(false);
-            this.sinon.stub(TraceKit.report, 'subscribe');
-
-            Raven.afterLoad();
-
-            assert.equal(Raven._globalKey, 'random');
-            assert.equal(Raven._globalEndpoint, 'http://some.other.server:80/api/2/store/');
-
-            assert.equal(Raven._globalOptions.some, 'config');
-            assert.equal(Raven._globalProject, '2');
-
-            assert.isTrue(Raven.isSetup.calledOnce);
-            assert.isFalse(TraceKit.report.subscribe.calledOnce);
-
-            delete window.RavenConfig;
-        });
+      assert.equal(Raven._globalKey, 'abc');
+      assert.equal(Raven._globalEndpoint, '//example.com/api/2/store/');
+      assert.equal(Raven._globalProject, '2');
+      assert.isTrue(Raven.isSetup());
     });
 
-    describe('.setDSN', function() {
-        it('should work with a DSN after Raven has been configured', function() {
-            Raven.config('//def@lol.com/3');
-            Raven.setDSN(SENTRY_DSN)
-
-            assert.equal(Raven._globalKey, 'abc');
-            assert.equal(Raven._globalSecret, '');
-            assert.equal(Raven._globalEndpoint, 'http://example.com:80/api/2/store/');
-            assert.equal(Raven._globalProject, '2');
-        });
-
-        it('should reset the backoff state', function() {
-            Raven.config('//def@lol.com/3');
-
-            Raven._backoffStart = 100;
-            Raven._backoffDuration = 2000;
-
-            Raven.setDSN(SENTRY_DSN);
-
-            assert.equal(Raven._backoffStart, null);
-            assert.equal(Raven._backoffDuration, 0);
-        });
+    it('should work should work at a non root path', function() {
+      Raven.config('//abc@example.com/sentry/2');
+      assert.equal(Raven._globalKey, 'abc');
+      assert.equal(Raven._globalEndpoint, '//example.com/sentry/api/2/store/');
+      assert.equal(Raven._globalProject, '2');
+      assert.isTrue(Raven.isSetup());
     });
 
-    describe('.config', function() {
-        it('should work with a DSN', function() {
-            assert.equal(Raven, Raven.config(SENTRY_DSN, {foo: 'bar'}), 'it should return Raven');
-
-            assert.equal(Raven._globalKey, 'abc');
-            assert.equal(Raven._globalSecret, '');
-            assert.equal(Raven._globalEndpoint, 'http://example.com:80/api/2/store/');
-            assert.equal(Raven._globalOptions.foo, 'bar');
-            assert.equal(Raven._globalProject, '2');
-            assert.isTrue(Raven.isSetup());
-        });
-
-        it('throw an Error if the DSN contains a private/secret key', function () {
-            assert.throws(function () {
-                Raven.config('http://abc:def@example.com:80/2');
-            }, Error);
-        });
-
-        it('will NOT throw an Error if the DSN contains a private/secret key AND allowSecretKey is true', function () {
-            assert.equal(
-                Raven,
-                Raven.config('http://abc:def@example.com:80/2', {allowSecretKey: true}),
-                'it should return Raven'
-            );
-
-            assert.equal(Raven._globalKey, 'abc');
-            assert.equal(Raven._globalSecret, 'def');
-            assert.equal(Raven._globalEndpoint, 'http://example.com:80/api/2/store/');
-            assert.equal(Raven._globalProject, '2');
-            assert.isTrue(Raven.isSetup());
-        });
-
-        it('should work with a protocol relative DSN', function() {
-            Raven.config('//abc@example.com/2');
-
-            assert.equal(Raven._globalKey, 'abc');
-            assert.equal(Raven._globalEndpoint, '//example.com/api/2/store/');
-            assert.equal(Raven._globalProject, '2');
-            assert.isTrue(Raven.isSetup());
-        });
-
-        it('should work should work at a non root path', function() {
-            Raven.config('//abc@example.com/sentry/2');
-            assert.equal(Raven._globalKey, 'abc');
-            assert.equal(Raven._globalEndpoint, '//example.com/sentry/api/2/store/');
-            assert.equal(Raven._globalProject, '2');
-            assert.isTrue(Raven.isSetup());
-        });
-
-        it('should noop a falsey dsn', function() {
-            Raven.config('');
-            assert.isFalse(Raven.isSetup());
-        });
-
-        it('should return Raven for a falsey dsn', function() {
-            assert.equal(Raven.config(''), Raven);
-        });
-
-        it('should not set global options more than once', function() {
-            this.sinon.spy(Raven, '_parseDSN');
-            this.sinon.stub(Raven, '_logDebug');
-            setupRaven();
-            setupRaven();
-            assert.isTrue(Raven._parseDSN.calledOnce);
-            assert.isTrue(Raven._logDebug.called);
-        });
-
-        it('should populate global context for tags, extra, and user', function() {
-            Raven.config('//abc@example.com/sentry/2', {
-                tags: {tag1: 'tagValue1'},
-                extra: {extra1: 'extraValue1'},
-                user: {name: 'Matt'},
-                whitelistUrls: ['not-a-context-value']
-            });
-            assert.deepEqual(Raven._globalContext, {
-                tags: {tag1: 'tagValue1'},
-                extra: {extra1: 'extraValue1'},
-                user: {name: 'Matt'},
-            });
-        });
-
-        describe('whitelistUrls', function() {
-            it('should be false if none are passed', function() {
-                Raven.config('//abc@example.com/2');
-                assert.equal(Raven._globalOptions.whitelistUrls, false);
-            });
-
-            it('should join into a single RegExp', function() {
-                Raven.config('//abc@example.com/2', {
-                    whitelistUrls: [
-                        /my.app/i,
-                        /other.app/i
-                    ]
-                });
-
-                assert.match(Raven._globalOptions.whitelistUrls, /my.app|other.app/i);
-            });
-
-            it('should handle strings as well', function() {
-                Raven.config('//abc@example.com/2', {
-                    whitelistUrls: [
-                        /my.app/i,
-                        "stringy.app"
-                    ]
-                });
-
-                assert.match(Raven._globalOptions.whitelistUrls, /my.app|stringy.app/i);
-            });
-        });
-
-        describe('collectWindowErrors', function() {
-            it('should be true by default', function() {
-                Raven.config(SENTRY_DSN);
-                assert.isTrue(TraceKit.collectWindowErrors);
-            });
-
-            it('should be true if set to true', function() {
-                Raven.config(SENTRY_DSN, {
-                    collectWindowErrors: true
-                });
-
-                assert.isTrue(TraceKit.collectWindowErrors);
-            });
-
-            it('should be false if set to false', function() {
-                Raven.config(SENTRY_DSN, {
-                    collectWindowErrors: false
-                });
-
-                assert.isFalse(TraceKit.collectWindowErrors);
-            });
-        });
-
-        describe('maxBreadcrumbs', function () {
-            it('should override the default', function () {
-                Raven.config(SENTRY_DSN, { maxBreadcrumbs: 50 });
-                assert.equal(Raven._globalOptions.maxBreadcrumbs, 50);
-            });
-
-            it('should not permit maxBreadcrumbs above 100', function () {
-                Raven.config(SENTRY_DSN, { maxBreadcrumbs: 200 });
-                assert.equal(Raven._globalOptions.maxBreadcrumbs, 100);
-            });
-
-            it('should not permit maxBreadcrumbs below 0', function () {
-               Raven.config(SENTRY_DSN, { maxBreadcrumbs: -1 });
-                assert.equal(Raven._globalOptions.maxBreadcrumbs, 0);
-            });
-
-            it('should set maxBreadcrumbs to the default if not provided', function () {
-                Raven.config(SENTRY_DSN);
-                assert.equal(Raven._globalOptions.maxBreadcrumbs, 100);
-            });
-        });
-
-        describe('instrument', function () {
-            it('should convert `true` to a dictionary of enabled instrument features', function () {
-                Raven.config(SENTRY_DSN);
-                assert.deepEqual(Raven._globalOptions.instrument, {
-                    tryCatch: true,
-                });
-            });
-
-            it('should leave false as-is', function () {
-                Raven.config(SENTRY_DSN, {
-                    instrument: false
-                });
-                assert.equal(Raven._globalOptions.instrument, false);
-            });
-
-            it('should merge objects with the default instrument settings', function () {
-                Raven.config(SENTRY_DSN, {
-                    instrument: {
-                        tryCatch: false
-                    }
-                });
-                assert.deepEqual(Raven._globalOptions.instrument, {
-                    tryCatch: false,
-                });
-            });
-        });
-
-        describe('autoBreadcrumbs', function () {
-            it('should convert `true` to a dictionary of enabled breadcrumb features', function () {
-                Raven.config(SENTRY_DSN);
-                assert.deepEqual(Raven._globalOptions.autoBreadcrumbs, {
-                    xhr: true,
-                    console: true,
-                    dom: true,
-                    location: true
-                });
-            });
-
-            it('should leave false as-is', function () {
-                Raven.config(SENTRY_DSN, {
-                    autoBreadcrumbs: false
-                });
-                assert.equal(Raven._globalOptions.autoBreadcrumbs, false);
-            });
-
-            it('should merge objects with the default autoBreadcrumb settings', function () {
-                Raven.config(SENTRY_DSN, {
-                    autoBreadcrumbs: {
-                        location: false
-                    }
-                });
-                assert.deepEqual(Raven._globalOptions.autoBreadcrumbs, {
-                    xhr: true,
-                    console: true,
-                    dom: true,
-                    location: false /* ! */
-                });
-            });
-        });
+    it('should noop a falsey dsn', function() {
+      Raven.config('');
+      assert.isFalse(Raven.isSetup());
     });
 
-    describe('.wrap', function() {
-        it('should return a wrapped callback', function() {
-            var spy = this.sinon.spy();
-            var wrapped = Raven.wrap(spy);
-            assert.isFunction(wrapped);
-            assert.isTrue(wrapped.__raven__);
-            wrapped();
-            assert.isTrue(spy.calledOnce);
-        });
-
-        it('should copy property when wrapping function', function() {
-            var func = function() {};
-            func.test = true;
-            var wrapped = Raven.wrap(func);
-            assert.isTrue(wrapped.test);
-        });
-
-        it('should copy prototype property when wrapping function', function() {
-            var func = function() {};
-            func.prototype.test = 'foo';
-            var wrapped = Raven.wrap(func);
-            assert.equal(new wrapped().test, 'foo');
-        });
-
-        it('should return the result of a wrapped function', function() {
-            var func = function() { return 'foo'; };
-            var wrapped = Raven.wrap(func);
-            assert.equal(wrapped(), 'foo');
-        });
-
-        it('should not wrap a non-function', function() {
-            assert.equal(Raven.wrap('lol'), 'lol');
-            assert.equal(Raven.wrap({}, 'lol'), 'lol');
-            assert.equal(Raven.wrap(undefined, 'lol'), 'lol');
-            var a = [1, 2];
-            assert.equal(Raven.wrap(a), a);
-        });
-
-        it('should wrap function arguments', function() {
-            var spy = this.sinon.spy();
-            var wrapped = Raven.wrap(function(f) {
-                assert.isTrue(f.__raven__);
-                f();
-            });
-            wrapped(spy);
-            assert.isTrue(spy.calledOnce);
-        });
-
-        it('should not wrap function arguments', function() {
-            var spy = this.sinon.spy();
-            var wrapped = Raven.wrap({ deep: false }, function(f) {
-                assert.isUndefined(f.__raven__);
-                f();
-            });
-            wrapped(spy);
-            assert.isTrue(spy.calledOnce);
-        });
-
-        it('should maintain the correct scope', function() {
-            var foo = {};
-            var bar = function() {
-                assert.equal(this, foo);
-            };
-            bar.apply(foo, []);
-            Raven.wrap(bar).apply(foo, []);
-        });
-
-        it('should re-raise a thrown exception', function() {
-            var error = new Error('lol');
-            this.sinon.stub(Raven, 'captureException');
-            assert.throws(function() {
-                Raven.wrap(function() { throw error; })();
-            }, error);
-        });
-
-        it('should return input funciton as-is if accessing __raven__ prop throws exception', function (){
-            // see raven-js#495
-            var fn = function () {};
-            Object.defineProperty(fn, '__raven__', {
-              get: function () {
-                  throw new Error('Permission denied')
-              }
-            });
-            assert.throw(function () { fn.__raven__; }, 'Permission denied');
-            var wrapped = Raven.wrap(fn);
-            assert.equal(fn, wrapped);
-        });
-
-        it('should return input funciton as-is if accessing __raven_wrapper__ prop throws exception', function (){
-            // see raven-js#495
-            var fn = function () {};
-            Object.defineProperty(fn, '__raven_wrapper__', {
-              get: function () {
-                  throw new Error('Permission denied')
-              }
-            });
-            assert.throw(function () { fn.__raven_wrapper__; }, 'Permission denied');
-            var wrapped = Raven.wrap(fn);
-            assert.equal(fn, wrapped);
-        });
-
+    it('should return Raven for a falsey dsn', function() {
+      assert.equal(Raven.config(''), Raven);
     });
 
-    describe('.context', function() {
-        it('should execute the callback with options', function() {
-            var spy = this.sinon.spy();
-            this.sinon.stub(Raven, 'captureException');
-            Raven.context({'foo': 'bar'}, spy);
-            assert.isTrue(spy.calledOnce);
-            assert.isFalse(Raven.captureException.called);
-        });
-
-        it('should execute the callback with arguments', function() {
-            var spy = this.sinon.spy();
-            var args = [1, 2];
-            Raven.context(spy, args);
-            assert.deepEqual(spy.lastCall.args, args);
-        });
-
-        it('should execute the callback without options', function() {
-            var spy = this.sinon.spy();
-            this.sinon.stub(Raven, 'captureException');
-            Raven.context(spy);
-            assert.isTrue(spy.calledOnce);
-            assert.isFalse(Raven.captureException.called);
-        });
-
-        it('should capture the exception with options', function() {
-            var error = new Error('crap');
-            var broken = function() { throw error; };
-            this.sinon.stub(Raven, 'captureException');
-            assert.throws(function() {
-                Raven.context({foo: 'bar'}, broken);
-            }, error);
-            assert.isTrue(Raven.captureException.called);
-            assert.deepEqual(Raven.captureException.lastCall.args, [error, {
-                'foo': 'bar'
-            }]);
-        });
-
-        it('should capture the exception without options', function() {
-            var error = new Error('crap');
-            var broken = function() { throw error; };
-            this.sinon.stub(Raven, 'captureException');
-            assert.throws(function() {
-                Raven.context(broken);
-            }, error);
-            assert.isTrue(Raven.captureException.called);
-            assert.deepEqual(Raven.captureException.lastCall.args, [error, undefined]);
-        });
-
-        it('should execute the callback without arguments', function() {
-            // This is only reproducable in a browser that complains about passing
-            // undefined to Function.apply
-            var spy = this.sinon.spy();
-            Raven.context(spy);
-            assert.deepEqual(spy.lastCall.args, []);
-        });
-
-        it('should return the result of the wrapped function', function() {
-            var val = {};
-            var func = function() { return val; };
-            assert.equal(Raven.context(func), val);
-        });
+    it('should not set global options more than once', function() {
+      this.sinon.spy(Raven, '_parseDSN');
+      this.sinon.stub(Raven, '_logDebug');
+      setupRaven();
+      setupRaven();
+      assert.isTrue(Raven._parseDSN.calledOnce);
+      assert.isTrue(Raven._logDebug.called);
     });
 
-    describe('.setUserContext', function() {
-        it('should set the globalContext.user object', function() {
-            Raven.setUserContext({name: 'Matt'});
-            assert.deepEqual(Raven._globalContext.user, {name: 'Matt'});
-        });
-
-        it('should not merge globalContext.user object, but rewrite', function () {
-            Raven._globalContext.user = {name: 'Matt'};
-            Raven.setUserContext({age: 34, email: 'john@mail.com'});
-            assert.deepEqual(Raven._globalContext.user, {age: 34, email: 'john@mail.com'});
-        });
-
-        it('should clear the globalContext.user with no arguments', function() {
-            Raven._globalContext.user = {name: 'Matt'};
-            Raven.setUserContext();
-            assert.isUndefined(Raven._globalContext.user);
-        });
+    it('should populate global context for tags, extra, and user', function() {
+      Raven.config('//abc@example.com/sentry/2', {
+        tags: {tag1: 'tagValue1'},
+        extra: {extra1: 'extraValue1'},
+        user: {name: 'Matt'},
+        whitelistUrls: ['not-a-context-value']
+      });
+      assert.deepEqual(Raven._globalContext, {
+        tags: {tag1: 'tagValue1'},
+        extra: {extra1: 'extraValue1'},
+        user: {name: 'Matt'}
+      });
     });
 
-    describe('.setExtraContext', function() {
-        it('should set the globalContext.extra object', function() {
-            Raven.setExtraContext({name: 'Matt'});
-            assert.deepEqual(Raven._globalContext.extra, {name: 'Matt'});
+    describe('whitelistUrls', function() {
+      it('should be false if none are passed', function() {
+        Raven.config('//abc@example.com/2');
+        assert.equal(Raven._globalOptions.whitelistUrls, false);
+      });
+
+      it('should join into a single RegExp', function() {
+        Raven.config('//abc@example.com/2', {
+          whitelistUrls: [/my.app/i, /other.app/i]
         });
 
-        it('should clear globalContext.extra with no arguments', function() {
-            Raven.extra = {name: 'Matt'};
-            Raven.setExtraContext();
-            assert.isUndefined(Raven._globalContext.extra);
+        assert.match(Raven._globalOptions.whitelistUrls, /my.app|other.app/i);
+      });
+
+      it('should handle strings as well', function() {
+        Raven.config('//abc@example.com/2', {
+          whitelistUrls: [/my.app/i, 'stringy.app']
         });
 
-        it('should merge globalContext.extra with subsequent calls', function() {
-            Raven.setExtraContext({a: 1});
-            Raven.setExtraContext({b: 2});
-            assert.deepEqual(Raven._globalContext.extra, {a: 1, b: 2});
-        });
+        assert.match(Raven._globalOptions.whitelistUrls, /my.app|stringy.app/i);
+      });
     });
 
-    describe('.setTagsContext', function() {
-        it('should set the globalContext.tags object', function() {
-            Raven.setTagsContext({name: 'Matt'});
-            assert.deepEqual(Raven._globalContext.tags, {name: 'Matt'});
+    describe('collectWindowErrors', function() {
+      it('should be true by default', function() {
+        Raven.config(SENTRY_DSN);
+        assert.isTrue(TraceKit.collectWindowErrors);
+      });
+
+      it('should be true if set to true', function() {
+        Raven.config(SENTRY_DSN, {
+          collectWindowErrors: true
         });
 
-        it('should clear globalContext.tags with no arguments', function() {
-            Raven._globalContext.tags = {name: 'Matt'};
-            Raven.setTagsContext();
-            assert.isUndefined(Raven._globalContext.tags);
+        assert.isTrue(TraceKit.collectWindowErrors);
+      });
+
+      it('should be false if set to false', function() {
+        Raven.config(SENTRY_DSN, {
+          collectWindowErrors: false
         });
 
-        it('should merge globalContext.tags with subsequent calls', function() {
-            Raven.setTagsContext({a: 1});
-            Raven.setTagsContext({b: 2});
-            assert.deepEqual(Raven._globalContext.tags, {a: 1, b: 2});
-        });
+        assert.isFalse(TraceKit.collectWindowErrors);
+      });
     });
 
-    describe('.clearContext', function() {
-        it('should clear the globalContext object', function() {
-            Raven._globalState = {globalContext: {tags: {}, extra: {}, user: {}}};
-            Raven.clearContext();
-            assert.deepEqual(Raven._globalContext, {});
-        });
+    describe('maxBreadcrumbs', function() {
+      it('should override the default', function() {
+        Raven.config(SENTRY_DSN, {maxBreadcrumbs: 50});
+        assert.equal(Raven._globalOptions.maxBreadcrumbs, 50);
+      });
+
+      it('should not permit maxBreadcrumbs above 100', function() {
+        Raven.config(SENTRY_DSN, {maxBreadcrumbs: 200});
+        assert.equal(Raven._globalOptions.maxBreadcrumbs, 100);
+      });
+
+      it('should not permit maxBreadcrumbs below 0', function() {
+        Raven.config(SENTRY_DSN, {maxBreadcrumbs: -1});
+        assert.equal(Raven._globalOptions.maxBreadcrumbs, 0);
+      });
+
+      it('should set maxBreadcrumbs to the default if not provided', function() {
+        Raven.config(SENTRY_DSN);
+        assert.equal(Raven._globalOptions.maxBreadcrumbs, 100);
+      });
     });
 
-    describe('.getContext', function() {
-        it('should retrieve a copy of the current context', function() {
-            Raven._globalContext = {tags: {a: 1}};
-            var context = Raven.getContext();
-            var globalContext = Raven._globalContext;
-            assert.deepEqual(globalContext, context);
-            context.tags.a = 2;
-            // It shouldn't have mutated the original
-            assert.equal(globalContext.tags.a, 1);
+    describe('instrument', function() {
+      it('should convert `true` to a dictionary of enabled instrument features', function() {
+        Raven.config(SENTRY_DSN);
+        assert.deepEqual(Raven._globalOptions.instrument, {
+          tryCatch: true
         });
+      });
+
+      it('should leave false as-is', function() {
+        Raven.config(SENTRY_DSN, {
+          instrument: false
+        });
+        assert.equal(Raven._globalOptions.instrument, false);
+      });
+
+      it('should merge objects with the default instrument settings', function() {
+        Raven.config(SENTRY_DSN, {
+          instrument: {
+            tryCatch: false
+          }
+        });
+        assert.deepEqual(Raven._globalOptions.instrument, {
+          tryCatch: false
+        });
+      });
     });
 
-    describe('.setEnvironment', function() {
-        it('should set the globalOptions.environment attribute', function() {
-            Raven.setEnvironment('abc123');
-            assert.equal(Raven._globalOptions.environment, 'abc123');
+    describe('autoBreadcrumbs', function() {
+      it('should convert `true` to a dictionary of enabled breadcrumb features', function() {
+        Raven.config(SENTRY_DSN);
+        assert.deepEqual(Raven._globalOptions.autoBreadcrumbs, {
+          xhr: true,
+          console: true,
+          dom: true,
+          location: true
         });
+      });
 
-        it('should clear globalOptions.environment with no arguments', function() {
-            Raven._globalOptions.environment = 'abc123';
-            Raven.setEnvironment();
-            assert.isUndefined(Raven._globalOptions.environment);
+      it('should leave false as-is', function() {
+        Raven.config(SENTRY_DSN, {
+          autoBreadcrumbs: false
         });
+        assert.equal(Raven._globalOptions.autoBreadcrumbs, false);
+      });
+
+      it('should merge objects with the default autoBreadcrumb settings', function() {
+        Raven.config(SENTRY_DSN, {
+          autoBreadcrumbs: {
+            location: false
+          }
+        });
+        assert.deepEqual(Raven._globalOptions.autoBreadcrumbs, {
+          xhr: true,
+          console: true,
+          dom: true,
+          location: false /* ! */
+        });
+      });
+    });
+  });
+
+  describe('.wrap', function() {
+    it('should return a wrapped callback', function() {
+      var spy = this.sinon.spy();
+      var wrapped = Raven.wrap(spy);
+      assert.isFunction(wrapped);
+      assert.isTrue(wrapped.__raven__);
+      wrapped();
+      assert.isTrue(spy.calledOnce);
     });
 
-    describe('.setRelease', function() {
-        it('should set the globalOptions.release attribute', function() {
-            Raven.setRelease('abc123');
-            assert.equal(Raven._globalOptions.release, 'abc123');
-        });
-
-        it('should clear globalOptions.release with no arguments', function() {
-            Raven._globalOptions.release = 'abc123';
-            Raven.setRelease();
-            assert.isUndefined(Raven._globalOptions.release);
-        });
+    it('should copy property when wrapping function', function() {
+      var func = function() {};
+      func.test = true;
+      var wrapped = Raven.wrap(func);
+      assert.isTrue(wrapped.test);
     });
 
-    describe('.setDataCallback', function() {
-        it('should set the globalOptions.dataCallback attribute', function() {
-            var foo = sinon.stub();
-            Raven.setDataCallback(foo);
-
-            // note that setDataCallback creates a callback/closure around
-            // foo, so can't test for equality - just verify that calling the wrapper
-            // also calls foo
-            Raven._globalOptions.dataCallback();
-            assert.isTrue(foo.calledOnce);
-        });
-
-        it('should clear globalOptions.dataCallback with no arguments', function() {
-            var foo = function(){};
-            Raven._globalOptions.dataCallback = foo;
-            Raven.setDataCallback();
-            assert.isUndefined(Raven._globalOptions.dataCallback);
-        });
-
-        it('should generate a wrapper that passes the prior callback as the 2nd argument', function () {
-            var foo = sinon.stub();
-            var bar = sinon.spy(function(data, orig) {
-                assert.equal(orig, foo);
-                foo();
-            });
-            Raven._globalOptions.dataCallback = foo;
-            Raven.setDataCallback(bar);
-            Raven._globalOptions.dataCallback({
-                'a': 1 // "data"
-            });
-            assert.isTrue(bar.calledOnce);
-            assert.isTrue(foo.calledOnce);
-        });
+    it('should copy prototype property when wrapping function', function() {
+      var func = function() {};
+      func.prototype.test = 'foo';
+      var wrapped = Raven.wrap(func);
+      assert.equal(new wrapped().test, 'foo');
     });
 
-    describe('.setBreadcrumbCallback', function() {
-        it('should set the globalOptions.breadcrumbCallback attribute', function() {
-            var foo = sinon.stub();
-            Raven.setBreadcrumbCallback(foo);
-
-            // note that breadcrumbCallback creates a callback/closure around
-            // foo, so can't test for equality - just verify that calling the wrapper
-            // also calls foo
-            Raven._globalOptions.breadcrumbCallback();
-            assert.isTrue(foo.calledOnce);
-        });
-
-        it('should clear globalOptions.breadcrumbCallback with no arguments', function() {
-            var foo = function(){};
-            Raven._globalOptions.breadcrumbCallback = foo;
-            Raven.setBreadcrumbCallback();
-            assert.isUndefined(Raven._globalOptions.breadcrumbCallback);
-        });
-
-        it('should generate a wrapper that passes the prior callback as the 2nd argument', function () {
-            var foo = sinon.stub();
-            var bar = sinon.spy(function(data, orig) {
-                assert.equal(orig, foo);
-                foo();
-            });
-            Raven._globalOptions.breadcrumbCallback = foo;
-            Raven.setBreadcrumbCallback(bar);
-            Raven._globalOptions.breadcrumbCallback({
-                'a': 1 // "data"
-            });
-            assert.isTrue(bar.calledOnce);
-            assert.isTrue(foo.calledOnce);
-        });
+    it('should return the result of a wrapped function', function() {
+      var func = function() {
+        return 'foo';
+      };
+      var wrapped = Raven.wrap(func);
+      assert.equal(wrapped(), 'foo');
     });
 
-    describe('.setShouldSendCallback', function() {
-        it('should set the globalOptions.shouldSendCallback attribute', function() {
-            var foo = sinon.stub();
-            Raven.setShouldSendCallback(foo);
-
-            // note that setShouldSendCallback creates a callback/closure around
-            // foo, so can't test for equality - just verify that calling the wrapper
-            // also calls foo
-            Raven._globalOptions.shouldSendCallback();
-            assert.isTrue(foo.calledOnce);
-        });
-
-        it('should clear globalOptions.shouldSendCallback with no arguments', function() {
-            var foo = function(){};
-            Raven._globalOptions.shouldSendCallback = foo;
-            Raven.setShouldSendCallback();
-            assert.isUndefined(Raven._globalOptions.shouldSendCallback);
-        });
-
-        it('should generate a wrapper that passes the prior callback as the 2nd argument', function () {
-            var foo = sinon.stub();
-            var bar = sinon.spy(function(data, orig) {
-                assert.equal(orig, foo);
-                foo();
-            });
-            Raven._globalOptions.shouldSendCallback = foo;
-            Raven.setShouldSendCallback(bar);
-            Raven._globalOptions.shouldSendCallback({
-                'a': 1 // "data"
-            });
-            assert.isTrue(bar.calledOnce);
-            assert.isTrue(foo.calledOnce);
-        });
+    it('should not wrap a non-function', function() {
+      assert.equal(Raven.wrap('lol'), 'lol');
+      assert.equal(Raven.wrap({}, 'lol'), 'lol');
+      assert.equal(Raven.wrap(undefined, 'lol'), 'lol');
+      var a = [1, 2];
+      assert.equal(Raven.wrap(a), a);
     });
 
-    describe('.captureMessage', function() {
-        it('should work as advertised', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_send');
-            Raven.captureMessage('lol', {foo: 'bar'});
-            assert.isTrue(Raven._send.called);
-            assert.deepEqual(Raven._send.lastCall.args, [{
-                message: 'lol',
-                foo: 'bar'
-            }]);
+    it('should wrap function arguments', function() {
+      var spy = this.sinon.spy();
+      var wrapped = Raven.wrap(function(f) {
+        assert.isTrue(f.__raven__);
+        f();
+      });
+      wrapped(spy);
+      assert.isTrue(spy.calledOnce);
+    });
+
+    it('should not wrap function arguments', function() {
+      var spy = this.sinon.spy();
+      var wrapped = Raven.wrap({deep: false}, function(f) {
+        assert.isUndefined(f.__raven__);
+        f();
+      });
+      wrapped(spy);
+      assert.isTrue(spy.calledOnce);
+    });
+
+    it('should maintain the correct scope', function() {
+      var foo = {};
+      var bar = function() {
+        assert.equal(this, foo);
+      };
+      bar.apply(foo, []);
+      Raven.wrap(bar).apply(foo, []);
+    });
+
+    it('should re-raise a thrown exception', function() {
+      var error = new Error('lol');
+      this.sinon.stub(Raven, 'captureException');
+      assert.throws(function() {
+        Raven.wrap(function() {
+          throw error;
+        })();
+      }, error);
+    });
+
+    it('should return input funciton as-is if accessing __raven__ prop throws exception', function() {
+      // see raven-js#495
+      var fn = function() {};
+      Object.defineProperty(fn, '__raven__', {
+        get: function() {
+          throw new Error('Permission denied');
+        }
+      });
+      assert.throw(function() {
+        fn.__raven__;
+      }, 'Permission denied');
+      var wrapped = Raven.wrap(fn);
+      assert.equal(fn, wrapped);
+    });
+
+    it('should return input funciton as-is if accessing __raven_wrapper__ prop throws exception', function() {
+      // see raven-js#495
+      var fn = function() {};
+      Object.defineProperty(fn, '__raven_wrapper__', {
+        get: function() {
+          throw new Error('Permission denied');
+        }
+      });
+      assert.throw(function() {
+        fn.__raven_wrapper__;
+      }, 'Permission denied');
+      var wrapped = Raven.wrap(fn);
+      assert.equal(fn, wrapped);
+    });
+  });
+
+  describe('.context', function() {
+    it('should execute the callback with options', function() {
+      var spy = this.sinon.spy();
+      this.sinon.stub(Raven, 'captureException');
+      Raven.context({foo: 'bar'}, spy);
+      assert.isTrue(spy.calledOnce);
+      assert.isFalse(Raven.captureException.called);
+    });
+
+    it('should execute the callback with arguments', function() {
+      var spy = this.sinon.spy();
+      var args = [1, 2];
+      Raven.context(spy, args);
+      assert.deepEqual(spy.lastCall.args, args);
+    });
+
+    it('should execute the callback without options', function() {
+      var spy = this.sinon.spy();
+      this.sinon.stub(Raven, 'captureException');
+      Raven.context(spy);
+      assert.isTrue(spy.calledOnce);
+      assert.isFalse(Raven.captureException.called);
+    });
+
+    it('should capture the exception with options', function() {
+      var error = new Error('crap');
+      var broken = function() {
+        throw error;
+      };
+      this.sinon.stub(Raven, 'captureException');
+      assert.throws(function() {
+        Raven.context({foo: 'bar'}, broken);
+      }, error);
+      assert.isTrue(Raven.captureException.called);
+      assert.deepEqual(Raven.captureException.lastCall.args, [
+        error,
+        {
+          foo: 'bar'
+        }
+      ]);
+    });
+
+    it('should capture the exception without options', function() {
+      var error = new Error('crap');
+      var broken = function() {
+        throw error;
+      };
+      this.sinon.stub(Raven, 'captureException');
+      assert.throws(function() {
+        Raven.context(broken);
+      }, error);
+      assert.isTrue(Raven.captureException.called);
+      assert.deepEqual(Raven.captureException.lastCall.args, [error, undefined]);
+    });
+
+    it('should execute the callback without arguments', function() {
+      // This is only reproducable in a browser that complains about passing
+      // undefined to Function.apply
+      var spy = this.sinon.spy();
+      Raven.context(spy);
+      assert.deepEqual(spy.lastCall.args, []);
+    });
+
+    it('should return the result of the wrapped function', function() {
+      var val = {};
+      var func = function() {
+        return val;
+      };
+      assert.equal(Raven.context(func), val);
+    });
+  });
+
+  describe('.setUserContext', function() {
+    it('should set the globalContext.user object', function() {
+      Raven.setUserContext({name: 'Matt'});
+      assert.deepEqual(Raven._globalContext.user, {name: 'Matt'});
+    });
+
+    it('should not merge globalContext.user object, but rewrite', function() {
+      Raven._globalContext.user = {name: 'Matt'};
+      Raven.setUserContext({age: 34, email: 'john@mail.com'});
+      assert.deepEqual(Raven._globalContext.user, {age: 34, email: 'john@mail.com'});
+    });
+
+    it('should clear the globalContext.user with no arguments', function() {
+      Raven._globalContext.user = {name: 'Matt'};
+      Raven.setUserContext();
+      assert.isUndefined(Raven._globalContext.user);
+    });
+  });
+
+  describe('.setExtraContext', function() {
+    it('should set the globalContext.extra object', function() {
+      Raven.setExtraContext({name: 'Matt'});
+      assert.deepEqual(Raven._globalContext.extra, {name: 'Matt'});
+    });
+
+    it('should clear globalContext.extra with no arguments', function() {
+      Raven.extra = {name: 'Matt'};
+      Raven.setExtraContext();
+      assert.isUndefined(Raven._globalContext.extra);
+    });
+
+    it('should merge globalContext.extra with subsequent calls', function() {
+      Raven.setExtraContext({a: 1});
+      Raven.setExtraContext({b: 2});
+      assert.deepEqual(Raven._globalContext.extra, {a: 1, b: 2});
+    });
+  });
+
+  describe('.setTagsContext', function() {
+    it('should set the globalContext.tags object', function() {
+      Raven.setTagsContext({name: 'Matt'});
+      assert.deepEqual(Raven._globalContext.tags, {name: 'Matt'});
+    });
+
+    it('should clear globalContext.tags with no arguments', function() {
+      Raven._globalContext.tags = {name: 'Matt'};
+      Raven.setTagsContext();
+      assert.isUndefined(Raven._globalContext.tags);
+    });
+
+    it('should merge globalContext.tags with subsequent calls', function() {
+      Raven.setTagsContext({a: 1});
+      Raven.setTagsContext({b: 2});
+      assert.deepEqual(Raven._globalContext.tags, {a: 1, b: 2});
+    });
+  });
+
+  describe('.clearContext', function() {
+    it('should clear the globalContext object', function() {
+      Raven._globalState = {globalContext: {tags: {}, extra: {}, user: {}}};
+      Raven.clearContext();
+      assert.deepEqual(Raven._globalContext, {});
+    });
+  });
+
+  describe('.getContext', function() {
+    it('should retrieve a copy of the current context', function() {
+      Raven._globalContext = {tags: {a: 1}};
+      var context = Raven.getContext();
+      var globalContext = Raven._globalContext;
+      assert.deepEqual(globalContext, context);
+      context.tags.a = 2;
+      // It shouldn't have mutated the original
+      assert.equal(globalContext.tags.a, 1);
+    });
+  });
+
+  describe('.setEnvironment', function() {
+    it('should set the globalOptions.environment attribute', function() {
+      Raven.setEnvironment('abc123');
+      assert.equal(Raven._globalOptions.environment, 'abc123');
+    });
+
+    it('should clear globalOptions.environment with no arguments', function() {
+      Raven._globalOptions.environment = 'abc123';
+      Raven.setEnvironment();
+      assert.isUndefined(Raven._globalOptions.environment);
+    });
+  });
+
+  describe('.setRelease', function() {
+    it('should set the globalOptions.release attribute', function() {
+      Raven.setRelease('abc123');
+      assert.equal(Raven._globalOptions.release, 'abc123');
+    });
+
+    it('should clear globalOptions.release with no arguments', function() {
+      Raven._globalOptions.release = 'abc123';
+      Raven.setRelease();
+      assert.isUndefined(Raven._globalOptions.release);
+    });
+  });
+
+  describe('.setDataCallback', function() {
+    it('should set the globalOptions.dataCallback attribute', function() {
+      var foo = sinon.stub();
+      Raven.setDataCallback(foo);
+
+      // note that setDataCallback creates a callback/closure around
+      // foo, so can't test for equality - just verify that calling the wrapper
+      // also calls foo
+      Raven._globalOptions.dataCallback();
+      assert.isTrue(foo.calledOnce);
+    });
+
+    it('should clear globalOptions.dataCallback with no arguments', function() {
+      var foo = function() {};
+      Raven._globalOptions.dataCallback = foo;
+      Raven.setDataCallback();
+      assert.isUndefined(Raven._globalOptions.dataCallback);
+    });
+
+    it('should generate a wrapper that passes the prior callback as the 2nd argument', function() {
+      var foo = sinon.stub();
+      var bar = sinon.spy(function(data, orig) {
+        assert.equal(orig, foo);
+        foo();
+      });
+      Raven._globalOptions.dataCallback = foo;
+      Raven.setDataCallback(bar);
+      Raven._globalOptions.dataCallback({
+        a: 1 // "data"
+      });
+      assert.isTrue(bar.calledOnce);
+      assert.isTrue(foo.calledOnce);
+    });
+  });
+
+  describe('.setBreadcrumbCallback', function() {
+    it('should set the globalOptions.breadcrumbCallback attribute', function() {
+      var foo = sinon.stub();
+      Raven.setBreadcrumbCallback(foo);
+
+      // note that breadcrumbCallback creates a callback/closure around
+      // foo, so can't test for equality - just verify that calling the wrapper
+      // also calls foo
+      Raven._globalOptions.breadcrumbCallback();
+      assert.isTrue(foo.calledOnce);
+    });
+
+    it('should clear globalOptions.breadcrumbCallback with no arguments', function() {
+      var foo = function() {};
+      Raven._globalOptions.breadcrumbCallback = foo;
+      Raven.setBreadcrumbCallback();
+      assert.isUndefined(Raven._globalOptions.breadcrumbCallback);
+    });
+
+    it('should generate a wrapper that passes the prior callback as the 2nd argument', function() {
+      var foo = sinon.stub();
+      var bar = sinon.spy(function(data, orig) {
+        assert.equal(orig, foo);
+        foo();
+      });
+      Raven._globalOptions.breadcrumbCallback = foo;
+      Raven.setBreadcrumbCallback(bar);
+      Raven._globalOptions.breadcrumbCallback({
+        a: 1 // "data"
+      });
+      assert.isTrue(bar.calledOnce);
+      assert.isTrue(foo.calledOnce);
+    });
+  });
+
+  describe('.setShouldSendCallback', function() {
+    it('should set the globalOptions.shouldSendCallback attribute', function() {
+      var foo = sinon.stub();
+      Raven.setShouldSendCallback(foo);
+
+      // note that setShouldSendCallback creates a callback/closure around
+      // foo, so can't test for equality - just verify that calling the wrapper
+      // also calls foo
+      Raven._globalOptions.shouldSendCallback();
+      assert.isTrue(foo.calledOnce);
+    });
+
+    it('should clear globalOptions.shouldSendCallback with no arguments', function() {
+      var foo = function() {};
+      Raven._globalOptions.shouldSendCallback = foo;
+      Raven.setShouldSendCallback();
+      assert.isUndefined(Raven._globalOptions.shouldSendCallback);
+    });
+
+    it('should generate a wrapper that passes the prior callback as the 2nd argument', function() {
+      var foo = sinon.stub();
+      var bar = sinon.spy(function(data, orig) {
+        assert.equal(orig, foo);
+        foo();
+      });
+      Raven._globalOptions.shouldSendCallback = foo;
+      Raven.setShouldSendCallback(bar);
+      Raven._globalOptions.shouldSendCallback({
+        a: 1 // "data"
+      });
+      assert.isTrue(bar.calledOnce);
+      assert.isTrue(foo.calledOnce);
+    });
+  });
+
+  describe('.captureMessage', function() {
+    it('should work as advertised', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_send');
+      Raven.captureMessage('lol', {foo: 'bar'});
+      assert.isTrue(Raven._send.called);
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          message: 'lol',
+          foo: 'bar'
+        }
+      ]);
+    });
+
+    it('should coerce message to a string', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_send');
+      Raven.captureMessage({});
+      assert.isTrue(Raven._send.called);
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          message: '[object Object]'
+        }
+      ]);
+    });
+
+    it('should work as advertised #integration', function() {
+      var imageCache = [];
+
+      this.sinon.stub(Raven, '_makeRequest');
+      setupRaven();
+      Raven.captureMessage('lol', {foo: 'bar'});
+      assert.equal(Raven._makeRequest.callCount, 1);
+      // It'd be hard to assert the actual payload being sent
+      // since it includes the generated url, which is going to
+      // vary between users running the tests
+      // Unit tests should cover that the payload was constructed properly
+    });
+
+    it('should tag lastEventId #integration', function() {
+      this.sinon.stub(Raven, '_makeRequest');
+      setupRaven();
+      Raven.captureMessage('lol');
+      assert.equal(Raven.lastEventId(), 'abc123');
+    });
+
+    it('should respect `ignoreErrors`', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_send');
+
+      Raven._globalOptions.ignoreErrors = joinRegExp(['e1', 'e2']);
+      Raven.captureMessage('e1');
+      assert.isFalse(Raven._send.called);
+      Raven.captureMessage('e2');
+      assert.isFalse(Raven._send.called);
+      Raven.captureMessage('Non-ignored error');
+      assert.isTrue(Raven._send.calledOnce);
+    });
+
+    it('should not throw an error if not configured', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(false);
+      this.sinon.stub(Raven, '_send');
+      assert.doesNotThrow(function() {
+        Raven.captureMessage('foo');
+      });
+    });
+
+    describe('synthetic traces', function() {
+      function assertSynthetic(frames) {
+        // Raven.captureMessage
+        var last = frames[frames.length - 1];
+        assert.isTrue(/(captureMessage|^\?)$/.test(last.function)); // loose equality check because differs per-browser
+        assert.equal(last.in_app, false);
+
+        // foo
+        var secondLast = frames[frames.length - 2];
+        assert.equal(secondLast.function, 'foo');
+        assert.equal(secondLast.in_app, true);
+      }
+
+      it('should get collected if stacktrace:true is passed via options', function() {
+        this.sinon.stub(Raven, 'isSetup').returns(true);
+        this.sinon.stub(Raven, '_send');
+
+        function foo() {
+          Raven.captureMessage('foo', {
+            stacktrace: true
+          });
+        }
+
+        foo();
+        var frames = Raven._send.lastCall.args[0].stacktrace.frames;
+        assertSynthetic(frames);
+      });
+
+      it('should get collected if stacktrace:true is set via globalOptions', function() {
+        this.sinon.stub(Raven, 'isSetup').returns(true);
+        this.sinon.stub(Raven, '_send');
+
+        Raven._globalOptions.stacktrace = true;
+        function foo() {
+          Raven.captureMessage('foo');
+        }
+
+        foo();
+        var frames = Raven._send.lastCall.args[0].stacktrace.frames;
+        assertSynthetic(frames);
+      });
+    });
+  });
+
+  describe('.captureException', function() {
+    it('should call handleStackInfo', function() {
+      var error = new Error('crap');
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_handleStackInfo');
+      Raven.captureException(error, {foo: 'bar'});
+      assert.isTrue(Raven._handleStackInfo.calledOnce);
+    });
+
+    it('should store the last exception', function() {
+      var error = new Error('crap');
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_handleStackInfo');
+      Raven.captureException(error);
+      assert.equal(Raven.lastException(), error);
+    });
+
+    it("shouldn't reraise the if error is the same error", function() {
+      var error = new Error('crap');
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_handleStackInfo').throws(error);
+      // this would raise if the errors didn't match
+      Raven.captureException(error, {foo: 'bar'});
+      assert.isTrue(Raven._handleStackInfo.calledOnce);
+    });
+
+    it('should reraise a different error', function() {
+      var error = new Error('crap1');
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_handleStackInfo').throws(error);
+      assert.throws(function() {
+        Raven.captureException(new Error('crap2'));
+      }, error);
+    });
+
+    it('should capture as a normal message if a non-Error is passed', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, 'captureMessage');
+      this.sinon.stub(Raven, '_handleStackInfo');
+      Raven.captureException('derp');
+      assert.isTrue(Raven.captureMessage.called);
+      assert.equal(Raven.captureMessage.lastCall.args[0], 'derp');
+      assert.isFalse(Raven._handleStackInfo.called);
+      Raven.captureException(true);
+      assert.isTrue(Raven.captureMessage.called);
+      assert.equal(Raven.captureMessage.lastCall.args[0], true);
+      assert.isFalse(Raven._handleStackInfo.called);
+    });
+
+    it('should capture custom errors that extend the Error prototype', function() {
+      function NotImplementedError(message) {
+        this.name = 'NotImplementedError';
+        this.message = message || '';
+      }
+      NotImplementedError.prototype = Error.prototype;
+
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_handleStackInfo');
+
+      Raven.captureException(new NotImplementedError('Bzzap'));
+
+      assert.isTrue(Raven._handleStackInfo.calledOnce);
+    });
+
+    it('should not throw an error if not configured', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(false);
+      this.sinon.stub(Raven, '_handleStackInfo');
+      assert.doesNotThrow(function() {
+        Raven.captureException(new Error('err'));
+      });
+    });
+  });
+
+  describe('.captureBreadcrumb', function() {
+    it('should store the passed object in _breadcrumbs', function() {
+      Raven.captureBreadcrumb({
+        type: 'http',
+        data: {
+          url: 'http://example.org/api/0/auth/',
+          status_code: 200
+        }
+      });
+
+      assert.deepEqual(Raven._breadcrumbs[0], {
+        type: 'http',
+        timestamp: 0.1,
+        data: {
+          url: 'http://example.org/api/0/auth/',
+          status_code: 200
+        }
+      });
+    });
+
+    it('should dequeue the oldest breadcrumb when over limit', function() {
+      Raven._globalOptions.maxBreadcrumbs = 5;
+      Raven._breadcrumbs = [
+        {message: '1', timestamp: 0.1},
+        {message: '2', timestamp: 0.1},
+        {message: '3', timestamp: 0.1},
+        {message: '4', timestamp: 0.1},
+        {message: '5', timestamp: 0.1}
+      ];
+
+      Raven.captureBreadcrumb({message: 'lol'});
+      assert.deepEqual(Raven._breadcrumbs, [
+        {message: '2', timestamp: 0.1},
+        {message: '3', timestamp: 0.1},
+        {message: '4', timestamp: 0.1},
+        {message: '5', timestamp: 0.1},
+        {message: 'lol', timestamp: 0.1}
+      ]);
+    });
+
+    describe('breadcrumbCallback', function() {
+      it('should filter the breadcrumb if it returns false', function() {
+        Raven.setBreadcrumbCallback(function() {
+          return false;
         });
 
-        it('should coerce message to a string', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_send');
-            Raven.captureMessage({});
-            assert.isTrue(Raven._send.called);
-            assert.deepEqual(Raven._send.lastCall.args, [{
-                message: '[object Object]'
-            }]);
+        Raven.captureBreadcrumb({
+          type: 'http',
+          data: {
+            url: 'http://example.org/api/0/auth/',
+            status_code: 200
+          }
         });
 
-        it('should work as advertised #integration', function() {
-            var imageCache = [];
+        assert.strictEqual(Raven._breadcrumbs.length, 0);
+      });
 
-            this.sinon.stub(Raven, '_makeRequest');
-            setupRaven();
-            Raven.captureMessage('lol', {foo: 'bar'});
-            assert.equal(Raven._makeRequest.callCount, 1);
-            // It'd be hard to assert the actual payload being sent
-            // since it includes the generated url, which is going to
-            // vary between users running the tests
-            // Unit tests should cover that the payload was constructed properly
+      it('should not filter the breadcrumb if callback returns undefined', function() {
+        Raven.setBreadcrumbCallback(function() {});
+
+        Raven.captureBreadcrumb({
+          type: 'http',
+          data: {
+            url: 'http://example.org/api/0/auth/',
+            status_code: 200
+          }
         });
 
-        it('should tag lastEventId #integration', function() {
-            this.sinon.stub(Raven, '_makeRequest');
-            setupRaven();
-            Raven.captureMessage('lol');
-            assert.equal(Raven.lastEventId(), 'abc123');
-        });
-
-        it('should respect `ignoreErrors`', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_send');
-
-            Raven._globalOptions.ignoreErrors = joinRegExp(['e1', 'e2']);
-            Raven.captureMessage('e1');
-            assert.isFalse(Raven._send.called);
-            Raven.captureMessage('e2');
-            assert.isFalse(Raven._send.called);
-            Raven.captureMessage('Non-ignored error');
-            assert.isTrue(Raven._send.calledOnce);
-        });
-
-        it('should not throw an error if not configured', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(false);
-            this.sinon.stub(Raven, '_send');
-            assert.doesNotThrow(function() {
-                Raven.captureMessage('foo');
-            });
-        });
-
-
-        describe('synthetic traces', function () {
-            function assertSynthetic(frames) {
-               // Raven.captureMessage
-                var last = frames[frames.length - 1];
-                assert.isTrue(/(captureMessage|^\?)$/.test(last.function)); // loose equality check because differs per-browser
-                assert.equal(last.in_app, false);
-
-                // foo
-                var secondLast = frames[frames.length - 2];
-                assert.equal(secondLast.function, 'foo');
-                assert.equal(secondLast.in_app, true);
+        assert.deepEqual(Raven._breadcrumbs, [
+          {
+            type: 'http',
+            timestamp: 0.1,
+            data: {
+              url: 'http://example.org/api/0/auth/',
+              status_code: 200
             }
+          }
+        ]);
+      });
 
-            it('should get collected if stacktrace:true is passed via options', function () {
-                this.sinon.stub(Raven, 'isSetup').returns(true);
-                this.sinon.stub(Raven, '_send');
-
-                function foo() {
-                    Raven.captureMessage('foo', {
-                        stacktrace: true
-                    });
-                }
-
-                foo();
-                var frames = Raven._send.lastCall.args[0].stacktrace.frames;
-                assertSynthetic(frames);
-            });
-
-            it('should get collected if stacktrace:true is set via globalOptions', function () {
-                this.sinon.stub(Raven, 'isSetup').returns(true);
-                this.sinon.stub(Raven, '_send');
-
-                Raven._globalOptions.stacktrace = true;
-                function foo() {
-                    Raven.captureMessage('foo');
-                }
-
-                foo();
-                var frames = Raven._send.lastCall.args[0].stacktrace.frames;
-                assertSynthetic(frames);
-            });
-        });
-    });
-
-    describe('.captureException', function() {
-        it('should call handleStackInfo', function() {
-            var error = new Error('crap');
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_handleStackInfo');
-            Raven.captureException(error, {foo: 'bar'});
-            assert.isTrue(Raven._handleStackInfo.calledOnce);
+      it('should be able to mutate the breadcrumb', function() {
+        Raven.setBreadcrumbCallback(function(crumb) {
+          crumb.type = 'whee';
         });
 
-        it('should store the last exception', function() {
-            var error = new Error('crap');
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_handleStackInfo');
-            Raven.captureException(error);
-            assert.equal(Raven.lastException(), error);
+        Raven.captureBreadcrumb({
+          type: 'http',
+          data: {
+            url: 'http://example.org/api/0/auth/',
+            status_code: 200
+          }
         });
 
-        it('shouldn\'t reraise the if error is the same error', function() {
-            var error = new Error('crap');
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_handleStackInfo').throws(error);
-            // this would raise if the errors didn't match
-            Raven.captureException(error, {foo: 'bar'});
-            assert.isTrue(Raven._handleStackInfo.calledOnce);
-        });
-
-        it('should reraise a different error', function() {
-            var error = new Error('crap1');
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_handleStackInfo').throws(error);
-            assert.throws(function() {
-                Raven.captureException(new Error('crap2'));
-            }, error);
-        });
-
-        it('should capture as a normal message if a non-Error is passed', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, 'captureMessage');
-            this.sinon.stub(Raven, '_handleStackInfo');
-            Raven.captureException('derp');
-            assert.isTrue(Raven.captureMessage.called);
-            assert.equal(Raven.captureMessage.lastCall.args[0], 'derp');
-            assert.isFalse(Raven._handleStackInfo.called);
-            Raven.captureException(true);
-            assert.isTrue(Raven.captureMessage.called);
-            assert.equal(Raven.captureMessage.lastCall.args[0], true);
-            assert.isFalse(Raven._handleStackInfo.called);
-        });
-
-        it('should capture custom errors that extend the Error prototype', function() {
-            function NotImplementedError(message) {
-                this.name = "NotImplementedError";
-                this.message = message || "";
+        assert.deepEqual(Raven._breadcrumbs, [
+          {
+            type: 'whee',
+            timestamp: 0.1,
+            data: {
+              url: 'http://example.org/api/0/auth/',
+              status_code: 200
             }
-            NotImplementedError.prototype = Error.prototype;
+          }
+        ]);
+      });
 
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_handleStackInfo');
-
-            Raven.captureException(new NotImplementedError('Bzzap'));
-
-            assert.isTrue(Raven._handleStackInfo.calledOnce);
+      it('should enable replacing the breadcrumb', function() {
+        Raven.setBreadcrumbCallback(function() {
+          return {
+            foo: 'bar'
+          };
         });
 
-        it('should not throw an error if not configured', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(false);
-            this.sinon.stub(Raven, '_handleStackInfo');
-            assert.doesNotThrow(function() {
-                Raven.captureException(new Error('err'));
-            });
+        Raven.captureBreadcrumb({
+          type: 'http',
+          data: {
+            url: 'http://example.org/api/0/auth/',
+            status_code: 200
+          }
         });
+
+        assert.deepEqual(Raven._breadcrumbs[0], {
+          foo: 'bar'
+        });
+      });
+
+      it('should not replace the breadcrumb if a non object is returned', function() {
+        Raven.setBreadcrumbCallback(function() {
+          return 'foo';
+        });
+
+        Raven.captureBreadcrumb({
+          type: 'http',
+          data: {
+            url: 'http://example.org/api/0/auth/',
+            status_code: 200
+          }
+        });
+
+        assert.deepEqual(Raven._breadcrumbs, [
+          {
+            type: 'http',
+            timestamp: 0.1,
+            data: {
+              url: 'http://example.org/api/0/auth/',
+              status_code: 200
+            }
+          }
+        ]);
+      });
+
+      it('should not replace the breadcrumb if an empty object is returned', function() {
+        Raven.setBreadcrumbCallback(function() {
+          return {};
+        });
+
+        Raven.captureBreadcrumb({
+          type: 'http',
+          data: {
+            url: 'http://example.org/api/0/auth/',
+            status_code: 200
+          }
+        });
+
+        assert.deepEqual(Raven._breadcrumbs, [
+          {
+            type: 'http',
+            timestamp: 0.1,
+            data: {
+              url: 'http://example.org/api/0/auth/',
+              status_code: 200
+            }
+          }
+        ]);
+      });
+
+      it('should call the callback with the breadcrumb object', function() {
+        var callback = this.sinon.stub().returnsArg(0);
+        Raven.setBreadcrumbCallback(callback);
+
+        Raven.captureBreadcrumb({
+          type: 'http',
+          data: {
+            url: 'http://example.org/api/0/auth/',
+            status_code: 200
+          }
+        });
+
+        assert.isTrue(
+          callback.calledWith({
+            type: 'http',
+            timestamp: 0.1,
+            data: {
+              url: 'http://example.org/api/0/auth/',
+              status_code: 200
+            }
+          })
+        );
+      });
+
+      it('should enable filtering one breadcrumb but not another', function() {
+        function callback(data) {
+          if (data.data.url === 'example') {
+            return false;
+          }
+
+          return data;
+        }
+
+        Raven.setBreadcrumbCallback(callback);
+        Raven.captureBreadcrumb({
+          type: 'http',
+          data: {
+            url: 'example',
+            status_code: 200
+          }
+        });
+
+        Raven.captureBreadcrumb({
+          type: 'http',
+          data: {
+            url: 'foo',
+            status_code: 301
+          }
+        });
+
+        assert.deepEqual(Raven._breadcrumbs, [
+          {
+            type: 'http',
+            timestamp: 0.1,
+            data: {
+              url: 'foo',
+              status_code: 301
+            }
+          }
+        ]);
+      });
+    });
+  });
+
+  describe('.Raven.isSetup', function() {
+    it('should work as advertised', function() {
+      var isSetup = this.sinon.stub(Raven, 'isSetup');
+      isSetup.returns(true);
+      assert.isTrue(Raven.isSetup());
+      isSetup.returns(false);
+      assert.isFalse(Raven.isSetup());
+    });
+  });
+
+  describe('.showReportDialog', function() {
+    it('should throw a RavenConfigError if no eventId', function() {
+      assert.throws(function() {
+        Raven.showReportDialog({
+          dsn: SENTRY_DSN // dsn specified via options
+        });
+      }, 'Missing eventId');
+
+      Raven.config(SENTRY_DSN);
+      assert.throws(function() {
+        Raven.showReportDialog(); // dsn specified via Raven.config
+      }, 'Missing eventId');
     });
 
-    describe('.captureBreadcrumb', function () {
-        it('should store the passed object in _breadcrumbs', function() {
-            Raven.captureBreadcrumb({
-                type: 'http',
-                data: {
-                    url: 'http://example.org/api/0/auth/',
-                    status_code: 200
-                }
-            });
-
-            assert.deepEqual(Raven._breadcrumbs[0], {
-                type: 'http',
-                timestamp: 0.1,
-                data: {
-                    url: 'http://example.org/api/0/auth/',
-                    status_code: 200
-                }
-            });
+    it('should throw a RavenConfigError if no dsn', function() {
+      assert.throws(function() {
+        Raven.showReportDialog({
+          eventId: 'abc123'
         });
-
-        it('should dequeue the oldest breadcrumb when over limit', function() {
-            Raven._globalOptions.maxBreadcrumbs = 5;
-            Raven._breadcrumbs = [
-                { message: '1', timestamp: 0.1 },
-                { message: '2', timestamp: 0.1 },
-                { message: '3', timestamp: 0.1 },
-                { message: '4', timestamp: 0.1 },
-                { message: '5', timestamp: 0.1 }
-            ];
-
-            Raven.captureBreadcrumb({ message: 'lol' });
-            assert.deepEqual(Raven._breadcrumbs, [
-                { message: '2', timestamp: 0.1 },
-                { message: '3', timestamp: 0.1 },
-                { message: '4', timestamp: 0.1 },
-                { message: '5', timestamp: 0.1 },
-                { message: 'lol', timestamp: 0.1 }
-            ]);
-        });
-
-        describe('breadcrumbCallback', function() {
-            it('should filter the breadcrumb if it returns false', function() {
-                Raven.setBreadcrumbCallback(function() {
-                    return false;
-                });
-
-                Raven.captureBreadcrumb({
-                    type: 'http',
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                });
-
-                assert.strictEqual(Raven._breadcrumbs.length, 0);
-            });
-
-            it('should not filter the breadcrumb if callback returns undefined', function() {
-                Raven.setBreadcrumbCallback(function() {});
-
-                Raven.captureBreadcrumb({
-                    type: 'http',
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                });
-
-                assert.deepEqual(Raven._breadcrumbs, [{
-                    type: 'http',
-                    timestamp: 0.1,
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                }]);
-            });
-
-            it('should be able to mutate the breadcrumb', function() {
-                Raven.setBreadcrumbCallback(function(crumb) {
-                    crumb.type = 'whee';
-                });
-
-                Raven.captureBreadcrumb({
-                    type: 'http',
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                });
-
-                assert.deepEqual(Raven._breadcrumbs, [{
-                    type: 'whee',
-                    timestamp: 0.1,
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                }]);
-            });
-
-            it('should enable replacing the breadcrumb', function() {
-                Raven.setBreadcrumbCallback(function() {
-                    return {
-                        foo: 'bar'
-                    }
-                });
-
-                Raven.captureBreadcrumb({
-                    type: 'http',
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                });
-
-                assert.deepEqual(Raven._breadcrumbs[0], {
-                    foo: 'bar'
-                });
-            });
-
-            it('should not replace the breadcrumb if a non object is returned', function() {
-                Raven.setBreadcrumbCallback(function() {
-                    return 'foo';
-                });
-
-                Raven.captureBreadcrumb({
-                    type: 'http',
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                });
-
-                assert.deepEqual(Raven._breadcrumbs, [{
-                    type: 'http',
-                    timestamp: 0.1,
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                }]);
-            });
-
-            it('should not replace the breadcrumb if an empty object is returned', function() {
-                Raven.setBreadcrumbCallback(function() {
-                    return {};
-                });
-
-                Raven.captureBreadcrumb({
-                    type: 'http',
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                });
-
-                assert.deepEqual(Raven._breadcrumbs, [{
-                    type: 'http',
-                    timestamp: 0.1,
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                }]);
-            });
-
-            it('should call the callback with the breadcrumb object', function() {
-                var callback = this.sinon.stub().returnsArg(0);
-                Raven.setBreadcrumbCallback(callback);
-
-                Raven.captureBreadcrumb({
-                    type: 'http',
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                });
-
-                assert.isTrue(callback.calledWith({
-                    type: 'http',
-                    timestamp: 0.1,
-                    data: {
-                        url: 'http://example.org/api/0/auth/',
-                        status_code: 200
-                    }
-                }));
-            });
-
-            it('should enable filtering one breadcrumb but not another', function() {
-                function callback(data) {
-                    if (data.data.url === 'example') {
-                        return false;
-                    }
-
-                    return data;
-                }
-
-                Raven.setBreadcrumbCallback(callback);
-                Raven.captureBreadcrumb({
-                    type: 'http',
-                    data: {
-                        url: 'example',
-                        status_code: 200
-                    }
-                });
-
-                Raven.captureBreadcrumb({
-                    type: 'http',
-                    data: {
-                        url: 'foo',
-                        status_code: 301
-                    }
-                });
-
-                assert.deepEqual(Raven._breadcrumbs, [{
-                    type: 'http',
-                    timestamp: 0.1,
-                    data: {
-                        url: 'foo',
-                        status_code: 301
-                    }
-                }]);
-            });
-        });
+      }, 'Missing DSN');
     });
 
-    describe('.Raven.isSetup', function() {
-        it('should work as advertised', function() {
-            var isSetup = this.sinon.stub(Raven, 'isSetup');
-            isSetup.returns(true);
-            assert.isTrue(Raven.isSetup());
-            isSetup.returns(false);
-            assert.isFalse(Raven.isSetup());
+    describe('script tag insertion', function() {
+      beforeEach(function() {
+        this.appendChildStub = this.sinon.stub(document.head, 'appendChild');
+      });
+
+      it('should specify embed API endpoint and basic query string (DSN, eventId)', function() {
+        this.sinon.stub(Raven, '_makeRequest');
+
+        Raven.showReportDialog({
+          eventId: 'abc123',
+          dsn: SENTRY_DSN
         });
+
+        var script = this.appendChildStub.getCall(0).args[0];
+        assert.equal(
+          script.src,
+          'http://example.com/api/embed/error-page/?eventId=abc123&dsn=http%3A%2F%2Fabc%40example.com%3A80%2F2'
+        );
+
+        this.appendChildStub.reset();
+
+        Raven.config(SENTRY_DSN)
+          .captureException(new Error('foo')) // generates lastEventId
+          .showReportDialog();
+
+        this.appendChildStub.getCall(0).args[0];
+        assert.equal(
+          script.src,
+          'http://example.com/api/embed/error-page/?eventId=abc123&dsn=http%3A%2F%2Fabc%40example.com%3A80%2F2'
+        );
+      });
+
+      it('should specify embed API endpoint and full query string (DSN, eventId, user)', function() {
+        this.sinon.stub(Raven, '_makeRequest');
+
+        Raven.showReportDialog({
+          eventId: 'abc123',
+          dsn: SENTRY_DSN,
+          user: {
+            name: 'Average Normalperson',
+            email: 'an@example.com'
+          }
+        });
+
+        var script = this.appendChildStub.getCall(0).args[0];
+        assert.equal(
+          script.src,
+          'http://example.com/api/embed/error-page/?eventId=abc123&dsn=http%3A%2F%2Fabc%40example.com%3A80%2F2&name=Average%20Normalperson&email=an%40example.com'
+        );
+
+        this.appendChildStub.reset();
+        Raven.config(SENTRY_DSN)
+          .captureException(new Error('foo')) // generates lastEventId
+          .setUserContext({
+            name: 'Average Normalperson 2',
+            email: 'an2@example.com'
+          })
+          .showReportDialog();
+
+        var script = this.appendChildStub.getCall(0).args[0];
+        assert.equal(
+          script.src,
+          'http://example.com/api/embed/error-page/?eventId=abc123&dsn=http%3A%2F%2Fabc%40example.com%3A80%2F2&name=Average%20Normalperson%202&email=an2%40example.com'
+        );
+      });
     });
-
-    describe('.showReportDialog', function () {
-        it('should throw a RavenConfigError if no eventId', function () {
-            assert.throws(function () {
-                Raven.showReportDialog({
-                    dsn: SENTRY_DSN // dsn specified via options
-                });
-            }, 'Missing eventId');
-
-            Raven.config(SENTRY_DSN);
-            assert.throws(function () {
-                Raven.showReportDialog(); // dsn specified via Raven.config
-            }, 'Missing eventId');
-        });
-
-        it('should throw a RavenConfigError if no dsn', function () {
-            assert.throws(function () {
-                Raven.showReportDialog({
-                    eventId: 'abc123'
-                });
-            }, 'Missing DSN');
-        });
-
-        describe('script tag insertion', function () {
-            beforeEach(function () {
-                this.appendChildStub = this.sinon.stub(document.head, 'appendChild');
-            });
-
-            it('should specify embed API endpoint and basic query string (DSN, eventId)', function () {
-                this.sinon.stub(Raven, '_makeRequest');
-
-                Raven.showReportDialog({
-                    eventId: 'abc123',
-                    dsn: SENTRY_DSN
-                });
-
-                var script = this.appendChildStub.getCall(0).args[0];
-                assert.equal(script.src, 'http://example.com/api/embed/error-page/?eventId=abc123&dsn=http%3A%2F%2Fabc%40example.com%3A80%2F2');
-
-                this.appendChildStub.reset();
-
-                Raven
-                    .config(SENTRY_DSN)
-                    .captureException(new Error('foo')) // generates lastEventId
-                    .showReportDialog();
-
-                this.appendChildStub.getCall(0).args[0];
-                assert.equal(script.src, 'http://example.com/api/embed/error-page/?eventId=abc123&dsn=http%3A%2F%2Fabc%40example.com%3A80%2F2');
-            });
-
-            it('should specify embed API endpoint and full query string (DSN, eventId, user)', function () {
-                this.sinon.stub(Raven, '_makeRequest');
-
-                Raven.showReportDialog({
-                    eventId: 'abc123',
-                    dsn: SENTRY_DSN,
-                    user: {
-                        name: 'Average Normalperson',
-                        email: 'an@example.com'
-                    }
-                });
-
-                var script = this.appendChildStub.getCall(0).args[0];
-                assert.equal(script.src, 'http://example.com/api/embed/error-page/?eventId=abc123&dsn=http%3A%2F%2Fabc%40example.com%3A80%2F2&name=Average%20Normalperson&email=an%40example.com');
-
-                this.appendChildStub.reset();
-                Raven
-                    .config(SENTRY_DSN)
-                    .captureException(new Error('foo')) // generates lastEventId
-                    .setUserContext({
-                        name: 'Average Normalperson 2',
-                        email: 'an2@example.com'
-                    })
-                    .showReportDialog();
-
-                var script = this.appendChildStub.getCall(0).args[0];
-                assert.equal(script.src, 'http://example.com/api/embed/error-page/?eventId=abc123&dsn=http%3A%2F%2Fabc%40example.com%3A80%2F2&name=Average%20Normalperson%202&email=an2%40example.com');
-            });
-        });
-    });
+  });
 });
 
-describe('Raven (private methods)', function () {
-    beforeEach(function () {
-        this.clock = sinon.useFakeTimers();
-        this.clock.tick(0); // Raven initialized at time "0"
-        Raven = new _Raven();
+describe('Raven (private methods)', function() {
+  beforeEach(function() {
+    this.clock = sinon.useFakeTimers();
+    this.clock.tick(0); // Raven initialized at time "0"
+    Raven = new _Raven();
+  });
+
+  afterEach(function() {
+    this.clock.restore();
+  });
+
+  describe('._captureUrlChange', function() {
+    it('should create a new breadcrumb from its "from" and "to" arguments', function() {
+      this.clock.tick(100);
+      Raven._breadcrumbs = [];
+      Raven._captureUrlChange('/foo', '/bar');
+      assert.deepEqual(Raven._breadcrumbs, [
+        {category: 'navigation', timestamp: 0.1, data: {from: '/foo', to: '/bar'}}
+      ]);
     });
 
-   afterEach(function () {
-        this.clock.restore();
+    it('should strip protocol/host if passed URLs share the same origin as location.href', function() {
+      this.clock.tick(100);
+      Raven._location = {href: 'http://example.com/foo'};
+      Raven._breadcrumbs = [];
+
+      Raven._captureUrlChange('http://example.com/foo', 'http://example.com/bar');
+      assert.deepEqual(Raven._breadcrumbs, [
+        {category: 'navigation', timestamp: 0.1, data: {from: '/foo', to: '/bar'}}
+      ]);
+    });
+  });
+
+  describe('._isRepeatData', function() {
+    describe('from captureMessage', function() {
+      beforeEach(function() {
+        Raven._lastData = {
+          message: 'the thing broke'
+        };
+      });
+
+      it('should return true for duplicate captureMessage payloads', function() {
+        var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        assert.isTrue(Raven._isRepeatData(data));
+      });
+
+      it('should return true for duplicate captureMessage payloads w/ synthetic traces', function() {
+        Raven._lastData.stacktrace = {
+          frames: [
+            {
+              lineno: 100,
+              colno: 1337,
+              function: 'lol',
+              filename: 'https://example.com/js/foo.js'
+            }
+          ]
+        };
+        var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        assert.isTrue(Raven._isRepeatData(data));
+      });
+
+      it('should return false for different messages', function() {
+        var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.message = 'the other thing broke';
+
+        assert.isFalse(Raven._isRepeatData(data));
+      });
+
+      it('should return false for different captureMessage payloads w/ synthetic traces', function() {
+        Raven._lastData.stacktrace = {
+          frames: [
+            {
+              lineno: 100,
+              colno: 1337,
+              function: 'lol',
+              filename: 'https://example.com/js/foo.js'
+            },
+            {
+              lineno: 200,
+              colno: 1338,
+              function: 'woo',
+              filename: 'https://example.com/js/bar.js'
+            }
+          ]
+        };
+        var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.stacktrace.frames[0].lineno = 101;
+        assert.isFalse(Raven._isRepeatData(data));
+
+        data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.stacktrace.frames.shift(); // different frame count
+        assert.isFalse(Raven._isRepeatData(data));
+
+        data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.stacktrace = undefined; // no stacktrace, same msg
+        assert.isFalse(Raven._isRepeatData(data));
+      });
     });
 
-    describe('._captureUrlChange', function () {
-        it('should create a new breadcrumb from its "from" and "to" arguments', function () {
-            this.clock.tick(100);
-            Raven._breadcrumbs = [];
-            Raven._captureUrlChange('/foo', '/bar');
-            assert.deepEqual(Raven._breadcrumbs, [
-                { category: 'navigation', timestamp: 0.1, data: { from: '/foo', to: '/bar' }}
-            ]);
-        });
-
-        it('should strip protocol/host if passed URLs share the same origin as location.href', function () {
-            this.clock.tick(100);
-            Raven._location = { href: 'http://example.com/foo' };
-            Raven._breadcrumbs = [];
-
-            Raven._captureUrlChange('http://example.com/foo', 'http://example.com/bar');
-            assert.deepEqual(Raven._breadcrumbs, [
-                { category: 'navigation', timestamp: 0.1, data: { from: '/foo', to: '/bar' }}
-            ]);
-        });
-    });
-
-    describe('._isRepeatData', function () {
-        describe('from captureMessage', function () {
-            beforeEach(function () {
-                Raven._lastData = {
-                    message: 'the thing broke'
-                }
-            });
-
-            it('should return true for duplicate captureMessage payloads', function () {
-                var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                assert.isTrue(Raven._isRepeatData(data));
-            });
-
-            it('should return true for duplicate captureMessage payloads w/ synthetic traces', function () {
-                Raven._lastData.stacktrace = {
-                    frames: [{
-                        lineno: 100,
-                        colno: 1337,
-                        'function': 'lol',
-                        filename: 'https://example.com/js/foo.js'
-                    }]
-                };
-                var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                assert.isTrue(Raven._isRepeatData(data));
-            });
-
-            it('should return false for different messages', function () {
-                var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                data.message = 'the other thing broke';
-
-                assert.isFalse(Raven._isRepeatData(data));
-            });
-
-            it('should return false for different captureMessage payloads w/ synthetic traces', function () {
-                Raven._lastData.stacktrace = {
-                    frames: [{
-                        lineno: 100,
-                        colno: 1337,
-                        'function': 'lol',
-                        filename: 'https://example.com/js/foo.js'
-                    }, {
-                        lineno: 200,
-                        colno: 1338,
-                        'function': 'woo',
-                        filename: 'https://example.com/js/bar.js'
-                    }]
-                };
-                var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                data.stacktrace.frames[0].lineno = 101;
-                assert.isFalse(Raven._isRepeatData(data));
-
-                data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                data.stacktrace.frames.shift(); // different frame count
-                assert.isFalse(Raven._isRepeatData(data));
-
-                data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                data.stacktrace = undefined; // no stacktrace, same msg
-                assert.isFalse(Raven._isRepeatData(data));
-            });
-        });
-
-        describe('from captureException/onerror', function () {
-            beforeEach(function () {
-                Raven._lastData = {
-                    culprit: 'https://example.com/js/foo.js',
-                    exception: {
-                        type: 'TypeError',
-                        value: 'foo is not defined',
-                        values: [{
-                            stacktrace: {
-                                frames: [{
-                                    lineno: 100,
-                                    colno: 1337,
-                                    'function': 'lol',
-                                    filename: 'https://example.com/js/foo.js'
-                                }]
-                            }
-                        }]
+    describe('from captureException/onerror', function() {
+      beforeEach(function() {
+        Raven._lastData = {
+          culprit: 'https://example.com/js/foo.js',
+          exception: {
+            type: 'TypeError',
+            value: 'foo is not defined',
+            values: [
+              {
+                stacktrace: {
+                  frames: [
+                    {
+                      lineno: 100,
+                      colno: 1337,
+                      function: 'lol',
+                      filename: 'https://example.com/js/foo.js'
                     }
+                  ]
                 }
-            });
+              }
+            ]
+          }
+        };
+      });
 
-            it('should return true for duplicate exceptions', function () {
-                var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                assert.isTrue(Raven._isRepeatData(data));
-            });
+      it('should return true for duplicate exceptions', function() {
+        var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        assert.isTrue(Raven._isRepeatData(data));
+      });
 
-            it('should return false for different exceptions', function () {
-                var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                data.culprit = 'https://example.com/js/bar.js';
-                assert.isFalse(Raven._isRepeatData(data));
+      it('should return false for different exceptions', function() {
+        var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.culprit = 'https://example.com/js/bar.js';
+        assert.isFalse(Raven._isRepeatData(data));
 
-                data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                data.exception.values[0].stacktrace.frames[0].lineno = 101;
-                assert.isFalse(Raven._isRepeatData(data));
+        data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.exception.values[0].stacktrace.frames[0].lineno = 101;
+        assert.isFalse(Raven._isRepeatData(data));
 
-                data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-                data.exception.values[0].stacktrace.frames = [];
-                assert.isFalse(Raven._isRepeatData(data));
-            });
-        });
+        data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        data.exception.values[0].stacktrace.frames = [];
+        assert.isFalse(Raven._isRepeatData(data));
+      });
     });
+  });
 });
 
 // intentionally separate install/uninstall from other test methods, because
 // the built-in wrapping doesn't play nice w/ Sinon's useFakeTimers() [won't
 // restore setTimeout, setInterval, etc]
-describe('install/uninstall', function () {
-   beforeEach(function () {
-      Raven = new _Raven();
-   });
+describe('install/uninstall', function() {
+  beforeEach(function() {
+    Raven = new _Raven();
+  });
 
-   describe('.install', function() {
-        beforeEach(function () {
-            this.sinon.stub(TraceKit.report, 'subscribe');
-        });
-
-        it('should check `Raven.isSetup`', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(false);
-            Raven.install();
-            assert.isTrue(Raven.isSetup.calledOnce);
-            assert.isFalse(TraceKit.report.subscribe.calledOnce);
-        });
-
-        it('should register itself with TraceKit', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            this.sinon.stub(Raven, '_handleStackInfo');
-            assert.equal(Raven, Raven.install());
-            assert.isTrue(TraceKit.report.subscribe.calledOnce);
-
-            // `install` subscribes to TraceKit w/ an anonymous function that
-            // wraps _handleStackInfo to preserve `this`. Invoke the anonymous
-            // function and verify that `_handleStackInfo` is called.
-            TraceKit.report.subscribe.lastCall.args[0]();
-            assert.isTrue(Raven._handleStackInfo.calledOnce);
-        });
-
-        it('should not register itself more than once', function() {
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-            Raven.install();
-            Raven.install();
-            assert.isTrue(TraceKit.report.subscribe.calledOnce);
-        });
-
-        it('_instrumentBreadcrumbs should use attachEvent instead of addEventListener in IE8', function () {
-            Raven._globalOptions.autoBreadcrumbs = {
-                dom: true
-            };
-
-            // Maintain a ref to the old function so we can restore it later.
-            var temp = document.addEventListener;
-
-            // Test setup.
-            this.sinon.stub(Raven, 'isSetup').returns(true);
-
-            document.addEventListener = false;
-            document.attachEvent = this.sinon.stub();
-
-            // Invoke and assert.
-            Raven.install();
-            assert.isTrue(document.attachEvent.called);
-
-            // Cleanup.
-            document.addEventListener = temp;
-        });
-
-        it('should instrument try/catch by default', function () {
-            this.sinon.stub(Raven, '_instrumentTryCatch');
-            Raven.config(SENTRY_DSN).install();
-            assert.isTrue(Raven._instrumentTryCatch.calledOnce);
-        });
-
-        it('should not instrument try/catch if instrument is false', function () {
-            this.sinon.stub(Raven, '_instrumentTryCatch');
-            Raven.config(SENTRY_DSN, {
-                instrument: false
-            }).install();
-            assert.isFalse(Raven._instrumentTryCatch.called);
-        });
-
-        it('should not instrument try/catch if instrument.tryCatch is false', function () {
-            this.sinon.stub(Raven, '_instrumentTryCatch');
-            Raven.config(SENTRY_DSN, {
-                instrument: {
-                    tryCatch: false
-                }
-            }).install();
-            assert.isFalse(Raven._instrumentTryCatch.called);
-        });
-
-        it('should instrument breadcrumbs by default', function () {
-            this.sinon.stub(Raven, '_instrumentBreadcrumbs');
-            Raven.config(SENTRY_DSN).install();
-            assert.isTrue(Raven._instrumentBreadcrumbs.calledOnce);
-        });
-
-        it('should instrument breadcrumbs if autoBreadcrumbs is an object', function () {
-            this.sinon.stub(Raven, '_instrumentBreadcrumbs');
-            Raven.config(SENTRY_DSN, {
-                dom: true,
-                location: false
-            }).install();
-
-            assert.isTrue(Raven._instrumentBreadcrumbs.calledOnce);
-        });
-
-        it('should not instrument breadcrumbs if autoBreadcrumbs is false', function () {
-            this.sinon.stub(Raven, '_instrumentBreadcrumbs');
-            Raven.config(SENTRY_DSN, {
-                autoBreadcrumbs: false
-            }).install();
-            assert.isFalse(Raven._instrumentBreadcrumbs.called);
-        });
+  describe('.install', function() {
+    beforeEach(function() {
+      this.sinon.stub(TraceKit.report, 'subscribe');
     });
 
-    describe('.uninstall', function() {
-        it('should uninstall from TraceKit', function() {
-            this.sinon.stub(TraceKit.report, 'uninstall');
-            Raven.uninstall();
-            assert.isTrue(TraceKit.report.uninstall.calledOnce);
-        });
-
-        it('should set isRavenInstalled flag to false', function() {
-            Raven._isRavenInstalled = true;
-            this.sinon.stub(TraceKit.report, 'uninstall');
-            Raven.uninstall();
-            assert.isFalse(Raven._isRavenInstalled);
-        });
+    it('should check `Raven.isSetup`', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(false);
+      Raven.install();
+      assert.isTrue(Raven.isSetup.calledOnce);
+      assert.isFalse(TraceKit.report.subscribe.calledOnce);
     });
+
+    it('should register itself with TraceKit', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_handleStackInfo');
+      assert.equal(Raven, Raven.install());
+      assert.isTrue(TraceKit.report.subscribe.calledOnce);
+
+      // `install` subscribes to TraceKit w/ an anonymous function that
+      // wraps _handleStackInfo to preserve `this`. Invoke the anonymous
+      // function and verify that `_handleStackInfo` is called.
+      TraceKit.report.subscribe.lastCall.args[0]();
+      assert.isTrue(Raven._handleStackInfo.calledOnce);
+    });
+
+    it('should not register itself more than once', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      Raven.install();
+      Raven.install();
+      assert.isTrue(TraceKit.report.subscribe.calledOnce);
+    });
+
+    it('_instrumentBreadcrumbs should use attachEvent instead of addEventListener in IE8', function() {
+      Raven._globalOptions.autoBreadcrumbs = {
+        dom: true
+      };
+
+      // Maintain a ref to the old function so we can restore it later.
+      var temp = document.addEventListener;
+
+      // Test setup.
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+
+      document.addEventListener = false;
+      document.attachEvent = this.sinon.stub();
+
+      // Invoke and assert.
+      Raven.install();
+      assert.isTrue(document.attachEvent.called);
+
+      // Cleanup.
+      document.addEventListener = temp;
+    });
+
+    it('should instrument try/catch by default', function() {
+      this.sinon.stub(Raven, '_instrumentTryCatch');
+      Raven.config(SENTRY_DSN).install();
+      assert.isTrue(Raven._instrumentTryCatch.calledOnce);
+    });
+
+    it('should not instrument try/catch if instrument is false', function() {
+      this.sinon.stub(Raven, '_instrumentTryCatch');
+      Raven.config(SENTRY_DSN, {
+        instrument: false
+      }).install();
+      assert.isFalse(Raven._instrumentTryCatch.called);
+    });
+
+    it('should not instrument try/catch if instrument.tryCatch is false', function() {
+      this.sinon.stub(Raven, '_instrumentTryCatch');
+      Raven.config(SENTRY_DSN, {
+        instrument: {
+          tryCatch: false
+        }
+      }).install();
+      assert.isFalse(Raven._instrumentTryCatch.called);
+    });
+
+    it('should instrument breadcrumbs by default', function() {
+      this.sinon.stub(Raven, '_instrumentBreadcrumbs');
+      Raven.config(SENTRY_DSN).install();
+      assert.isTrue(Raven._instrumentBreadcrumbs.calledOnce);
+    });
+
+    it('should instrument breadcrumbs if autoBreadcrumbs is an object', function() {
+      this.sinon.stub(Raven, '_instrumentBreadcrumbs');
+      Raven.config(SENTRY_DSN, {
+        dom: true,
+        location: false
+      }).install();
+
+      assert.isTrue(Raven._instrumentBreadcrumbs.calledOnce);
+    });
+
+    it('should not instrument breadcrumbs if autoBreadcrumbs is false', function() {
+      this.sinon.stub(Raven, '_instrumentBreadcrumbs');
+      Raven.config(SENTRY_DSN, {
+        autoBreadcrumbs: false
+      }).install();
+      assert.isFalse(Raven._instrumentBreadcrumbs.called);
+    });
+  });
+
+  describe('.uninstall', function() {
+    it('should uninstall from TraceKit', function() {
+      this.sinon.stub(TraceKit.report, 'uninstall');
+      Raven.uninstall();
+      assert.isTrue(TraceKit.report.uninstall.calledOnce);
+    });
+
+    it('should set isRavenInstalled flag to false', function() {
+      Raven._isRavenInstalled = true;
+      this.sinon.stub(TraceKit.report, 'uninstall');
+      Raven.uninstall();
+      assert.isFalse(Raven._isRavenInstalled);
+    });
+  });
 });

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -21,332 +21,351 @@ var htmlTreeAsString = utils.htmlTreeAsString;
 var htmlElementAsString = utils.htmlElementAsString;
 var parseUrl = utils.parseUrl;
 
-describe('utils', function () {
-    describe('isUndefined', function() {
-        it('should do as advertised', function() {
-            assert.isTrue(isUndefined());
-            assert.isFalse(isUndefined({}));
-            assert.isFalse(isUndefined(''));
-            assert.isTrue(isUndefined(undefined));
-        });
+describe('utils', function() {
+  describe('isUndefined', function() {
+    it('should do as advertised', function() {
+      assert.isTrue(isUndefined());
+      assert.isFalse(isUndefined({}));
+      assert.isFalse(isUndefined(''));
+      assert.isTrue(isUndefined(undefined));
+    });
+  });
+
+  describe('isFunction', function() {
+    it('should do as advertised', function() {
+      assert.isTrue(isFunction(function() {}));
+      assert.isFalse(isFunction({}));
+      assert.isFalse(isFunction(''));
+      assert.isFalse(isFunction(undefined));
+    });
+  });
+
+  describe('isString', function() {
+    it('should do as advertised', function() {
+      assert.isTrue(isString(''));
+      assert.isTrue(isString(String('')));
+      assert.isTrue(isString(new String('')));
+      assert.isFalse(isString({}));
+      assert.isFalse(isString(undefined));
+      assert.isFalse(isString(function() {}));
+    });
+  });
+
+  describe('isObject', function() {
+    it('should do as advertised', function() {
+      assert.isTrue(isObject({}));
+      assert.isTrue(isObject(new Error()));
+      assert.isFalse(isObject(''));
+    });
+  });
+
+  describe('isEmptyObject', function() {
+    it('should work as advertised', function() {
+      assert.isTrue(isEmptyObject({}));
+      assert.isFalse(isEmptyObject({foo: 1}));
+    });
+  });
+
+  describe('isError', function() {
+    function testErrorFromDifferentContext(createError) {
+      var iframe = document.createElement('iframe');
+      document.body.appendChild(iframe);
+      try {
+        return createError(iframe.contentWindow);
+      } finally {
+        iframe.parentElement.removeChild(iframe);
+      }
+    }
+
+    function fromContext(win) {
+      return new win.Error();
+    }
+
+    function domException(win) {
+      try {
+        win.document.querySelectorAll('');
+      } catch (e) {
+        return e;
+      }
+    }
+
+    it('should work as advertised', function() {
+      assert.isTrue(isError(new Error()));
+      assert.isTrue(isError(new ReferenceError()));
+      assert.isTrue(isError(new RavenConfigError()));
+      assert.isTrue(isError(testErrorFromDifferentContext(fromContext)));
+      assert.isTrue(isError(testErrorFromDifferentContext(domException)));
+      assert.isFalse(isError({}));
+      assert.isFalse(
+        isError({
+          message: 'A fake error',
+          stack: 'no stack here'
+        })
+      );
+      assert.isFalse(isError(''));
+      assert.isFalse(isError(true));
+    });
+  });
+
+  describe('objectMerge', function() {
+    it('should work as advertised', function() {
+      assert.deepEqual(objectMerge({}, {}), {});
+      assert.deepEqual(objectMerge({a: 1}, {b: 2}), {a: 1, b: 2});
+      assert.deepEqual(objectMerge({a: 1}), {a: 1});
+    });
+  });
+
+  describe('truncate', function() {
+    it('should work as advertised', function() {
+      assert.equal(truncate('lolol', 3), 'lol\u2026');
+      assert.equal(truncate('lolol', 10), 'lolol');
+      assert.equal(truncate('lol', 3), 'lol');
+      assert.equal(truncate(new Array(1000).join('f'), 0), new Array(1000).join('f'));
+    });
+  });
+
+  describe('joinRegExp', function() {
+    it('should work as advertised', function() {
+      assert.equal(
+        joinRegExp(['a', 'b', 'a.b', /d/, /[0-9]/]).source,
+        'a|b|a\\.b|d|[0-9]'
+      );
     });
 
-    describe('isFunction', function() {
-        it('should do as advertised', function() {
-            assert.isTrue(isFunction(function(){}));
-            assert.isFalse(isFunction({}));
-            assert.isFalse(isFunction(''));
-            assert.isFalse(isFunction(undefined));
-        });
+    it('should not process empty or undefined variables', function() {
+      assert.equal(joinRegExp(['a', 'b', null, undefined]).source, 'a|b');
     });
 
-    describe('isString', function() {
-        it('should do as advertised', function() {
-            assert.isTrue(isString(''));
-            assert.isTrue(isString(String('')));
-            assert.isTrue(isString(new String('')));
-            assert.isFalse(isString({}));
-            assert.isFalse(isString(undefined));
-            assert.isFalse(isString(function(){}));
-        });
+    it('should skip entries that are not strings or regular expressions in the passed array of patterns', function() {
+      assert.equal(
+        joinRegExp(['a', 'b', null, 'a.b', undefined, true, /d/, 123, {}, /[0-9]/, []])
+          .source,
+        'a|b|a\\.b|d|[0-9]'
+      );
     });
+  });
 
-    describe('isObject', function() {
-        it('should do as advertised', function() {
-            assert.isTrue(isObject({}));
-            assert.isTrue(isObject(new Error()))
-            assert.isFalse(isObject(''));
-        });
+  describe('urlencode', function() {
+    it('should work', function() {
+      assert.equal(urlencode({}), '');
+      assert.equal(urlencode({foo: 'bar', baz: '1 2'}), 'foo=bar&baz=1%202');
     });
+  });
 
-    describe('isEmptyObject', function() {
-        it('should work as advertised', function() {
-            assert.isTrue(isEmptyObject({}));
-            assert.isFalse(isEmptyObject({foo: 1}));
-        });
-    });
-
-    describe('isError', function() {
-      function testErrorFromDifferentContext(createError) {
-          var iframe = document.createElement('iframe');
-          document.body.appendChild(iframe);
-          try {
-              return createError(iframe.contentWindow);
-          } finally {
-              iframe.parentElement.removeChild(iframe);
+  describe('htmlTreeAsString', function() {
+    it('should work', function() {
+      var tree = {
+        tagName: 'INPUT',
+        id: 'the-username',
+        className: 'form-control',
+        getAttribute: function(key) {
+          return {
+            name: 'username'
+          }[key];
+        },
+        parentNode: {
+          tagName: 'span',
+          getAttribute: function() {},
+          parentNode: {
+            tagName: 'div',
+            getAttribute: function() {}
           }
-      }
+        }
+      };
 
-      function fromContext(win) {
-          return new win.Error();
-      }
+      assert.equal(
+        htmlTreeAsString(tree),
+        'div > span > input#the-username.form-control[name="username"]'
+      );
+    });
 
-      function domException(win) {
-          try {
-              win.document.querySelectorAll('');
-          } catch(e) {
-              return e;
+    it('should not create strings that are too big', function() {
+      var tree = {
+        tagName: 'INPUT',
+        id: 'the-username',
+        className: 'form-control',
+        getAttribute: function(key) {
+          return {
+            name: 'username'
+          }[key];
+        },
+        parentNode: {
+          tagName: 'span',
+          getAttribute: function() {},
+          parentNode: {
+            tagName: 'div',
+            getAttribute: function(key) {
+              return {
+                name:
+                  'super long input name that nobody would really ever have i mean come on look at this'
+              }[key];
+            }
           }
+        }
+      };
+
+      // NOTE: <div/> omitted because crazy long name
+      assert.equal(
+        htmlTreeAsString(tree),
+        'span > input#the-username.form-control[name="username"]'
+      );
+    });
+  });
+
+  describe('htmlElementAsString', function() {
+    it('should work', function() {
+      assert.equal(
+        htmlElementAsString({
+          tagName: 'INPUT',
+          id: 'the-username',
+          className: 'form-control',
+          getAttribute: function(key) {
+            return {
+              name: 'username',
+              placeholder: 'Enter your username'
+            }[key];
+          }
+        }),
+        'input#the-username.form-control[name="username"]'
+      );
+
+      assert.equal(
+        htmlElementAsString({
+          tagName: 'IMG',
+          id: 'image-3',
+          getAttribute: function(key) {
+            return {
+              title: 'A picture of an apple',
+              'data-something': 'This should be ignored' // skipping data-* attributes in first implementation
+            }[key];
+          }
+        }),
+        'img#image-3[title="A picture of an apple"]'
+      );
+    });
+
+    it('should return an empty string if the input element is falsy', function() {
+      assert.equal(htmlElementAsString(null), '');
+      assert.equal(htmlElementAsString(0), '');
+      assert.equal(htmlElementAsString(undefined), '');
+    });
+
+    it('should return an empty string if the input element has no tagName property', function() {
+      assert.equal(
+        htmlElementAsString({
+          id: 'the-username',
+          className: 'form-control'
+        }),
+        ''
+      );
+    });
+
+    it('should gracefully handle when className is not a string (e.g. SVGAnimatedString', function() {
+      assert.equal(
+        htmlElementAsString({
+          tagName: 'INPUT',
+          id: 'the-username',
+          className: {}, // not a string
+          getAttribute: function(key) {
+            return {
+              name: 'username'
+            }[key];
+          }
+        }),
+        'input#the-username[name="username"]'
+      );
+    });
+  });
+
+  describe('parseUrl', function() {
+    it('should parse fully qualified URLs', function() {
+      assert.deepEqual(parseUrl('http://example.com/foo'), {
+        protocol: 'http',
+        host: 'example.com',
+        path: '/foo',
+        relative: '/foo'
+      });
+      assert.deepEqual(parseUrl('//example.com/foo?query'), {
+        protocol: undefined,
+        host: 'example.com',
+        path: '/foo',
+        relative: '/foo?query'
+      });
+    });
+
+    it('should parse partial URLs, e.g. path only', function() {
+      assert.deepEqual(parseUrl('/foo'), {
+        protocol: undefined,
+        host: undefined,
+        path: '/foo',
+        relative: '/foo'
+      });
+      assert.deepEqual(parseUrl('example.com/foo#derp'), {
+        protocol: undefined,
+        host: undefined,
+        path: 'example.com/foo',
+        relative: 'example.com/foo#derp'
+        // this is correct! pushState({}, '', 'example.com/foo') would take you
+        // from example.com => example.com/example.com/foo (valid url).
+      });
+    });
+  });
+
+  describe('wrappedCallback', function() {
+    it('should return data from callback', function() {
+      var expected = 'yup';
+      var cb = wrappedCallback(function() {
+        return expected;
+      });
+      assert.equal(cb(), expected);
+    });
+
+    it('should return mutated data from callback', function() {
+      var cb = wrappedCallback(function(data) {
+        data.mutated = true;
+      });
+      assert.deepEqual(cb({}), {mutated: true});
+    });
+
+    it('should return data from original', function() {
+      var expected = 'yup';
+      var cb = wrappedCallback(function(data) {
+        return 'nope';
+      });
+
+      function original() {
+        return expected;
+      }
+      assert.equal(cb({}, original), expected);
+    });
+
+    it('should return mutated data from original', function() {
+      var cb = wrappedCallback(function(data) {
+        data.mutatedSomeMore = true;
+      });
+
+      function original(data) {
+        data.mutated = true;
+      }
+      assert.deepEqual(cb({}, original), {
+        mutated: true,
+        mutatedSomeMore: true
+      });
+    });
+
+    it('should call callback and original in the right order', function() {
+      var cb = wrappedCallback(function(data) {
+        return data + 'callback first, ';
+      });
+
+      function original(data) {
+        return data + 'then the original.';
       }
 
-        it('should work as advertised', function() {
-            assert.isTrue(isError(new Error()));
-            assert.isTrue(isError(new ReferenceError()));
-            assert.isTrue(isError(new RavenConfigError()));
-            assert.isTrue(isError(testErrorFromDifferentContext(fromContext)));
-            assert.isTrue(isError(testErrorFromDifferentContext(domException)));
-            assert.isFalse(isError({}));
-            assert.isFalse(isError({
-              message: 'A fake error',
-              stack: 'no stack here'
-            }));
-            assert.isFalse(isError(''));
-            assert.isFalse(isError(true));
-        });
+      assert.equal(
+        cb('it will run the ', original),
+        'it will run the callback first, then the original.'
+      );
     });
-
-    describe('objectMerge', function() {
-        it('should work as advertised', function() {
-            assert.deepEqual(objectMerge({}, {}), {});
-            assert.deepEqual(objectMerge({a:1}, {b:2}), {a:1, b:2});
-            assert.deepEqual(objectMerge({a:1}), {a:1});
-        });
-    });
-
-    describe('truncate', function() {
-        it('should work as advertised', function() {
-            assert.equal(truncate('lolol', 3), 'lol\u2026');
-            assert.equal(truncate('lolol', 10), 'lolol');
-            assert.equal(truncate('lol', 3), 'lol');
-            assert.equal(truncate(new Array(1000).join('f'), 0), new Array(1000).join('f'));
-        });
-    });
-
-
-    describe('joinRegExp', function() {
-        it('should work as advertised', function() {
-            assert.equal(joinRegExp([
-                'a', 'b', 'a.b', /d/, /[0-9]/
-            ]).source, 'a|b|a\\.b|d|[0-9]');
-        });
-
-        it('should not process empty or undefined variables', function() {
-            assert.equal(joinRegExp([
-                'a', 'b', null, undefined
-            ]).source, 'a|b');
-        });
-
-        it('should skip entries that are not strings or regular expressions in the passed array of patterns', function() {
-            assert.equal(joinRegExp([
-                'a', 'b', null, 'a.b', undefined, true, /d/, 123, {}, /[0-9]/, []
-            ]).source, 'a|b|a\\.b|d|[0-9]');
-        });
-    });
-
-
-    describe('urlencode', function() {
-        it('should work', function() {
-            assert.equal(urlencode({}), '');
-            assert.equal(urlencode({'foo': 'bar', 'baz': '1 2'}), 'foo=bar&baz=1%202');
-        });
-    });
-
-    describe('htmlTreeAsString', function () {
-        it('should work', function () {
-            var tree = {
-                tagName: 'INPUT',
-                id: 'the-username',
-                className: 'form-control',
-                getAttribute: function (key){
-                    return {
-                        name: 'username'
-                    }[key];
-                },
-                parentNode: {
-                    tagName: 'span',
-                    getAttribute: function () {},
-                    parentNode: {
-                        tagName: 'div',
-                        getAttribute: function () {},
-                    }
-                }
-            };
-
-            assert.equal(htmlTreeAsString(tree), 'div > span > input#the-username.form-control[name="username"]');
-        });
-
-
-        it('should not create strings that are too big', function () {
-            var tree = {
-                tagName: 'INPUT',
-                id: 'the-username',
-                className: 'form-control',
-                getAttribute: function (key){
-                    return {
-                        name: 'username'
-                    }[key];
-                },
-                parentNode: {
-                    tagName: 'span',
-                    getAttribute: function () {},
-                    parentNode: {
-                        tagName: 'div',
-                        getAttribute: function (key) {
-                            return {
-                                name: 'super long input name that nobody would really ever have i mean come on look at this'
-                            }[key];
-                        }
-                    }
-                }
-            };
-
-            // NOTE: <div/> omitted because crazy long name
-            assert.equal(htmlTreeAsString(tree), 'span > input#the-username.form-control[name="username"]');
-        });
-    });
-
-    describe('htmlElementAsString', function () {
-        it('should work', function () {
-            assert.equal(htmlElementAsString({
-                tagName: 'INPUT',
-                id: 'the-username',
-                className: 'form-control',
-                getAttribute: function (key){
-                    return {
-                        name: 'username',
-                        placeholder: 'Enter your username'
-                    }[key];
-                }
-            }), 'input#the-username.form-control[name="username"]');
-
-            assert.equal(htmlElementAsString({
-                tagName: 'IMG',
-                id: 'image-3',
-                getAttribute: function (key){
-                    return {
-                        title: 'A picture of an apple',
-                        'data-something': 'This should be ignored' // skipping data-* attributes in first implementation
-                    }[key];
-                }
-            }), 'img#image-3[title="A picture of an apple"]');
-        });
-
-        it('should return an empty string if the input element is falsy', function () {
-            assert.equal(htmlElementAsString(null), '');
-            assert.equal(htmlElementAsString(0), '');
-            assert.equal(htmlElementAsString(undefined), '');
-        });
-
-        it('should return an empty string if the input element has no tagName property', function () {
-            assert.equal(htmlElementAsString({
-                id: 'the-username',
-                className: 'form-control'
-            }), '');
-        });
-
-        it('should gracefully handle when className is not a string (e.g. SVGAnimatedString', function () {
-            assert.equal(htmlElementAsString({
-                tagName: 'INPUT',
-                id: 'the-username',
-                className: {}, // not a string
-                getAttribute: function (key){
-                    return {
-                        name: 'username'
-                    }[key];
-                }
-            }), 'input#the-username[name="username"]');
-        });
-    });
-
-    describe('parseUrl', function () {
-        it('should parse fully qualified URLs', function () {
-            assert.deepEqual(parseUrl('http://example.com/foo'), {
-                protocol: 'http',
-                host: 'example.com',
-                path: '/foo',
-                relative: '/foo'
-            });
-            assert.deepEqual(parseUrl('//example.com/foo?query'), {
-                protocol: undefined,
-                host: 'example.com',
-                path: '/foo',
-                relative: '/foo?query'
-            });
-        });
-
-        it('should parse partial URLs, e.g. path only', function () {
-            assert.deepEqual(parseUrl('/foo'), {
-                protocol: undefined,
-                host: undefined,
-                path: '/foo',
-                relative: '/foo'
-            });
-            assert.deepEqual(parseUrl('example.com/foo#derp'), {
-                protocol: undefined,
-                host: undefined,
-                path: 'example.com/foo',
-                relative: 'example.com/foo#derp'
-                // this is correct! pushState({}, '', 'example.com/foo') would take you
-                // from example.com => example.com/example.com/foo (valid url).
-            });
-        });
-    });
-
-    describe('wrappedCallback', function () {
-        it('should return data from callback', function () {
-            var expected = 'yup';
-            var cb = wrappedCallback(function() {
-              return expected;
-            });
-            assert.equal(cb(), expected);
-        });
-
-        it('should return mutated data from callback', function () {
-            var cb = wrappedCallback(function(data) {
-                data.mutated = true;
-            });
-            assert.deepEqual(cb({}), {mutated: true});
-        });
-
-        it('should return data from original', function () {
-            var expected = 'yup';
-            var cb = wrappedCallback(function(data) {
-                return 'nope';
-            });
-
-            function original() {
-                return expected;
-            }
-            assert.equal(cb({}, original), expected);
-        });
-
-        it('should return mutated data from original', function () {
-            var cb = wrappedCallback(function(data) {
-                data.mutatedSomeMore = true;
-            });
-
-            function original(data) {
-                data.mutated = true;
-            }
-            assert.deepEqual(cb({}, original), {
-                mutated: true,
-                mutatedSomeMore: true
-            });
-        });
-
-        it('should call callback and original in the right order', function () {
-            var cb = wrappedCallback(function(data) {
-                return data + 'callback first, ';
-            });
-
-            function original(data) {
-                return data + 'then the original.';
-            }
-
-            assert.equal(
-                cb('it will run the ', original),
-                'it will run the callback first, then the original.'
-            );
-        });
-    });
+  });
 });

--- a/test/vendor/json-stringify-safe.test.js
+++ b/test/vendor/json-stringify-safe.test.js
@@ -1,248 +1,289 @@
 /*global Mocha, assert*/
-var Sinon = require("sinon")
+var Sinon = require('sinon');
 var stringify = require('../../vendor/json-stringify-safe/stringify');
 
-function jsonify(obj) { return JSON.stringify(obj, null, 2) }
+function jsonify(obj) {
+  return JSON.stringify(obj, null, 2);
+}
 
-describe("Stringify", function() {
-  it("must stringify circular objects", function() {
-    var obj = {name: "Alice"}
-    obj.self = obj
-    var json = stringify(obj, null, 2)
-    assert.deepEqual(json, jsonify({name: "Alice", self: "[Circular ~]"}))
-  })
+describe('Stringify', function() {
+  it('must stringify circular objects', function() {
+    var obj = {name: 'Alice'};
+    obj.self = obj;
+    var json = stringify(obj, null, 2);
+    assert.deepEqual(json, jsonify({name: 'Alice', self: '[Circular ~]'}));
+  });
 
-  it("must stringify circular objects with intermediaries", function() {
-    var obj = {name: "Alice"}
-    obj.identity = {self: obj}
-    var json = stringify(obj, null, 2)
-    assert.deepEqual(json, jsonify({name: "Alice", identity: {self: "[Circular ~]"}}))
-  })
+  it('must stringify circular objects with intermediaries', function() {
+    var obj = {name: 'Alice'};
+    obj.identity = {self: obj};
+    var json = stringify(obj, null, 2);
+    assert.deepEqual(json, jsonify({name: 'Alice', identity: {self: '[Circular ~]'}}));
+  });
 
-  it("must stringify circular objects deeper", function() {
-    var obj = {name: "Alice", child: {name: "Bob"}}
-    obj.child.self = obj.child
+  it('must stringify circular objects deeper', function() {
+    var obj = {name: 'Alice', child: {name: 'Bob'}};
+    obj.child.self = obj.child;
 
-    assert.deepEqual(stringify(obj, null, 2), jsonify({
-      name: "Alice",
-      child: {name: "Bob", self: "[Circular ~.child]"}
-    }))
-  })
+    assert.deepEqual(
+      stringify(obj, null, 2),
+      jsonify({
+        name: 'Alice',
+        child: {name: 'Bob', self: '[Circular ~.child]'}
+      })
+    );
+  });
 
-  it("must stringify circular objects deeper with intermediaries", function() {
-    var obj = {name: "Alice", child: {name: "Bob"}}
-    obj.child.identity = {self: obj.child}
+  it('must stringify circular objects deeper with intermediaries', function() {
+    var obj = {name: 'Alice', child: {name: 'Bob'}};
+    obj.child.identity = {self: obj.child};
 
-    assert.deepEqual(stringify(obj, null, 2), jsonify({
-      name: "Alice",
-      child: {name: "Bob", identity: {self: "[Circular ~.child]"}}
-    }))
-  })
+    assert.deepEqual(
+      stringify(obj, null, 2),
+      jsonify({
+        name: 'Alice',
+        child: {name: 'Bob', identity: {self: '[Circular ~.child]'}}
+      })
+    );
+  });
 
-  it("must stringify circular objects in an array", function() {
-    var obj = {name: "Alice"}
-    obj.self = [obj, obj]
+  it('must stringify circular objects in an array', function() {
+    var obj = {name: 'Alice'};
+    obj.self = [obj, obj];
 
-    assert.deepEqual(stringify(obj, null, 2), jsonify({
-      name: "Alice", self: ["[Circular ~]", "[Circular ~]"]
-    }))
-  })
+    assert.deepEqual(
+      stringify(obj, null, 2),
+      jsonify({
+        name: 'Alice',
+        self: ['[Circular ~]', '[Circular ~]']
+      })
+    );
+  });
 
-  it("must stringify circular objects deeper in an array", function() {
-    var obj = {name: "Alice", children: [{name: "Bob"}, {name: "Eve"}]}
-    obj.children[0].self = obj.children[0]
-    obj.children[1].self = obj.children[1]
+  it('must stringify circular objects deeper in an array', function() {
+    var obj = {name: 'Alice', children: [{name: 'Bob'}, {name: 'Eve'}]};
+    obj.children[0].self = obj.children[0];
+    obj.children[1].self = obj.children[1];
 
-    assert.deepEqual(stringify(obj, null, 2), jsonify({
-      name: "Alice",
-      children: [
-        {name: "Bob", self: "[Circular ~.children.0]"},
-        {name: "Eve", self: "[Circular ~.children.1]"}
-      ]
-    }))
-  })
+    assert.deepEqual(
+      stringify(obj, null, 2),
+      jsonify({
+        name: 'Alice',
+        children: [
+          {name: 'Bob', self: '[Circular ~.children.0]'},
+          {name: 'Eve', self: '[Circular ~.children.1]'}
+        ]
+      })
+    );
+  });
 
-  it("must stringify circular arrays", function() {
-    var obj = []
-    obj.push(obj)
-    obj.push(obj)
-    var json = stringify(obj, null, 2)
-    assert.deepEqual(json, jsonify(["[Circular ~]", "[Circular ~]"]))
-  })
+  it('must stringify circular arrays', function() {
+    var obj = [];
+    obj.push(obj);
+    obj.push(obj);
+    var json = stringify(obj, null, 2);
+    assert.deepEqual(json, jsonify(['[Circular ~]', '[Circular ~]']));
+  });
 
-  it("must stringify circular arrays with intermediaries", function() {
-    var obj = []
-    obj.push({name: "Alice", self: obj})
-    obj.push({name: "Bob", self: obj})
+  it('must stringify circular arrays with intermediaries', function() {
+    var obj = [];
+    obj.push({name: 'Alice', self: obj});
+    obj.push({name: 'Bob', self: obj});
 
-    assert.deepEqual(stringify(obj, null, 2), jsonify([
-      {name: "Alice", self: "[Circular ~]"},
-      {name: "Bob", self: "[Circular ~]"}
-    ]))
-  })
+    assert.deepEqual(
+      stringify(obj, null, 2),
+      jsonify([
+        {name: 'Alice', self: '[Circular ~]'},
+        {name: 'Bob', self: '[Circular ~]'}
+      ])
+    );
+  });
 
-  it("must stringify repeated objects in objects", function() {
-    var obj = {}
-    var alice = {name: "Alice"}
-    obj.alice1 = alice
-    obj.alice2 = alice
+  it('must stringify repeated objects in objects', function() {
+    var obj = {};
+    var alice = {name: 'Alice'};
+    obj.alice1 = alice;
+    obj.alice2 = alice;
 
-    assert.deepEqual(stringify(obj, null, 2), jsonify({
-      alice1: {name: "Alice"},
-      alice2: {name: "Alice"}
-    }))
-  })
+    assert.deepEqual(
+      stringify(obj, null, 2),
+      jsonify({
+        alice1: {name: 'Alice'},
+        alice2: {name: 'Alice'}
+      })
+    );
+  });
 
-  it("must stringify repeated objects in arrays", function() {
-    var alice = {name: "Alice"}
-    var obj = [alice, alice]
-    var json = stringify(obj, null, 2)
-    assert.deepEqual(json, jsonify([{name: "Alice"}, {name: "Alice"}]))
-  })
+  it('must stringify repeated objects in arrays', function() {
+    var alice = {name: 'Alice'};
+    var obj = [alice, alice];
+    var json = stringify(obj, null, 2);
+    assert.deepEqual(json, jsonify([{name: 'Alice'}, {name: 'Alice'}]));
+  });
 
-  it("must call given decycler and use its output", function() {
-    var obj = {}
-    obj.a = obj
-    obj.b = obj
+  it('must call given decycler and use its output', function() {
+    var obj = {};
+    obj.a = obj;
+    obj.b = obj;
 
-    var decycle = Sinon.spy(function() { return decycle.callCount })
-    var json = stringify(obj, null, 2, decycle)
-    assert.deepEqual(json, jsonify({a: 1, b: 2}, null, 2))
+    var decycle = Sinon.spy(function() {
+      return decycle.callCount;
+    });
+    var json = stringify(obj, null, 2, decycle);
+    assert.deepEqual(json, jsonify({a: 1, b: 2}, null, 2));
 
-    assert.strictEqual(decycle.callCount, 2)
-    assert.strictEqual(decycle.thisValues[0], obj)
-    assert.strictEqual(decycle.args[0][0], "a")
-    assert.strictEqual(decycle.args[0][1], obj)
-    assert.strictEqual(decycle.thisValues[1], obj)
-    assert.strictEqual(decycle.args[1][0], "b")
-    assert.strictEqual(decycle.args[1][1], obj)
-  })
+    assert.strictEqual(decycle.callCount, 2);
+    assert.strictEqual(decycle.thisValues[0], obj);
+    assert.strictEqual(decycle.args[0][0], 'a');
+    assert.strictEqual(decycle.args[0][1], obj);
+    assert.strictEqual(decycle.thisValues[1], obj);
+    assert.strictEqual(decycle.args[1][0], 'b');
+    assert.strictEqual(decycle.args[1][1], obj);
+  });
 
-  it("must call replacer and use its output", function() {
-    var obj = {name: "Alice", child: {name: "Bob"}}
+  it('must call replacer and use its output', function() {
+    var obj = {name: 'Alice', child: {name: 'Bob'}};
 
-    var replacer = Sinon.spy(bangString)
-    var json = stringify(obj, replacer, 2)
-    assert.deepEqual(json, jsonify({name: "Alice!", child: {name: "Bob!"}}))
+    var replacer = Sinon.spy(bangString);
+    var json = stringify(obj, replacer, 2);
+    assert.deepEqual(json, jsonify({name: 'Alice!', child: {name: 'Bob!'}}));
 
-    assert.strictEqual(replacer.callCount, 4)
-    assert.strictEqual(replacer.args[0][0], "")
-    assert.strictEqual(replacer.args[0][1], obj)
-    assert.strictEqual(replacer.thisValues[1], obj)
-    assert.strictEqual(replacer.args[1][0], "name")
-    assert.strictEqual(replacer.args[1][1], "Alice")
-    assert.strictEqual(replacer.thisValues[2], obj)
-    assert.strictEqual(replacer.args[2][0], "child")
-    assert.strictEqual(replacer.args[2][1], obj.child)
-    assert.strictEqual(replacer.thisValues[3], obj.child)
-    assert.strictEqual(replacer.args[3][0], "name")
-    assert.strictEqual(replacer.args[3][1], "Bob")
-  })
+    assert.strictEqual(replacer.callCount, 4);
+    assert.strictEqual(replacer.args[0][0], '');
+    assert.strictEqual(replacer.args[0][1], obj);
+    assert.strictEqual(replacer.thisValues[1], obj);
+    assert.strictEqual(replacer.args[1][0], 'name');
+    assert.strictEqual(replacer.args[1][1], 'Alice');
+    assert.strictEqual(replacer.thisValues[2], obj);
+    assert.strictEqual(replacer.args[2][0], 'child');
+    assert.strictEqual(replacer.args[2][1], obj.child);
+    assert.strictEqual(replacer.thisValues[3], obj.child);
+    assert.strictEqual(replacer.args[3][0], 'name');
+    assert.strictEqual(replacer.args[3][1], 'Bob');
+  });
 
-  it("must call replacer after describing circular references", function() {
-    var obj = {name: "Alice"}
-    obj.self = obj
+  it('must call replacer after describing circular references', function() {
+    var obj = {name: 'Alice'};
+    obj.self = obj;
 
-    var replacer = Sinon.spy(bangString)
-    var json = stringify(obj, replacer, 2)
-    assert.deepEqual(json, jsonify({name: "Alice!", self: "[Circular ~]!"}))
+    var replacer = Sinon.spy(bangString);
+    var json = stringify(obj, replacer, 2);
+    assert.deepEqual(json, jsonify({name: 'Alice!', self: '[Circular ~]!'}));
 
-    assert.strictEqual(replacer.callCount, 3)
-    assert.strictEqual(replacer.args[0][0], "")
-    assert.strictEqual(replacer.args[0][1], obj)
-    assert.strictEqual(replacer.thisValues[1], obj)
-    assert.strictEqual(replacer.args[1][0], "name")
-    assert.strictEqual(replacer.args[1][1], "Alice")
-    assert.strictEqual(replacer.thisValues[2], obj)
-    assert.strictEqual(replacer.args[2][0], "self")
-    assert.strictEqual(replacer.args[2][1], "[Circular ~]")
-  })
+    assert.strictEqual(replacer.callCount, 3);
+    assert.strictEqual(replacer.args[0][0], '');
+    assert.strictEqual(replacer.args[0][1], obj);
+    assert.strictEqual(replacer.thisValues[1], obj);
+    assert.strictEqual(replacer.args[1][0], 'name');
+    assert.strictEqual(replacer.args[1][1], 'Alice');
+    assert.strictEqual(replacer.thisValues[2], obj);
+    assert.strictEqual(replacer.args[2][0], 'self');
+    assert.strictEqual(replacer.args[2][1], '[Circular ~]');
+  });
 
-  it("must call given decycler and use its output for nested objects",
-    function() {
-    var obj = {}
-    obj.a = obj
-    obj.b = {self: obj}
+  it('must call given decycler and use its output for nested objects', function() {
+    var obj = {};
+    obj.a = obj;
+    obj.b = {self: obj};
 
-    var decycle = Sinon.spy(function() { return decycle.callCount })
-    var json = stringify(obj, null, 2, decycle)
-    assert.deepEqual(json, jsonify({a: 1, b: {self: 2}}))
+    var decycle = Sinon.spy(function() {
+      return decycle.callCount;
+    });
+    var json = stringify(obj, null, 2, decycle);
+    assert.deepEqual(json, jsonify({a: 1, b: {self: 2}}));
 
-    assert.strictEqual(decycle.callCount, 2)
-    assert.strictEqual(decycle.args[0][0], "a")
-    assert.strictEqual(decycle.args[0][1], obj)
-    assert.strictEqual(decycle.args[1][0], "self")
-    assert.strictEqual(decycle.args[1][1], obj)
-  })
+    assert.strictEqual(decycle.callCount, 2);
+    assert.strictEqual(decycle.args[0][0], 'a');
+    assert.strictEqual(decycle.args[0][1], obj);
+    assert.strictEqual(decycle.args[1][0], 'self');
+    assert.strictEqual(decycle.args[1][1], obj);
+  });
 
   it("must use decycler's output when it returned null", function() {
-    var obj = {a: "b"}
-    obj.self = obj
-    obj.selves = [obj, obj]
+    var obj = {a: 'b'};
+    obj.self = obj;
+    obj.selves = [obj, obj];
 
-    function decycle() { return null }
-    assert.deepEqual(stringify(obj, null, 2, decycle), jsonify({
-      a: "b",
-      self: null,
-      selves: [null, null]
-    }))
-  })
+    function decycle() {
+      return null;
+    }
+    assert.deepEqual(
+      stringify(obj, null, 2, decycle),
+      jsonify({
+        a: 'b',
+        self: null,
+        selves: [null, null]
+      })
+    );
+  });
 
   it("must use decycler's output when it returned undefined", function() {
-    var obj = {a: "b"}
-    obj.self = obj
-    obj.selves = [obj, obj]
+    var obj = {a: 'b'};
+    obj.self = obj;
+    obj.selves = [obj, obj];
 
     function decycle() {}
-    assert.deepEqual(stringify(obj, null, 2, decycle), jsonify({
-      a: "b",
-      selves: [null, null]
-    }))
-  })
+    assert.deepEqual(
+      stringify(obj, null, 2, decycle),
+      jsonify({
+        a: 'b',
+        selves: [null, null]
+      })
+    );
+  });
 
-  it("must throw given a decycler that returns a cycle", function() {
-    var obj = {}
-    obj.self = obj
-    var err
-    function identity(key, value) { return value }
-    try { stringify(obj, null, 2, identity) } catch (ex) { err = ex }
-    assert.ok(err instanceof TypeError)
-  })
+  it('must throw given a decycler that returns a cycle', function() {
+    var obj = {};
+    obj.self = obj;
+    var err;
+    function identity(key, value) {
+      return value;
+    }
+    try {
+      stringify(obj, null, 2, identity);
+    } catch (ex) {
+      err = ex;
+    }
+    assert.ok(err instanceof TypeError);
+  });
 
-  describe(".getSerialize", function() {
-    it("must stringify circular objects", function() {
-      var obj = {a: "b"}
-      obj.circularRef = obj
-      obj.list = [obj, obj]
+  describe('.getSerialize', function() {
+    it('must stringify circular objects', function() {
+      var obj = {a: 'b'};
+      obj.circularRef = obj;
+      obj.list = [obj, obj];
 
-      var json = JSON.stringify(obj, stringify.getSerialize(), 2)
-      assert.deepEqual(json, jsonify({
-        "a": "b",
-        "circularRef": "[Circular ~]",
-        "list": ["[Circular ~]", "[Circular ~]"]
-      }))
-    })
+      var json = JSON.stringify(obj, stringify.getSerialize(), 2);
+      assert.deepEqual(
+        json,
+        jsonify({
+          a: 'b',
+          circularRef: '[Circular ~]',
+          list: ['[Circular ~]', '[Circular ~]']
+        })
+      );
+    });
 
     // This is the behavior as of Mar 3, 2015.
     // The serializer function keeps state inside the returned function and
     // so far I'm not sure how to not do that. JSON.stringify's replacer is not
     // called _after_ serialization.
-    xit("must return a function that could be called twice", function() {
-      var obj = {name: "Alice"}
-      obj.self = obj
+    xit('must return a function that could be called twice', function() {
+      var obj = {name: 'Alice'};
+      obj.self = obj;
 
-      var json
-      var serializer = stringify.getSerialize()
+      var json;
+      var serializer = stringify.getSerialize();
 
-      json = JSON.stringify(obj, serializer, 2)
-      assert.deepEqual(json, jsonify({name: "Alice", self: "[Circular ~]"}))
+      json = JSON.stringify(obj, serializer, 2);
+      assert.deepEqual(json, jsonify({name: 'Alice', self: '[Circular ~]'}));
 
-      json = JSON.stringify(obj, serializer, 2)
-      assert.deepEqual(json, jsonify({name: "Alice", self: "[Circular ~]"}))
-    })
-  })
-})
+      json = JSON.stringify(obj, serializer, 2);
+      assert.deepEqual(json, jsonify({name: 'Alice', self: '[Circular ~]'}));
+    });
+  });
+});
 
 function bangString(key, value) {
-  return typeof value == "string" ? value + "!" : value
+  return typeof value == 'string' ? value + '!' : value;
 }

--- a/test/vendor/tracekit-parser.test.js
+++ b/test/vendor/tracekit-parser.test.js
@@ -4,267 +4,841 @@
 var TraceKit = require('../../vendor/TraceKit/tracekit');
 var CapturedExceptions = require('./fixtures/captured-errors');
 
-describe('TraceKit', function () {
-    describe('Parser', function() {
-        it('should parse Safari 6 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_6);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 4);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 48, column: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'dumpException3', args: [], line: 52, column: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'onclick', args: [], line: 82, column: null });
-            assert.deepEqual(stackFrames.stack[3], { url: '[native code]', func: '?', args: [], line: null, column: null });
-        });
-
-        it('should parse Safari 7 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_7);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 48, column: 22 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 107 });
-        });
-
-        it('should parse Safari 8 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_8);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 47, column: 22 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 23 });
-        });
-
-        it('should parse Safari 8 eval error', function () {
-            // TODO: Take into account the line and column properties on the error object and use them for the first stack trace.
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_8_EVAL);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: '[native code]', func: 'eval', args: [], line: null, column: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 58, column: 21 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 109, column: 91 });
-        });
-
-        it('should parse Firefox 3 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_3);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://127.0.0.1:8000/js/stacktrace.js', func: '?', args: [], line: 44, column: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://127.0.0.1:8000/js/stacktrace.js', func: '?', args: ['null'], line: 31, column: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://127.0.0.1:8000/js/stacktrace.js', func: 'printStackTrace', args: [], line: 18, column: null });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://127.0.0.1:8000/js/file.js', func: 'bar', args: ['1'], line: 13, column: null });
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://127.0.0.1:8000/js/file.js', func: 'bar', args: ['2'], line: 16, column: null });
-            assert.deepEqual(stackFrames.stack[5], { url: 'http://127.0.0.1:8000/js/file.js', func: 'foo', args: [], line: 20, column: null });
-            assert.deepEqual(stackFrames.stack[6], { url: 'http://127.0.0.1:8000/js/file.js', func: '?', args: [], line: 24, column: null });
-        });
-
-        it('should parse Firefox 7 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_7);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[0], { url: 'file:///G:/js/stacktrace.js', func: '?', args: [], line: 44, column: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'file:///G:/js/stacktrace.js', func: '?', args: ['null'], line: 31, column: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'file:///G:/js/stacktrace.js', func: 'printStackTrace', args: [], line: 18, column: null });
-            assert.deepEqual(stackFrames.stack[3], { url: 'file:///G:/js/file.js', func: 'bar', args: ['1'], line: 13, column: null });
-            assert.deepEqual(stackFrames.stack[4], { url: 'file:///G:/js/file.js', func: 'bar', args: ['2'], line: 16, column: null });
-            assert.deepEqual(stackFrames.stack[5], { url: 'file:///G:/js/file.js', func: 'foo', args: [], line: 20, column: null });
-            assert.deepEqual(stackFrames.stack[6], { url: 'file:///G:/js/file.js', func: '?', args: [], line: 24, column: null });
-        });
-
-        it('should parse Firefox 14 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_14);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 48, column: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'dumpException3', args: [], line: 52, column: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'onclick', args: [], line: 1, column: null });
-        });
-
-        it('should parse Firefox 31 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_31);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 41, column: 13 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 1, column: 1 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '.plugin/e.fn[c]/<', args: [], line: 1, column: 1 });
-        });
-
-        it('should parse Firefox 44 ns exceptions', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_44_NS_EXCEPTION);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 4);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '[2]</Bar.prototype._baz/</<', args: [], line: 703, column: 28 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'file:///path/to/file.js', func: 'App.prototype.foo', args: [], line: 15, column: 2 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'file:///path/to/file.js', func: 'bar', args: [], line: 20, column: 3 });
-            assert.deepEqual(stackFrames.stack[3], { url: 'file:///path/to/index.html', func: '?', args: [], line: 23, column: 1 });
-        });
-
-        it('should parse Chrome error with no location', function () {
-            var stackFrames = TraceKit.computeStackTrace({stack: "error\n at Array.forEach (native)"});
-            assert.deepEqual(stackFrames.stack.length, 1);
-            assert.deepEqual(stackFrames.stack[0], { url: null, func: 'Array.forEach', args: ['native'], line: null, column: null });
-        });
-
-        it('should parse Chrome 15 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_15);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 4);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 13, column: 17 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 16, column: 5 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 20, column: 5 });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: '?', args: [], line: 24, column: 4 });
-        });
-
-        it('should parse Chrome 36 error with port numbers', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_36);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8080/file.js', func: 'dumpExceptionError', args: [], line: 41, column: 27 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8080/file.js', func: 'HTMLButtonElement.onclick', args: [], line: 107, column: 146 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8080/file.js', func: 'I.e.fn.(anonymous function) [as index]', args: [], line: 10, column: 3651 });
-        });
-
-
-        it('should parse Chrome error with webpack URLs', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_XX_WEBPACK);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 4);
-            assert.deepEqual(stackFrames.stack[0], { url: 'webpack:///./src/components/test/test.jsx?', func: 'TESTTESTTEST.eval', args: [], line: 295, column: 108 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'webpack:///./src/components/test/test.jsx?', func: 'TESTTESTTEST.render', args: [], line: 272, column: 32 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'webpack:///./~/react-transform-catch-errors/lib/index.js?', func: 'TESTTESTTEST.tryRender', args: [], line: 34, column: 31 });
-            assert.deepEqual(stackFrames.stack[3], { url: 'webpack:///./~/react-proxy/modules/createPrototypeProxy.js?', func: 'TESTTESTTEST.proxiedMethod', args: [], line: 44, column: 30 });
-        });
-
-        it('should parse nested eval() from Chrome', function() {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_48_EVAL);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 5);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8080/file.js', func: 'baz', args: [], line: 21, column: 17});
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8080/file.js', func: 'foo', args: [], line: 21, column: 17});
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8080/file.js', func: 'eval', args: [], line: 21, column: 17});
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://localhost:8080/file.js', func: 'Object.speak', args: [], line: 21, column: 17});
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://localhost:8080/file.js', func: '?', args: [], line: 31, column: 13});
-        });
-
-        it('should parse Chrome error with blob URLs', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_48_BLOB);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 7);
-            assert.deepEqual(stackFrames.stack[1], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 's', args: [], line: 31, column: 29146 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 'Object.d [as add]', args: [  ], line: 31, column: 30039 });
-            assert.deepEqual(stackFrames.stack[3], { url: 'blob:http%3A//localhost%3A8080/d4eefe0f-361a-4682-b217-76587d9f712a', func: '?', args: [], line: 15, column: 10978 });
-            assert.deepEqual(stackFrames.stack[4], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: '?', args: [], line: 1, column: 6911 });
-            assert.deepEqual(stackFrames.stack[5], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 'n.fire', args: [], line: 7, column: 3019 });
-            assert.deepEqual(stackFrames.stack[6], { url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379', func: 'n.handle', args: [], line: 7, column: 2863 });
-        });
-
-        it('should parse empty IE 9 error', function() {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.IE_9);
-            assert.ok(stackFrames);
-            stackFrames.stack && assert.deepEqual(stackFrames.stack.length, 0);
-        });
-
-        it('should parse IE 10 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.IE_10);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            // TODO: func should be normalized
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'Anonymous function', args: [], line: 48, column: 13 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 46, column: 9 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 82, column: 1 });
-        });
-
-        it('should parse IE 11 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.IE_11);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            // TODO: func should be normalized
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: 'Anonymous function', args: [], line: 47, column: 21 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 45, column: 13 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 1 });
-        });
-
-
-        it('should parse IE 11 eval error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.IE_11_EVAL);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'eval code', func: 'eval code', args: [], line: 1, column: 1 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 58, column: 17 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 109, column: 1 });
-        });
-
-        it('should parse Opera 11 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_11);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 5);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '<anonymous function: run>', args: ['[arguments not available]'], line: 27, column: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://domain.com:1234/path/to/file.js', func: 'bar', args: ['[arguments not available]'], line: 18, column: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://domain.com:1234/path/to/file.js', func: 'foo', args: ['[arguments not available]'], line: 11, column: null });
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://path/to/file.js', func: '<anonymous function>', args: [], line: 15, column: null });
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://path/to/file.js', func: 'Error created at <anonymous function>', args: [], line: 15, column: null });
-        });
-
-        it('should parse Opera 12 error', function () {
-            // TODO: Improve anonymous function name.
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_12);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8000/ExceptionLab.html', func: '<anonymous function>', args: ['[arguments not available]'], line: 48, column: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8000/ExceptionLab.html', func: 'dumpException3', args: ['[arguments not available]'], line: 46, column: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8000/ExceptionLab.html', func: '<anonymous function>', args: ['[arguments not available]'], line: 1, column: null });
-        });
-
-        it('should parse Opera 25 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_25);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://path/to/file.js', func: '?', args: [], line: 47, column: 22 });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 52, column: 15 });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: 'bar', args: [], line: 108, column: 168 });
-        });
-
-        it('should parse PhantomJS 1.19 error', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.PHANTOMJS_1_19);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'file:///path/to/file.js', func: '?', args: [], line: 878, column: null });
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://path/to/file.js', func: 'foo', args: [], line: 4283, column: null });
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://path/to/file.js', func: '?', args: [], line: 4287, column: null });
-        });
-
-        it('should parse Firefox errors with resource: URLs', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_50_RESOURCE_URL);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 3);
-            assert.deepEqual(stackFrames.stack[0], { url: 'resource://path/data/content/bundle.js', func: 'render', args: [], line: 5529, column: 16 });
-        });
-
-        it('should parse Firefox errors with eval URLs', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_43_EVAL);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 5);
-            assert.deepEqual(stackFrames.stack[0], { url: 'http://localhost:8080/file.js', func: 'baz', args:[], line: 26, column: null});
-            assert.deepEqual(stackFrames.stack[1], { url: 'http://localhost:8080/file.js', func: 'foo', args:[], line: 26, column: null});
-            assert.deepEqual(stackFrames.stack[2], { url: 'http://localhost:8080/file.js', func: '?', args:[], line: 26, column: null});
-            assert.deepEqual(stackFrames.stack[3], { url: 'http://localhost:8080/file.js', func: 'speak', args:[], line: 26, column: 17});
-            assert.deepEqual(stackFrames.stack[4], { url: 'http://localhost:8080/file.js', func: '?', args:[], line: 33, column: 9});
-        });
-
-        it('should parse React Native errors on Android', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.ANDROID_REACT_NATIVE);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 8);
-            assert.deepEqual(stackFrames.stack[0], { url: '/home/username/sample-workspace/sampleapp.collect.react/src/components/GpsMonitorScene.js', func: 'render', args: [], line: 78, column: 24 });
-            assert.deepEqual(stackFrames.stack[7], { url: '/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js', func: 'this', args: [], line: 74, column: 41 });
-        });
-
-        it('should parse React Native errors on Android Production', function () {
-            var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.ANDROID_REACT_NATIVE_PROD);
-            assert.ok(stackFrames);
-            assert.deepEqual(stackFrames.stack.length, 37);
-            assert.deepEqual(stackFrames.stack[0], { url: 'index.android.bundle', func: 'value', args: [], line: 12, column: 1917 });
-            assert.deepEqual(stackFrames.stack[35], { url: 'index.android.bundle', func: 'value', args: [], line: 29, column: 927 });
-            assert.deepEqual(stackFrames.stack[36], { url: '[native code]', func: '?', args: [], line: null, column: null });
-        });
+describe('TraceKit', function() {
+  describe('Parser', function() {
+    it('should parse Safari 6 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_6);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 4);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: '?',
+        args: [],
+        line: 48,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'dumpException3',
+        args: [],
+        line: 52,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'onclick',
+        args: [],
+        line: 82,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: '[native code]',
+        func: '?',
+        args: [],
+        line: null,
+        column: null
+      });
     });
+
+    it('should parse Safari 7 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_7);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: '?',
+        args: [],
+        line: 48,
+        column: 22
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 52,
+        column: 15
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 108,
+        column: 107
+      });
+    });
+
+    it('should parse Safari 8 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_8);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: '?',
+        args: [],
+        line: 47,
+        column: 22
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 52,
+        column: 15
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 108,
+        column: 23
+      });
+    });
+
+    it('should parse Safari 8 eval error', function() {
+      // TODO: Take into account the line and column properties on the error object and use them for the first stack trace.
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.SAFARI_8_EVAL);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: '[native code]',
+        func: 'eval',
+        args: [],
+        line: null,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 58,
+        column: 21
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 109,
+        column: 91
+      });
+    });
+
+    it('should parse Firefox 3 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_3);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 7);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://127.0.0.1:8000/js/stacktrace.js',
+        func: '?',
+        args: [],
+        line: 44,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://127.0.0.1:8000/js/stacktrace.js',
+        func: '?',
+        args: ['null'],
+        line: 31,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://127.0.0.1:8000/js/stacktrace.js',
+        func: 'printStackTrace',
+        args: [],
+        line: 18,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: 'http://127.0.0.1:8000/js/file.js',
+        func: 'bar',
+        args: ['1'],
+        line: 13,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[4], {
+        url: 'http://127.0.0.1:8000/js/file.js',
+        func: 'bar',
+        args: ['2'],
+        line: 16,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[5], {
+        url: 'http://127.0.0.1:8000/js/file.js',
+        func: 'foo',
+        args: [],
+        line: 20,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[6], {
+        url: 'http://127.0.0.1:8000/js/file.js',
+        func: '?',
+        args: [],
+        line: 24,
+        column: null
+      });
+    });
+
+    it('should parse Firefox 7 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_7);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 7);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'file:///G:/js/stacktrace.js',
+        func: '?',
+        args: [],
+        line: 44,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'file:///G:/js/stacktrace.js',
+        func: '?',
+        args: ['null'],
+        line: 31,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'file:///G:/js/stacktrace.js',
+        func: 'printStackTrace',
+        args: [],
+        line: 18,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: 'file:///G:/js/file.js',
+        func: 'bar',
+        args: ['1'],
+        line: 13,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[4], {
+        url: 'file:///G:/js/file.js',
+        func: 'bar',
+        args: ['2'],
+        line: 16,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[5], {
+        url: 'file:///G:/js/file.js',
+        func: 'foo',
+        args: [],
+        line: 20,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[6], {
+        url: 'file:///G:/js/file.js',
+        func: '?',
+        args: [],
+        line: 24,
+        column: null
+      });
+    });
+
+    it('should parse Firefox 14 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_14);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: '?',
+        args: [],
+        line: 48,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'dumpException3',
+        args: [],
+        line: 52,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'onclick',
+        args: [],
+        line: 1,
+        column: null
+      });
+    });
+
+    it('should parse Firefox 31 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_31);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 41,
+        column: 13
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 1,
+        column: 1
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: '.plugin/e.fn[c]/<',
+        args: [],
+        line: 1,
+        column: 1
+      });
+    });
+
+    it('should parse Firefox 44 ns exceptions', function() {
+      var stackFrames = TraceKit.computeStackTrace(
+        CapturedExceptions.FIREFOX_44_NS_EXCEPTION
+      );
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 4);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: '[2]</Bar.prototype._baz/</<',
+        args: [],
+        line: 703,
+        column: 28
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'file:///path/to/file.js',
+        func: 'App.prototype.foo',
+        args: [],
+        line: 15,
+        column: 2
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'file:///path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 20,
+        column: 3
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: 'file:///path/to/index.html',
+        func: '?',
+        args: [],
+        line: 23,
+        column: 1
+      });
+    });
+
+    it('should parse Chrome error with no location', function() {
+      var stackFrames = TraceKit.computeStackTrace({
+        stack: 'error\n at Array.forEach (native)'
+      });
+      assert.deepEqual(stackFrames.stack.length, 1);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: null,
+        func: 'Array.forEach',
+        args: ['native'],
+        line: null,
+        column: null
+      });
+    });
+
+    it('should parse Chrome 15 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_15);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 4);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 13,
+        column: 17
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 16,
+        column: 5
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 20,
+        column: 5
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: 'http://path/to/file.js',
+        func: '?',
+        args: [],
+        line: 24,
+        column: 4
+      });
+    });
+
+    it('should parse Chrome 36 error with port numbers', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_36);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://localhost:8080/file.js',
+        func: 'dumpExceptionError',
+        args: [],
+        line: 41,
+        column: 27
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://localhost:8080/file.js',
+        func: 'HTMLButtonElement.onclick',
+        args: [],
+        line: 107,
+        column: 146
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://localhost:8080/file.js',
+        func: 'I.e.fn.(anonymous function) [as index]',
+        args: [],
+        line: 10,
+        column: 3651
+      });
+    });
+
+    it('should parse Chrome error with webpack URLs', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_XX_WEBPACK);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 4);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'webpack:///./src/components/test/test.jsx?',
+        func: 'TESTTESTTEST.eval',
+        args: [],
+        line: 295,
+        column: 108
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'webpack:///./src/components/test/test.jsx?',
+        func: 'TESTTESTTEST.render',
+        args: [],
+        line: 272,
+        column: 32
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'webpack:///./~/react-transform-catch-errors/lib/index.js?',
+        func: 'TESTTESTTEST.tryRender',
+        args: [],
+        line: 34,
+        column: 31
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: 'webpack:///./~/react-proxy/modules/createPrototypeProxy.js?',
+        func: 'TESTTESTTEST.proxiedMethod',
+        args: [],
+        line: 44,
+        column: 30
+      });
+    });
+
+    it('should parse nested eval() from Chrome', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_48_EVAL);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 5);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://localhost:8080/file.js',
+        func: 'baz',
+        args: [],
+        line: 21,
+        column: 17
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://localhost:8080/file.js',
+        func: 'foo',
+        args: [],
+        line: 21,
+        column: 17
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://localhost:8080/file.js',
+        func: 'eval',
+        args: [],
+        line: 21,
+        column: 17
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: 'http://localhost:8080/file.js',
+        func: 'Object.speak',
+        args: [],
+        line: 21,
+        column: 17
+      });
+      assert.deepEqual(stackFrames.stack[4], {
+        url: 'http://localhost:8080/file.js',
+        func: '?',
+        args: [],
+        line: 31,
+        column: 13
+      });
+    });
+
+    it('should parse Chrome error with blob URLs', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.CHROME_48_BLOB);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 7);
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379',
+        func: 's',
+        args: [],
+        line: 31,
+        column: 29146
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379',
+        func: 'Object.d [as add]',
+        args: [],
+        line: 31,
+        column: 30039
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: 'blob:http%3A//localhost%3A8080/d4eefe0f-361a-4682-b217-76587d9f712a',
+        func: '?',
+        args: [],
+        line: 15,
+        column: 10978
+      });
+      assert.deepEqual(stackFrames.stack[4], {
+        url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379',
+        func: '?',
+        args: [],
+        line: 1,
+        column: 6911
+      });
+      assert.deepEqual(stackFrames.stack[5], {
+        url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379',
+        func: 'n.fire',
+        args: [],
+        line: 7,
+        column: 3019
+      });
+      assert.deepEqual(stackFrames.stack[6], {
+        url: 'blob:http%3A//localhost%3A8080/abfc40e9-4742-44ed-9dcd-af8f99a29379',
+        func: 'n.handle',
+        args: [],
+        line: 7,
+        column: 2863
+      });
+    });
+
+    it('should parse empty IE 9 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.IE_9);
+      assert.ok(stackFrames);
+      stackFrames.stack && assert.deepEqual(stackFrames.stack.length, 0);
+    });
+
+    it('should parse IE 10 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.IE_10);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      // TODO: func should be normalized
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: 'Anonymous function',
+        args: [],
+        line: 48,
+        column: 13
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 46,
+        column: 9
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 82,
+        column: 1
+      });
+    });
+
+    it('should parse IE 11 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.IE_11);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      // TODO: func should be normalized
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: 'Anonymous function',
+        args: [],
+        line: 47,
+        column: 21
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 45,
+        column: 13
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 108,
+        column: 1
+      });
+    });
+
+    it('should parse IE 11 eval error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.IE_11_EVAL);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'eval code',
+        func: 'eval code',
+        args: [],
+        line: 1,
+        column: 1
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 58,
+        column: 17
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 109,
+        column: 1
+      });
+    });
+
+    it('should parse Opera 11 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_11);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 5);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: '<anonymous function: run>',
+        args: ['[arguments not available]'],
+        line: 27,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://domain.com:1234/path/to/file.js',
+        func: 'bar',
+        args: ['[arguments not available]'],
+        line: 18,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://domain.com:1234/path/to/file.js',
+        func: 'foo',
+        args: ['[arguments not available]'],
+        line: 11,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: 'http://path/to/file.js',
+        func: '<anonymous function>',
+        args: [],
+        line: 15,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[4], {
+        url: 'http://path/to/file.js',
+        func: 'Error created at <anonymous function>',
+        args: [],
+        line: 15,
+        column: null
+      });
+    });
+
+    it('should parse Opera 12 error', function() {
+      // TODO: Improve anonymous function name.
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_12);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://localhost:8000/ExceptionLab.html',
+        func: '<anonymous function>',
+        args: ['[arguments not available]'],
+        line: 48,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://localhost:8000/ExceptionLab.html',
+        func: 'dumpException3',
+        args: ['[arguments not available]'],
+        line: 46,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://localhost:8000/ExceptionLab.html',
+        func: '<anonymous function>',
+        args: ['[arguments not available]'],
+        line: 1,
+        column: null
+      });
+    });
+
+    it('should parse Opera 25 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.OPERA_25);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://path/to/file.js',
+        func: '?',
+        args: [],
+        line: 47,
+        column: 22
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 52,
+        column: 15
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: 'bar',
+        args: [],
+        line: 108,
+        column: 168
+      });
+    });
+
+    it('should parse PhantomJS 1.19 error', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.PHANTOMJS_1_19);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'file:///path/to/file.js',
+        func: '?',
+        args: [],
+        line: 878,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://path/to/file.js',
+        func: 'foo',
+        args: [],
+        line: 4283,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://path/to/file.js',
+        func: '?',
+        args: [],
+        line: 4287,
+        column: null
+      });
+    });
+
+    it('should parse Firefox errors with resource: URLs', function() {
+      var stackFrames = TraceKit.computeStackTrace(
+        CapturedExceptions.FIREFOX_50_RESOURCE_URL
+      );
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 3);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'resource://path/data/content/bundle.js',
+        func: 'render',
+        args: [],
+        line: 5529,
+        column: 16
+      });
+    });
+
+    it('should parse Firefox errors with eval URLs', function() {
+      var stackFrames = TraceKit.computeStackTrace(CapturedExceptions.FIREFOX_43_EVAL);
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 5);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'http://localhost:8080/file.js',
+        func: 'baz',
+        args: [],
+        line: 26,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[1], {
+        url: 'http://localhost:8080/file.js',
+        func: 'foo',
+        args: [],
+        line: 26,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[2], {
+        url: 'http://localhost:8080/file.js',
+        func: '?',
+        args: [],
+        line: 26,
+        column: null
+      });
+      assert.deepEqual(stackFrames.stack[3], {
+        url: 'http://localhost:8080/file.js',
+        func: 'speak',
+        args: [],
+        line: 26,
+        column: 17
+      });
+      assert.deepEqual(stackFrames.stack[4], {
+        url: 'http://localhost:8080/file.js',
+        func: '?',
+        args: [],
+        line: 33,
+        column: 9
+      });
+    });
+
+    it('should parse React Native errors on Android', function() {
+      var stackFrames = TraceKit.computeStackTrace(
+        CapturedExceptions.ANDROID_REACT_NATIVE
+      );
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 8);
+      assert.deepEqual(stackFrames.stack[0], {
+        url:
+          '/home/username/sample-workspace/sampleapp.collect.react/src/components/GpsMonitorScene.js',
+        func: 'render',
+        args: [],
+        line: 78,
+        column: 24
+      });
+      assert.deepEqual(stackFrames.stack[7], {
+        url:
+          '/home/username/sample-workspace/sampleapp.collect.react/node_modules/react-native/Libraries/Renderer/src/renderers/native/ReactNativeBaseComponent.js',
+        func: 'this',
+        args: [],
+        line: 74,
+        column: 41
+      });
+    });
+
+    it('should parse React Native errors on Android Production', function() {
+      var stackFrames = TraceKit.computeStackTrace(
+        CapturedExceptions.ANDROID_REACT_NATIVE_PROD
+      );
+      assert.ok(stackFrames);
+      assert.deepEqual(stackFrames.stack.length, 37);
+      assert.deepEqual(stackFrames.stack[0], {
+        url: 'index.android.bundle',
+        func: 'value',
+        args: [],
+        line: 12,
+        column: 1917
+      });
+      assert.deepEqual(stackFrames.stack[35], {
+        url: 'index.android.bundle',
+        func: 'value',
+        args: [],
+        line: 29,
+        column: 927
+      });
+      assert.deepEqual(stackFrames.stack[36], {
+        url: '[native code]',
+        func: '?',
+        args: [],
+        line: null,
+        column: null
+      });
+    });
+  });
 });

--- a/test/vendor/tracekit.test.js
+++ b/test/vendor/tracekit.test.js
@@ -3,247 +3,279 @@
 
 var TraceKit = require('../../vendor/TraceKit/tracekit');
 
-describe('TraceKit', function(){
-    describe('stacktrace info', function() {
-        it('should not remove anonymous functions from the stack', function() {
-            // mock up an error object with a stack trace that includes both
-            // named functions and anonymous functions
-            var stack_str = "" +
-                "  Error: \n" +
-                "    at new <anonymous> (http://example.com/js/test.js:63:1)\n" +   // stack[0]
-                "    at namedFunc0 (http://example.com/js/script.js:10:2)\n" +      // stack[1]
-                "    at http://example.com/js/test.js:65:10\n" +                    // stack[2]
-                "    at namedFunc2 (http://example.com/js/script.js:20:5)\n" +      // stack[3]
-                "    at http://example.com/js/test.js:67:5\n" +                     // stack[4]
-                "    at namedFunc4 (http://example.com/js/script.js:100001:10002)"; // stack[5]
-            var mock_err = { stack: stack_str };
-            var trace = TraceKit.computeStackTrace.computeStackTraceFromStackProp(mock_err);
+describe('TraceKit', function() {
+  describe('stacktrace info', function() {
+    it('should not remove anonymous functions from the stack', function() {
+      // mock up an error object with a stack trace that includes both
+      // named functions and anonymous functions
+      var stack_str =
+        '' +
+        '  Error: \n' +
+        '    at new <anonymous> (http://example.com/js/test.js:63:1)\n' + // stack[0]
+        '    at namedFunc0 (http://example.com/js/script.js:10:2)\n' + // stack[1]
+        '    at http://example.com/js/test.js:65:10\n' + // stack[2]
+        '    at namedFunc2 (http://example.com/js/script.js:20:5)\n' + // stack[3]
+        '    at http://example.com/js/test.js:67:5\n' + // stack[4]
+        '    at namedFunc4 (http://example.com/js/script.js:100001:10002)'; // stack[5]
+      var mock_err = {stack: stack_str};
+      var trace = TraceKit.computeStackTrace.computeStackTraceFromStackProp(mock_err);
 
-            // Make sure TraceKit didn't remove the anonymous functions
-            // from the stack like it used to :)
-            assert.equal(trace.stack[0].func, 'new <anonymous>');
-            assert.equal(trace.stack[0].url, 'http://example.com/js/test.js');
-            assert.equal(trace.stack[0].line, 63);
-            assert.equal(trace.stack[0].column, 1);
+      // Make sure TraceKit didn't remove the anonymous functions
+      // from the stack like it used to :)
+      assert.equal(trace.stack[0].func, 'new <anonymous>');
+      assert.equal(trace.stack[0].url, 'http://example.com/js/test.js');
+      assert.equal(trace.stack[0].line, 63);
+      assert.equal(trace.stack[0].column, 1);
 
-            assert.equal(trace.stack[1].func, 'namedFunc0');
-            assert.equal(trace.stack[1].url, 'http://example.com/js/script.js');
-            assert.equal(trace.stack[1].line, 10);
-            assert.equal(trace.stack[1].column, 2);
+      assert.equal(trace.stack[1].func, 'namedFunc0');
+      assert.equal(trace.stack[1].url, 'http://example.com/js/script.js');
+      assert.equal(trace.stack[1].line, 10);
+      assert.equal(trace.stack[1].column, 2);
 
-            assert.equal(trace.stack[2].func, '?');
-            assert.equal(trace.stack[2].url, 'http://example.com/js/test.js');
-            assert.equal(trace.stack[2].line, 65);
-            assert.equal(trace.stack[2].column, 10);
+      assert.equal(trace.stack[2].func, '?');
+      assert.equal(trace.stack[2].url, 'http://example.com/js/test.js');
+      assert.equal(trace.stack[2].line, 65);
+      assert.equal(trace.stack[2].column, 10);
 
-            assert.equal(trace.stack[3].func, 'namedFunc2');
-            assert.equal(trace.stack[3].url, 'http://example.com/js/script.js');
-            assert.equal(trace.stack[3].line, 20);
-            assert.equal(trace.stack[3].column, 5);
+      assert.equal(trace.stack[3].func, 'namedFunc2');
+      assert.equal(trace.stack[3].url, 'http://example.com/js/script.js');
+      assert.equal(trace.stack[3].line, 20);
+      assert.equal(trace.stack[3].column, 5);
 
-            assert.equal(trace.stack[4].func, '?');
-            assert.equal(trace.stack[4].url, 'http://example.com/js/test.js');
-            assert.equal(trace.stack[4].line, 67);
-            assert.equal(trace.stack[4].column, 5);
+      assert.equal(trace.stack[4].func, '?');
+      assert.equal(trace.stack[4].url, 'http://example.com/js/test.js');
+      assert.equal(trace.stack[4].line, 67);
+      assert.equal(trace.stack[4].column, 5);
 
-            assert.equal(trace.stack[5].func, 'namedFunc4');
-            assert.equal(trace.stack[5].url, 'http://example.com/js/script.js');
-            assert.equal(trace.stack[5].line, 100001);
-            assert.equal(trace.stack[5].column, 10002);
-        });
-
-        it('should handle eval/anonymous strings in Chrome 46', function () {
-            var stack_str = "" +
-                "ReferenceError: baz is not defined\n" +
-                "   at bar (http://example.com/js/test.js:19:7)\n" +
-                "   at foo (http://example.com/js/test.js:23:7)\n" +
-                "   at eval (eval at <anonymous> (http://example.com/js/test.js:26:5), <anonymous>:1:26)\n";
-
-            var mock_err = { stack: stack_str };
-            var trace = TraceKit.computeStackTrace.computeStackTraceFromStackProp(mock_err);
-            assert.equal(trace.stack[0].func, 'bar');
-            assert.equal(trace.stack[0].url, 'http://example.com/js/test.js');
-            assert.equal(trace.stack[0].line, 19);
-            assert.equal(trace.stack[0].column, 7);
-
-            assert.equal(trace.stack[1].func, 'foo');
-            assert.equal(trace.stack[1].url, 'http://example.com/js/test.js');
-            assert.equal(trace.stack[1].line, 23);
-            assert.equal(trace.stack[1].column, 7);
-
-            assert.equal(trace.stack[2].func, 'eval');
-            // TODO: fix nested evals
-            assert.equal(trace.stack[2].url, 'http://example.com/js/test.js');
-            assert.equal(trace.stack[2].line, 26);
-            assert.equal(trace.stack[2].column, 5);
-        });
+      assert.equal(trace.stack[5].func, 'namedFunc4');
+      assert.equal(trace.stack[5].url, 'http://example.com/js/script.js');
+      assert.equal(trace.stack[5].line, 100001);
+      assert.equal(trace.stack[5].column, 10002);
     });
 
-    describe('.computeStackTrace', function() {
-        it('should handle a native error object', function() {
-            var ex = new Error('test');
-            var stack = TraceKit.computeStackTrace(ex);
-            assert.deepEqual(stack.name, 'Error');
-            assert.deepEqual(stack.message, 'test');
-        });
+    it('should handle eval/anonymous strings in Chrome 46', function() {
+      var stack_str =
+        '' +
+        'ReferenceError: baz is not defined\n' +
+        '   at bar (http://example.com/js/test.js:19:7)\n' +
+        '   at foo (http://example.com/js/test.js:23:7)\n' +
+        '   at eval (eval at <anonymous> (http://example.com/js/test.js:26:5), <anonymous>:1:26)\n';
 
-        it('should handle a native error object stack from Chrome', function() {
-            var stackStr = "" +
-            "Error: foo\n" +
-            "    at <anonymous>:2:11\n" +
-            "    at Object.InjectedScript._evaluateOn (<anonymous>:904:140)\n" +
-            "    at Object.InjectedScript._evaluateAndWrap (<anonymous>:837:34)\n" +
-            "    at Object.InjectedScript.evaluate (<anonymous>:693:21)";
-            var mockErr = {
-                name: 'Error',
-                message: 'foo',
-                stack: stackStr
-            };
-            var trace = TraceKit.computeStackTrace(mockErr);
-            assert.deepEqual(trace.stack[0].url, '<anonymous>');
-        });
+      var mock_err = {stack: stack_str};
+      var trace = TraceKit.computeStackTrace.computeStackTraceFromStackProp(mock_err);
+      assert.equal(trace.stack[0].func, 'bar');
+      assert.equal(trace.stack[0].url, 'http://example.com/js/test.js');
+      assert.equal(trace.stack[0].line, 19);
+      assert.equal(trace.stack[0].column, 7);
+
+      assert.equal(trace.stack[1].func, 'foo');
+      assert.equal(trace.stack[1].url, 'http://example.com/js/test.js');
+      assert.equal(trace.stack[1].line, 23);
+      assert.equal(trace.stack[1].column, 7);
+
+      assert.equal(trace.stack[2].func, 'eval');
+      // TODO: fix nested evals
+      assert.equal(trace.stack[2].url, 'http://example.com/js/test.js');
+      assert.equal(trace.stack[2].line, 26);
+      assert.equal(trace.stack[2].column, 5);
+    });
+  });
+
+  describe('.computeStackTrace', function() {
+    it('should handle a native error object', function() {
+      var ex = new Error('test');
+      var stack = TraceKit.computeStackTrace(ex);
+      assert.deepEqual(stack.name, 'Error');
+      assert.deepEqual(stack.message, 'test');
     });
 
-    describe('error notifications', function(){
-        var testMessage = "__mocha_ignore__";
-        var testLineNo = 1337;
+    it('should handle a native error object stack from Chrome', function() {
+      var stackStr =
+        '' +
+        'Error: foo\n' +
+        '    at <anonymous>:2:11\n' +
+        '    at Object.InjectedScript._evaluateOn (<anonymous>:904:140)\n' +
+        '    at Object.InjectedScript._evaluateAndWrap (<anonymous>:837:34)\n' +
+        '    at Object.InjectedScript.evaluate (<anonymous>:693:21)';
+      var mockErr = {
+        name: 'Error',
+        message: 'foo',
+        stack: stackStr
+      };
+      var trace = TraceKit.computeStackTrace(mockErr);
+      assert.deepEqual(trace.stack[0].url, '<anonymous>');
+    });
+  });
 
-        var subscriptionHandler;
-        // TraceKit waits 2000ms for window.onerror to fire, so give the tests
-        // some extra time.
-        this.timeout(3000);
+  describe('error notifications', function() {
+    var testMessage = '__mocha_ignore__';
+    var testLineNo = 1337;
 
-        before(function() {
-            // Prevent the onerror call that's part of our tests from getting to
-            // mocha's handler, which would treat it as a test failure.
-            //
-            // We set this up here and don't ever restore the old handler, because
-            // we can't do that without clobbering TraceKit's handler, which can only
-            // be installed once.
-            var oldOnError = window.onerror;
-            window.onerror = function(message, url, lineNo) {
-                if (message == testMessage || lineNo === testLineNo) {
-                    return true;
-                }
-                return oldOnError.apply(this, arguments);
-            };
-        });
+    var subscriptionHandler;
+    // TraceKit waits 2000ms for window.onerror to fire, so give the tests
+    // some extra time.
+    this.timeout(3000);
 
-        afterEach(function() {
-            if (subscriptionHandler) {
-                TraceKit.report.unsubscribe(subscriptionHandler);
-                subscriptionHandler = null;
-            }
-        });
-
-        describe('with undefined arguments', function () {
-            it('should pass undefined:undefined', function () {
-                // this is probably not good behavior;  just writing this test to verify
-                // that it doesn't change unintentionally
-                subscriptionHandler = function (stackInfo, extra) {
-                    assert.equal(stackInfo.name, undefined);
-                    assert.equal(stackInfo.message, undefined);
-                };
-                TraceKit.report.subscribe(subscriptionHandler);
-                window.onerror(undefined, undefined, testLineNo);
-            });
-        });
-        describe('when no 5th argument (error object)', function () {
-            it('should seperate name, message for default error types (e.g. ReferenceError)', function (done) {
-                subscriptionHandler = function (stackInfo, extra) {
-                    assert.equal(stackInfo.name, 'ReferenceError');
-                    assert.equal(stackInfo.message, 'foo is undefined');
-                };
-                TraceKit.report.subscribe(subscriptionHandler);
-                // should work with/without "Uncaught"
-                window.onerror('Uncaught ReferenceError: foo is undefined', 'http://example.com', testLineNo);
-                window.onerror('ReferenceError: foo is undefined', 'http://example.com', testLineNo);
-                done();
-            });
-
-            it('should separate name, message for default error types on Opera Mini (see #546)', function (done) {
-                subscriptionHandler = function (stackInfo, extra) {
-                    assert.equal(stackInfo.name, 'ReferenceError');
-                    assert.equal(stackInfo.message, 'Undefined variable: foo');
-                };
-                TraceKit.report.subscribe(subscriptionHandler);
-                window.onerror('Uncaught exception: ReferenceError: Undefined variable: foo', 'http://example.com', testLineNo);
-                done();
-            });
-
-            it('should ignore unknown error types', function (done) {
-                // TODO: should we attempt to parse this?
-                subscriptionHandler = function (stackInfo, extra) {
-                    assert.equal(stackInfo.name, undefined);
-                    assert.equal(stackInfo.message, 'CustomError: woo scary');
-                    done();
-                };
-                TraceKit.report.subscribe(subscriptionHandler);
-                window.onerror('CustomError: woo scary', 'http://example.com', testLineNo);
-            });
-
-            it('should ignore arbitrary messages passed through onerror', function (done) {
-                subscriptionHandler = function (stackInfo, extra) {
-                    assert.equal(stackInfo.name, undefined);
-                    assert.equal(stackInfo.message, 'all work and no play makes homer: something something');
-                    done();
-                };
-                TraceKit.report.subscribe(subscriptionHandler);
-                window.onerror('all work and no play makes homer: something something', 'http://example.com', testLineNo);
-            });
-        });
-
-        function testErrorNotification(collectWindowErrors, callOnError, numReports, done) {
-            var extraVal = "foo";
-            var numDone = 0;
-            // TraceKit's collectWindowErrors flag shouldn't affect direct calls
-            // to TraceKit.report, so we parameterize it for the tests.
-            TraceKit.collectWindowErrors = collectWindowErrors;
-
-            subscriptionHandler = function(stackInfo, extra) {
-                assert.equal(extra, extraVal);
-                numDone++;
-                if (numDone == numReports) {
-                    done();
-                }
-            };
-            TraceKit.report.subscribe(subscriptionHandler);
-
-            // TraceKit.report always throws an exception in order to trigger
-            // window.onerror so it can gather more stack data. Mocha treats
-            // uncaught exceptions as errors, so we catch it via assert.throws
-            // here (and manually call window.onerror later if appropriate).
-            //
-            // We test multiple reports because TraceKit has special logic for when
-            // report() is called a second time before either a timeout elapses or
-            // window.onerror is called (which is why we always call window.onerror
-            // only once below, after all calls to report()).
-            for (var i=0; i < numReports; i++) {
-                var e = new Error('testing');
-                assert.throws(function() {
-                    TraceKit.report(e, extraVal);
-                }, e);
-            }
-            // The call to report should work whether or not window.onerror is
-            // triggered, so we parameterize it for the tests. We only call it
-            // once, regardless of numReports, because the case we want to test for
-            // multiple reports is when window.onerror is *not* called between them.
-            if (callOnError) {
-                window.onerror(testMessage);
-            }
+    before(function() {
+      // Prevent the onerror call that's part of our tests from getting to
+      // mocha's handler, which would treat it as a test failure.
+      //
+      // We set this up here and don't ever restore the old handler, because
+      // we can't do that without clobbering TraceKit's handler, which can only
+      // be installed once.
+      var oldOnError = window.onerror;
+      window.onerror = function(message, url, lineNo) {
+        if (message == testMessage || lineNo === testLineNo) {
+          return true;
         }
-
-        Mocha.utils.forEach([false, true], function(collectWindowErrors) {
-            Mocha.utils.forEach([false, true], function(callOnError) {
-                Mocha.utils.forEach([1, 2], function(numReports) {
-                    it('it should receive arguments from report() when' +
-                       ' collectWindowErrors is ' + collectWindowErrors +
-                       ' and callOnError is ' + callOnError +
-                       ' and numReports is ' + numReports, function(done) {
-                        testErrorNotification(collectWindowErrors, callOnError, numReports, done);
-                    });
-                });
-            });
-        });
+        return oldOnError.apply(this, arguments);
+      };
     });
+
+    afterEach(function() {
+      if (subscriptionHandler) {
+        TraceKit.report.unsubscribe(subscriptionHandler);
+        subscriptionHandler = null;
+      }
+    });
+
+    describe('with undefined arguments', function() {
+      it('should pass undefined:undefined', function() {
+        // this is probably not good behavior;  just writing this test to verify
+        // that it doesn't change unintentionally
+        subscriptionHandler = function(stackInfo, extra) {
+          assert.equal(stackInfo.name, undefined);
+          assert.equal(stackInfo.message, undefined);
+        };
+        TraceKit.report.subscribe(subscriptionHandler);
+        window.onerror(undefined, undefined, testLineNo);
+      });
+    });
+    describe('when no 5th argument (error object)', function() {
+      it('should seperate name, message for default error types (e.g. ReferenceError)', function(
+        done
+      ) {
+        subscriptionHandler = function(stackInfo, extra) {
+          assert.equal(stackInfo.name, 'ReferenceError');
+          assert.equal(stackInfo.message, 'foo is undefined');
+        };
+        TraceKit.report.subscribe(subscriptionHandler);
+        // should work with/without "Uncaught"
+        window.onerror(
+          'Uncaught ReferenceError: foo is undefined',
+          'http://example.com',
+          testLineNo
+        );
+        window.onerror(
+          'ReferenceError: foo is undefined',
+          'http://example.com',
+          testLineNo
+        );
+        done();
+      });
+
+      it('should separate name, message for default error types on Opera Mini (see #546)', function(
+        done
+      ) {
+        subscriptionHandler = function(stackInfo, extra) {
+          assert.equal(stackInfo.name, 'ReferenceError');
+          assert.equal(stackInfo.message, 'Undefined variable: foo');
+        };
+        TraceKit.report.subscribe(subscriptionHandler);
+        window.onerror(
+          'Uncaught exception: ReferenceError: Undefined variable: foo',
+          'http://example.com',
+          testLineNo
+        );
+        done();
+      });
+
+      it('should ignore unknown error types', function(done) {
+        // TODO: should we attempt to parse this?
+        subscriptionHandler = function(stackInfo, extra) {
+          assert.equal(stackInfo.name, undefined);
+          assert.equal(stackInfo.message, 'CustomError: woo scary');
+          done();
+        };
+        TraceKit.report.subscribe(subscriptionHandler);
+        window.onerror('CustomError: woo scary', 'http://example.com', testLineNo);
+      });
+
+      it('should ignore arbitrary messages passed through onerror', function(done) {
+        subscriptionHandler = function(stackInfo, extra) {
+          assert.equal(stackInfo.name, undefined);
+          assert.equal(
+            stackInfo.message,
+            'all work and no play makes homer: something something'
+          );
+          done();
+        };
+        TraceKit.report.subscribe(subscriptionHandler);
+        window.onerror(
+          'all work and no play makes homer: something something',
+          'http://example.com',
+          testLineNo
+        );
+      });
+    });
+
+    function testErrorNotification(collectWindowErrors, callOnError, numReports, done) {
+      var extraVal = 'foo';
+      var numDone = 0;
+      // TraceKit's collectWindowErrors flag shouldn't affect direct calls
+      // to TraceKit.report, so we parameterize it for the tests.
+      TraceKit.collectWindowErrors = collectWindowErrors;
+
+      subscriptionHandler = function(stackInfo, extra) {
+        assert.equal(extra, extraVal);
+        numDone++;
+        if (numDone == numReports) {
+          done();
+        }
+      };
+      TraceKit.report.subscribe(subscriptionHandler);
+
+      // TraceKit.report always throws an exception in order to trigger
+      // window.onerror so it can gather more stack data. Mocha treats
+      // uncaught exceptions as errors, so we catch it via assert.throws
+      // here (and manually call window.onerror later if appropriate).
+      //
+      // We test multiple reports because TraceKit has special logic for when
+      // report() is called a second time before either a timeout elapses or
+      // window.onerror is called (which is why we always call window.onerror
+      // only once below, after all calls to report()).
+      for (var i = 0; i < numReports; i++) {
+        var e = new Error('testing');
+        assert.throws(function() {
+          TraceKit.report(e, extraVal);
+        }, e);
+      }
+      // The call to report should work whether or not window.onerror is
+      // triggered, so we parameterize it for the tests. We only call it
+      // once, regardless of numReports, because the case we want to test for
+      // multiple reports is when window.onerror is *not* called between them.
+      if (callOnError) {
+        window.onerror(testMessage);
+      }
+    }
+
+    Mocha.utils.forEach([false, true], function(collectWindowErrors) {
+      Mocha.utils.forEach([false, true], function(callOnError) {
+        Mocha.utils.forEach([1, 2], function(numReports) {
+          it(
+            'it should receive arguments from report() when' +
+              ' collectWindowErrors is ' +
+              collectWindowErrors +
+              ' and callOnError is ' +
+              callOnError +
+              ' and numReports is ' +
+              numReports,
+            function(done) {
+              testErrorNotification(collectWindowErrors, callOnError, numReports, done);
+            }
+          );
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
This PR includes:
- unified `package.json` file, so it's almost exactly the same as `raven-node` one (missing `author` field)
- `prettier` setup with `husky`, so it runs for every file that's about to be commited
- updated `grunt-eslint`, which allows us to use `eslint-disable-next-line` clause (prettier moves `eslint-disable-line` clauses to the line below, which breaks it's functionality)
- used prettier options from sentry repository and extended eslint config to use eslint-config-prettier. This way prettier won't collide with any stylistic rules of eslint.
- added `lint` script to `package.json`

Notes:
- no manual code changes has been made in this PR
- setup and config has been done in a separate commit, and automated changes has been made in separate ones
- all tests are passing

Related `raven-node` PR: https://github.com/getsentry/raven-node/pull/364