### PR TITLE
fix: Don't override lastEventId when event was dropped

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1725,11 +1725,6 @@ Raven.prototype = {
 
     if (!this.isSetup()) return;
 
-    // Send along an event_id if not explicitly passed.
-    // This event_id can be used to reference the error within Sentry itself.
-    // Set lastEventId after we know the error should actually be sent
-    this._lastEventId = data.event_id || (data.event_id = this._getUuid());
-
     // Try and clean up the packet before sending by truncating long values
     data = this._trimPacket(data);
 
@@ -1741,6 +1736,11 @@ Raven.prototype = {
       return;
     }
 
+    // Send along an event_id if not explicitly passed.
+    // This event_id can be used to reference the error within Sentry itself.
+    // Set lastEventId after we know the error should actually be sent
+    this._lastEventId = data.event_id || (data.event_id = this._getUuid());
+
     // Store outbound payload after trim
     this._lastData = data;
 
@@ -1751,6 +1751,7 @@ Raven.prototype = {
       sentry_client: 'raven-js/' + this.VERSION,
       sentry_key: this._globalKey
     };
+
     if (this._globalSecret) {
       auth.sentry_secret = this._globalSecret;
     }

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -3088,6 +3088,46 @@ describe('Raven (public API)', function() {
       });
     });
   });
+
+  describe('.lastEventId', function() {
+    it('should return eventId of last event sent', function() {
+      Raven.config(SENTRY_DSN);
+
+      Raven.captureMessage('foo', {
+        event_id: 'bar'
+      });
+
+      assert.equal(Raven.lastEventId(), 'bar');
+    });
+
+    it('should override lastEventId when duplicate happens and they are allowed', function() {
+      Raven.config(SENTRY_DSN, {allowDuplicates: true});
+
+      Raven.captureMessage('foo', {
+        event_id: 'bar'
+      });
+
+      Raven.captureMessage('foo', {
+        event_id: 'baz'
+      });
+
+      assert.equal(Raven.lastEventId(), 'baz');
+    });
+
+    it('should not override lastEventId when duplicate happens but they are not allowed', function() {
+      Raven.config(SENTRY_DSN, {allowDuplicates: false});
+
+      Raven.captureMessage('foo', {
+        event_id: 'bar'
+      });
+
+      Raven.captureMessage('foo', {
+        event_id: 'baz'
+      });
+
+      assert.equal(Raven.lastEventId(), 'bar');
+    });
+  });
 });
 
 describe('Raven (private methods)', function() {


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-js/issues/1039

Note: `event_id` is not used to determine whether it's a duplicate or not in any way.