### PR TITLE
feat: Add Errors serialization to json-stringify-safe

### DIFF
--- a/vendor/json-stringify-safe/stringify.js
+++ b/vendor/json-stringify-safe/stringify.js
@@ -5,8 +5,8 @@
  Like JSON.stringify, but doesn't throw on circular references.
 
  Originally forked from https://github.com/isaacs/json-stringify-safe
- version 5.0.1 on 3/8/2017 and modified for IE8 compatibility.
- Tests for this are in test/vendor.
+ version 5.0.1 on 3/8/2017 and modified to handle Errors serialization
+ and IE8 compatibility. Tests for this are in test/vendor.
 
  ISC license: https://github.com/isaacs/json-stringify-safe/blob/master/LICENSE
 */
@@ -25,24 +25,52 @@ function stringify(obj, replacer, spaces, cycleReplacer) {
   return JSON.stringify(obj, serializer(replacer, cycleReplacer), spaces);
 }
 
-function serializer(replacer, cycleReplacer) {
-  var stack = [],
-    keys = [];
+// https://github.com/ftlabs/js-abbreviate/blob/fa709e5f139e7770a71827b1893f22418097fbda/index.js#L95-L106
+function stringifyError(value) {
+  var err = {
+    // These properties are implemented as magical getters and don't show up in for in
+    stack: value.stack,
+    message: value.message,
+    name: value.name
+  };
 
-  if (cycleReplacer == null)
+  for (var i in value) {
+    if (Object.prototype.hasOwnProperty.call(value, i)) {
+      err[i] = value[i];
+    }
+  }
+
+  return err;
+}
+
+function serializer(replacer, cycleReplacer) {
+  var stack = [];
+  var keys = [];
+
+  if (cycleReplacer == null) {
     cycleReplacer = function(key, value) {
-      if (stack[0] === value) return '[Circular ~]';
+      if (stack[0] === value) {
+        return '[Circular ~]';
+      }
       return '[Circular ~.' + keys.slice(0, indexOf(stack, value)).join('.') + ']';
     };
+  }
 
   return function(key, value) {
     if (stack.length > 0) {
       var thisPos = indexOf(stack, this);
       ~thisPos ? stack.splice(thisPos + 1) : stack.push(this);
       ~thisPos ? keys.splice(thisPos, Infinity, key) : keys.push(key);
-      if (~indexOf(stack, value)) value = cycleReplacer.call(this, key, value);
-    } else stack.push(value);
 
-    return replacer == null ? value : replacer.call(this, key, value);
+      if (~indexOf(stack, value)) {
+        value = cycleReplacer.call(this, key, value);
+      }
+    } else {
+      stack.push(value);
+    }
+
+    return replacer == null
+      ? value instanceof Error ? stringifyError(value) : value
+      : replacer.call(this, key, value);
   };
 }


### PR DESCRIPTION
It's basically just copy-paste from https://github.com/getsentry/raven-node/commit/519c3f0c592964945d9b8de124d7539ed13643ff

Fixes https://github.com/getsentry/raven-js/issues/982 https://github.com/getsentry/raven-js/issues/984 and https://github.com/getsentry/raven-js/issues/483