### PR TITLE
ci: Run TravisCI only once - for master branch PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - master
 sudo: false
 language: node_js
 node_js:


### PR DESCRIPTION
It'll prevent spawning 36 browsers on SauceLabs (18 instead), as we pay per-minute there, not a flat rate.