### PR TITLE
ref: Remove deprecated crossOrigin option

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -55,7 +55,6 @@ function Raven() {
     ignoreUrls: [],
     whitelistUrls: [],
     includePaths: [],
-    crossOrigin: 'anonymous',
     collectWindowErrors: true,
     maxMessageLength: 0,
 


### PR DESCRIPTION
Ref https://github.com/getsentry/raven-js/issues/1014