### PR TITLE
Fix: Error thrown when fetch argument is not a string or a Request object.

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1179,11 +1179,13 @@ Raven.prototype = {
 
             if (typeof fetchInput === 'string') {
               url = fetchInput;
-            } else {
+            } else if ('Request' in _window && fetchInput instanceof _window.Request) {
               url = fetchInput.url;
               if (fetchInput.method) {
                 method = fetchInput.method;
               }
+            } else {
+              url = '' + fetchInput;
             }
 
             if (args[1] && args[1].method) {


### PR DESCRIPTION
Hello,

When using fetch and the first parameter of fetch is `undefined`, raven is throwing an error:

```
> fetch(undefined)
< Uncaught TypeError: Cannot read property 'url' of undefined
```
This fix covers the cases where the first arg of fetch is neither a string or a Request object.