### PR TITLE
fix: Make sure that document is available before reading location

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     <h1>Raven.js - Sentry SDK for JavaScript</h1>
 </p>
 
-[![Sauce Test Status](https://saucelabs.com/buildstatus/sentryio)](https://saucelabs.com/u/kamilsentry) [![Build Status](https://travis-ci.org/getsentry/raven-js.svg?branch=master)](https://travis-ci.org/getsentry/raven-js) [![npm](https://img.shields.io/npm/v/raven-js.svg)](https://www.npmjs.com/package/raven-js) [![npm](https://img.shields.io/npm/dm/raven-js.svg)](https://www.npmjs.com/package/raven-js)
+[![Sauce Test Status](https://saucelabs.com/buildstatus/sentryio)](https://saucelabs.com/u/sentryio) [![Build Status](https://travis-ci.org/getsentry/raven-js.svg?branch=master)](https://travis-ci.org/getsentry/raven-js) [![npm](https://img.shields.io/npm/v/raven-js.svg)](https://www.npmjs.com/package/raven-js) [![npm](https://img.shields.io/npm/dm/raven-js.svg)](https://www.npmjs.com/package/raven-js)
 
 [![Sauce Test Status](https://saucelabs.com/browser-matrix/sentryio.svg)](https://saucelabs.com/u/sentryio)
 

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -31,8 +31,7 @@ var UNKNOWN_FUNCTION = '?';
 var ERROR_TYPES_RE = /^(?:[Uu]ncaught (?:exception: )?)?(?:((?:Eval|Internal|Range|Reference|Syntax|Type|URI|)Error): )?(.*)$/;
 
 function getLocationHref() {
-    if (typeof document === 'undefined' || typeof document.location === 'undefined')
-        return '';
+    if (typeof document === 'undefined' || document.location == null) return '';
 
     return document.location.href;
 }


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-js/issues/1037

https://github.com/getsentry/raven-js/pull/1038/files?w=1#diff-05367d6a2553cabeca57c6ca111093fcR34 – this is the only real change, the rest is just prettify catching up with the rest of the files through precommit hook