### PR TITLE
ci: Update SauceLabs timeouts to account for all browsers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ cache:
 addons:
   chrome: stable
   sauce_connect: true
-before_install:
-- npm i -g npm@5.3.0
 script:
 - npm run test
 - npm run test:ci

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -209,6 +209,8 @@ module.exports = function(grunt) {
             'record-screenshots': false
           },
           build: process.env.TRAVIS_BUILD_NUMBER,
+          statusCheckAttempts: 200,
+          pollInterval: 3000,
           testname:
             'Raven.js' +
             (process.env.TRAVIS_JOB_NUMBER ? ' #' + process.env.TRAVIS_JOB_NUMBER : ''),

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -209,6 +209,11 @@ module.exports = function(grunt) {
             'record-screenshots': false
           },
           build: process.env.TRAVIS_BUILD_NUMBER,
+          // On average, our integration tests take 60s to run
+          // and unit tests about 30s, which gives us 90s in total
+          // And even though we are running 2 tests in parallel, it's safer to assume
+          // 90s * 7 browsers = ~10 minutes (plus some additional time, just in case)
+          // Therefore 200 * 3000ms = 10min
           statusCheckAttempts: 200,
           pollInterval: 3000,
           testname:
@@ -216,7 +221,7 @@ module.exports = function(grunt) {
             (process.env.TRAVIS_JOB_NUMBER ? ' #' + process.env.TRAVIS_JOB_NUMBER : ''),
           browsers: [
             // Latest version of Edge (v15) can't reach the server
-            // Already reached SauceLabs support
+            // Already notified SauceLabs support about this issue
             // ['Windows 10', 'microsoftedge', 'latest'],
 
             // Commenting out until we fix initial issues
@@ -224,14 +229,10 @@ module.exports = function(grunt) {
             // ['Windows 10', 'internet explorer', '11'],
 
             ['Windows 10', 'chrome', 'latest'],
-            ['Windows 10', 'chrome', 'latest-1'],
             ['Windows 10', 'firefox', 'latest'],
-            ['Windows 10', 'firefox', 'latest-1'],
             ['macOS 10.12', 'safari', '10'],
             ['macOS 10.12', 'chrome', 'latest'],
-            ['macOS 10.12', 'chrome', 'latest-1'],
-            ['macOS 10.12', 'firefox', 'latest'],
-            ['macOS 10.12', 'firefox', 'latest-1']
+            ['macOS 10.12', 'firefox', 'latest']
           ],
           public: 'public',
           tunnelArgs: ['--verbose']

--- a/package.json
+++ b/package.json
@@ -25,8 +25,8 @@
     "test:ci": "npm run lint && grunt test:ci"
   },
   "engines": {
-    "node": "~8.0.0",
-    "npm": "~5.3.0"
+    "node": "^8.4.0",
+    "npm": "^5.4.0"
   },
   "devDependencies": {
     "bluebird": "^3.4.1",

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -36,8 +36,6 @@ function parseUrl(url) {
 }
 
 describe('integration', function() {
-  this.timeout(10000);
-
   beforeEach(function(done) {
     this.iframe = createIframe(done);
   });


### PR DESCRIPTION
Per: https://github.com/axemclion/grunt-saucelabs#usage

Changed from 90 tries every 2 seconds (3 minutes), to 200 tries every 3 seconds (10 minutes).
2 tunnels just wasn't enough for 18 tests to run on time, so I had to update those settings.