### PR TITLE
Internet Explorer/Edge tests updates and SauceLabs integration

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -205,8 +205,7 @@ module.exports = function(grunt) {
             'http://127.0.0.1:9999/test/integration/index.html'
           ],
           sauceConfig: {
-            'record-video': false,
-            'record-screenshots': false
+            'record-video': false
           },
           build: process.env.TRAVIS_BUILD_NUMBER,
           // On average, our integration tests take 60s to run
@@ -224,10 +223,10 @@ module.exports = function(grunt) {
             // Already notified SauceLabs support about this issue
             // ['Windows 10', 'microsoftedge', 'latest'],
 
-            // Commenting out until we fix initial issues
-            // ['Windows 10', 'microsoftedge', 'latest-1'],
-            // ['Windows 10', 'internet explorer', '11'],
-
+            ['Windows 10', 'microsoftedge', 'latest-1'],
+            ['Windows 10', 'internet explorer', '11'],
+            ['Windows 7', 'internet explorer', '11'],
+            ['Windows 7', 'internet explorer', '10'],
             ['Windows 10', 'chrome', 'latest'],
             ['Windows 10', 'firefox', 'latest'],
             ['macOS 10.12', 'safari', '10'],
@@ -235,7 +234,11 @@ module.exports = function(grunt) {
             ['macOS 10.12', 'firefox', 'latest']
           ],
           public: 'public',
-          tunnelArgs: ['--verbose']
+          tunnelArgs: ['--verbose'],
+          onTestComplete: function(result, callback) {
+            console.log(result);
+            callback(null);
+          }
         }
       }
     },

--- a/src/raven.js
+++ b/src/raven.js
@@ -1118,7 +1118,7 @@ Raven.prototype = {
             var xhr = this;
 
             function onreadystatechangeHandler() {
-              if (xhr.__raven_xhr && (xhr.readyState === 1 || xhr.readyState === 4)) {
+              if (xhr.__raven_xhr && xhr.readyState === 4) {
                 try {
                   // touching statusCode in some platforms throws
                   // an exception
@@ -1126,6 +1126,7 @@ Raven.prototype = {
                 } catch (e) {
                   /* do nothing */
                 }
+
                 self.captureBreadcrumb({
                   type: 'http',
                   category: 'xhr',

--- a/test/integration/frame.html
+++ b/test/integration/frame.html
@@ -39,70 +39,50 @@
     }());
 
     /**
-     * Custom event factories for cross-browser compatibility
-     *
-     * Gecko browsers are using non-standard `initKeyEvent`, where others implemented `initKeyboardEvent`.
-     * To make it more consistent, we try to use standardized `MouseEvent`/`KeyboardEvent` now
-     * and fallback to older implementations for legacy browsers only.
-     *
-     * See deprecation notes:
-     * https://developer.mozilla.org/en-US/docs/Web/API/Document/createEvent
-     * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyEvent
-     * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/initKeyboardEvent
+     * DOM4 MouseEvent and KeyboardEvent Polyfills
      *
      * References:
-     * https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent#Specifications
-     * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent#Specifications
+     * https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent
+     * https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/MouseEvent#Polyfill
+     * https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/KeyboardEvent
      */
-    function createMouseEvent (options) {
-      var options = {
-        bubbles: true,
-        cancelable: true,
-        view: window
+    (function () {
+      try {
+        new MouseEvent('click');
+        return false; // No need to polyfill
+      } catch (e) {
+        // Need to polyfill - fall through
       }
 
-      if ('MouseEvent' in window) {
-        return new MouseEvent('click', options);
-      } else {
-        var event = document.createEvent('MouseEvent');
-        event.initMouseEvent(
-          'click',
-          options.bubbles,
-          options.cancelable,
-          options.view
-        );
-
-        return event;
+      var MouseEvent = function (eventType) {
+        var mouseEvent = document.createEvent('MouseEvent');
+        mouseEvent.initMouseEvent(eventType, true, true, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+        return mouseEvent;
       }
-    }
 
-    function createKeyboardEvent (key) {
-      var options = {
-        bubbles: true,
-        cancelable: true,
-        view: window,
-        key: key || 'a'
+      MouseEvent.prototype = Event.prototype;
+      window.MouseEvent = MouseEvent;
+    })();
+
+    (function () {
+      try {
+        new KeyboardEvent('keypress');
+        return false; // No need to polyfill
+      } catch (e) {
+        // Need to polyfill - fall through
       }
-      options.charCode = options.key.charCodeAt();
 
-      if ('KeyboardEvent' in window) {
-        return new KeyboardEvent('keypress', options);
-      } else {
-        var event = document.createEvent('KeyboardEvent');
-        event.initKeyboardEvent(
-          'keypress',
-          options.bubbles,
-          options.cancelable,
-          options.view,
-          options.key,
-          options.charCode
-        );
-
-        return event;
+      var KeyboardEvent = function (eventType) {
+        var keyboardEvent = document.createEvent('KeyboardEvent');
+        if (keyboardEvent.initKeyboardEvent) keyboardEvent.initKeyboardEvent(eventType, true, true, window, false, false, false, false, 'a', 0);
+        if (keyboardEvent.initKeyEvent) keyboardEvent.initKeyEvent(eventType, true, true, window, false, false, false, false, 'a');
+        return keyboardEvent;
       }
-    }
+
+      KeyboardEvent.prototype = Event.prototype;
+      window.KeyboardEvent = KeyboardEvent;
+    })();
   </script>
-  <script src="../../node_modules/jquery/dist/jquery.js"></script>
   <script src="../../build/raven.js"></script>
   <script>
     // stub _makeRequest so we don't actually transmit any data

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -86,7 +86,8 @@ describe('integration', function() {
         },
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
-          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 1);
+          assert.isAtLeast(ravenData.exception.values[0].stacktrace.frames.length, 2);
+          assert.isAtMost(ravenData.exception.values[0].stacktrace.frames.length, 4);
         }
       );
     });
@@ -105,7 +106,8 @@ describe('integration', function() {
         },
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
-          assert.isAbove(ravenData.stacktrace.frames.length, 0);
+          assert.isAtLeast(ravenData.stacktrace.frames.length, 1);
+          assert.isAtMost(ravenData.stacktrace.frames.length, 3);
 
           // verify trimHeadFrames hasn't slipped into final payload
           assert.isUndefined(ravenData.trimHeadFrames);
@@ -395,7 +397,9 @@ describe('integration', function() {
             assert.match(ravenData.exception.values[0].type, /^Error/);
           }
           assert.match(ravenData.exception.values[0].value, /realError$/);
-          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 0); // 1 or 2 depending on platform
+          // 1 or 2 depending on platform
+          assert.isAtLeast(ravenData.exception.values[0].stacktrace.frames.length, 1);
+          assert.isAtMost(ravenData.exception.values[0].stacktrace.frames.length, 2);
           assert.match(
             ravenData.exception.values[0].stacktrace.frames[0].filename,
             /\/test\/integration\/throw-error\.js/
@@ -479,7 +483,8 @@ describe('integration', function() {
         },
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
-          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+          assert.isAtLeast(ravenData.exception.values[0].stacktrace.frames.length, 3);
+          assert.isAtMost(ravenData.exception.values[0].stacktrace.frames.length, 5);
         }
       );
     });
@@ -527,7 +532,8 @@ describe('integration', function() {
         },
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
-          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+          assert.isAtLeast(ravenData.exception.values[0].stacktrace.frames.length, 3);
+          assert.isAtMost(ravenData.exception.values[0].stacktrace.frames.length, 4);
         }
       );
     });
@@ -547,7 +553,8 @@ describe('integration', function() {
         },
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
-          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+          assert.isAtLeast(ravenData.exception.values[0].stacktrace.frames.length, 3);
+          assert.isAtMost(ravenData.exception.values[0].stacktrace.frames.length, 4);
         }
       );
     });
@@ -568,7 +575,8 @@ describe('integration', function() {
         },
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
-          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+          assert.isAtLeast(ravenData.exception.values[0].stacktrace.frames.length, 3);
+          assert.isAtMost(ravenData.exception.values[0].stacktrace.frames.length, 4);
         }
       );
     });
@@ -601,7 +609,8 @@ describe('integration', function() {
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
           // # of frames alter significantly between chrome/firefox & safari
-          assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 2);
+          assert.isAtLeast(ravenData.exception.values[0].stacktrace.frames.length, 3);
+          assert.isAtMost(ravenData.exception.values[0].stacktrace.frames.length, 4);
         }
       );
     });
@@ -636,12 +645,8 @@ describe('integration', function() {
             breadcrumbs = Raven._breadcrumbs;
 
           assert.equal(breadcrumbs.length, 1);
-
           assert.equal(breadcrumbs[0].type, 'http');
           assert.equal(breadcrumbs[0].data.method, 'GET');
-          // NOTE: not checking status code because we seem to get
-          //       statusCode 0/undefined from Phantom when fetching
-          //       example.json (CORS issue?
         }
       );
     });
@@ -676,9 +681,6 @@ describe('integration', function() {
           assert.equal(breadcrumbs[0].type, 'http');
           assert.equal(breadcrumbs[0].category, 'xhr');
           assert.equal(breadcrumbs[0].data.method, 'GET');
-          // NOTE: not checking status code because we seem to get
-          //       statusCode 0/undefined from Phantom when fetching
-          //       example.json (CORS issue?
         }
       );
     });

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -456,7 +456,7 @@ describe('integration', function() {
             false
           );
 
-          var click = createMouseEvent();
+          var click = new MouseEvent('click');
           div.dispatchEvent(click);
         },
         function() {
@@ -485,14 +485,8 @@ describe('integration', function() {
           div.addEventListener('click', fooFn, false);
           div.removeEventListener('click', fooFn);
 
-          var evt;
-          if (document.createEvent) {
-            evt = document.createEvent('MouseEvents');
-            evt.initEvent('click', true, false);
-            div.dispatchEvent(evt);
-          } else if (document.createEventObject) {
-            div.fireEvent('onclick');
-          }
+          var click = new MouseEvent('click');
+          div.dispatchEvent(click);
         },
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
@@ -820,8 +814,8 @@ describe('integration', function() {
           input.addEventListener('click', clickHandler);
 
           // click <input/>
-          var evt = createMouseEvent();
-          input.dispatchEvent(evt);
+          var click = new MouseEvent('click');
+          input.dispatchEvent(click);
         },
         function() {
           var Raven = iframe.contentWindow.Raven,
@@ -853,10 +847,9 @@ describe('integration', function() {
           Raven._breadcrumbs = [];
 
           // click <input/>
-          var evt = createMouseEvent();
-
+          var click = new MouseEvent('click');
           var input = document.getElementsByTagName('input')[0];
-          input.dispatchEvent(evt);
+          input.dispatchEvent(click);
         },
         function() {
           var Raven = iframe.contentWindow.Raven,
@@ -899,10 +892,9 @@ describe('integration', function() {
           document.querySelector('.c').addEventListener('click', clickHandler);
 
           // click <input/>
-          var evt = createMouseEvent();
-
+          var click = new MouseEvent('click');
           var input = document.querySelector('.a'); // leaf node
-          input.dispatchEvent(evt);
+          input.dispatchEvent(click);
         },
         function() {
           var Raven = iframe.contentWindow.Raven,
@@ -932,16 +924,15 @@ describe('integration', function() {
           Raven._breadcrumbs = [];
 
           // click <input/>
-          var evt = createMouseEvent();
-
+          var click = new MouseEvent('click');
           function kaboom() {
             throw new Error('lol');
           }
-          Object.defineProperty(evt, 'type', {get: kaboom});
-          Object.defineProperty(evt, 'target', {get: kaboom});
+          Object.defineProperty(click, 'type', {get: kaboom});
+          Object.defineProperty(click, 'target', {get: kaboom});
 
           var input = document.querySelector('.a'); // leaf node
-          input.dispatchEvent(evt);
+          input.dispatchEvent(click);
         },
         function() {
           var Raven = iframe.contentWindow.Raven,
@@ -969,8 +960,8 @@ describe('integration', function() {
           Raven._breadcrumbs = [];
 
           // keypress <input/> twice
-          var keypress1 = createKeyboardEvent('a');
-          var keypress2 = createKeyboardEvent('b');
+          var keypress1 = new KeyboardEvent('keypress');
+          var keypress2 = new KeyboardEvent('keypress');
 
           var input = document.getElementsByTagName('input')[0];
           input.dispatchEvent(keypress1);
@@ -1004,7 +995,7 @@ describe('integration', function() {
           Raven._breadcrumbs = [];
 
           // keypress <input/>
-          var keypress = createKeyboardEvent();
+          var keypress = new KeyboardEvent('keypress');
 
           var input = document.getElementsByTagName('input')[0];
           input.dispatchEvent(keypress);
@@ -1042,11 +1033,11 @@ describe('integration', function() {
           Raven._breadcrumbs = [];
 
           // 1st keypress <input/>
-          var keypress1 = createKeyboardEvent('a');
+          var keypress1 = new KeyboardEvent('keypress');
           // click <input/>
-          var click = createMouseEvent();
+          var click = new MouseEvent('click');
           // 2nd keypress
-          var keypress2 = createKeyboardEvent('b');
+          var keypress2 = new KeyboardEvent('keypress');
 
           var input = document.getElementsByTagName('input')[0];
           input.dispatchEvent(keypress1);
@@ -1096,8 +1087,8 @@ describe('integration', function() {
           Raven._breadcrumbs = [];
 
           // keypress <input/> twice
-          var keypress1 = createKeyboardEvent('a');
-          var keypress2 = createKeyboardEvent('b');
+          var keypress1 = new KeyboardEvent('keypress');
+          var keypress2 = new KeyboardEvent('keypress');
 
           var div = document.querySelector('[contenteditable]');
           div.dispatchEvent(keypress1);

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -313,7 +313,7 @@ describe('integration', function() {
           );
           assert.match(
             ravenData.exception.values[0].stacktrace.frames[0]['function'],
-            /\?|global code/
+            /\?|global code/i
           );
         }
       );
@@ -350,7 +350,7 @@ describe('integration', function() {
           );
           assert.match(
             ravenData.exception.values[0].stacktrace.frames[0]['function'],
-            /\?|global code/
+            /\?|global code/i
           );
         }
       );
@@ -384,7 +384,7 @@ describe('integration', function() {
           );
           assert.match(
             ravenData.exception.values[0].stacktrace.frames[0]['function'],
-            /\?|global code/
+            /\?|global code|throwRealError/i
           );
         }
       );

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -44,6 +44,8 @@ function isEdge14() {
 }
 
 describe('integration', function() {
+  this.timeout(10000);
+
   beforeEach(function(done) {
     this.iframe = createIframe(done);
   });

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -35,6 +35,14 @@ function parseUrl(url) {
   return out;
 }
 
+function isBelowIE11() {
+  return /*@cc_on!@*/ false == !false;
+}
+
+function isEdge14() {
+  return window.navigator.userAgent.indexOf('Edge/14') !== -1;
+}
+
 describe('integration', function() {
   beforeEach(function(done) {
     this.iframe = createIframe(done);
@@ -277,7 +285,12 @@ describe('integration', function() {
         },
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
-          assert.isTrue(/SyntaxError/.test(ravenData.exception.values[0].type)); // full message differs per-browser
+          // ¯\_(ツ)_/¯
+          if (isBelowIE11() || isEdge14()) {
+            assert.equal(ravenData.exception.values[0].type, undefined);
+          } else {
+            assert.match(ravenData.exception.values[0].type, /SyntaxError/);
+          }
           assert.equal(ravenData.exception.values[0].stacktrace.frames.length, 1); // just one frame
         }
       );
@@ -375,7 +388,12 @@ describe('integration', function() {
         },
         function() {
           var ravenData = iframe.contentWindow.ravenData[0];
-          assert.match(ravenData.exception.values[0].type, /^Error/);
+          // ¯\_(ツ)_/¯
+          if (isBelowIE11() || isEdge14()) {
+            assert.equal(ravenData.exception.values[0].type, undefined);
+          } else {
+            assert.match(ravenData.exception.values[0].type, /^Error/);
+          }
           assert.match(ravenData.exception.values[0].value, /realError$/);
           assert.isAbove(ravenData.exception.values[0].stacktrace.frames.length, 0); // 1 or 2 depending on platform
           assert.match(


### PR DESCRIPTION
> bug: Store XHR breadcrumb only when readyState === 4

IE11 trigger change events for `readyState === 1`, therefore it captured the same breadcrumb twice.

> test: Fixed event-based tests on <= IE11

It has to be done like this, as in IE11, even though it has `MouseEvent` and `KeyboardEvent` constructors, it throws error when you try to initiate new instance ¯\_(ツ)_/¯

> test: Fixed error name on Edge

IE is capitalising first letter of `global error`, therefore had to make RegExp case-insensitive.

> test: Fixed tests with error types on <= IE10

IE <= 10 is not capable of providing us with error type (which is also the case in other browsers for throwing object literals for example), therefore we shouldn't test for it.
However, I didn't want to make it `^Error|undefined` as it makes tests too fragile.
This <= IE10 check is reliable, and it not "that bad" in my opinion, especially that it's only used in the tests.

> test: Make length-based tests more restricted

Make it a range instead of "just above N".

> ci: Enable Edge, IE11 and IE10 and SauceLabs