### PR TITLE
ci: Remove duplicated browsers on SauceLabs

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -229,9 +229,7 @@ module.exports = function(grunt) {
             ['Windows 7', 'internet explorer', '10'],
             ['Windows 10', 'chrome', 'latest'],
             ['Windows 10', 'firefox', 'latest'],
-            ['macOS 10.12', 'safari', '10'],
-            ['macOS 10.12', 'chrome', 'latest'],
-            ['macOS 10.12', 'firefox', 'latest']
+            ['macOS 10.12', 'safari', '10']
           ],
           public: 'public',
           tunnelArgs: ['--verbose'],


### PR DESCRIPTION
In the end they are exactly same engines, and I see that most of OSS is using one version each as well.

I know that more looks "cool", but it takes up build time, automation time (which is limited on Sauce Labs) and doesn't provide a lot of additional value.