### PR TITLE
Accept RegExp and Functions in filter options.

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1974,8 +1974,7 @@ function optimizeFilters(filters) {
     optimized_filters = [],
     i = 0,
     len = filters.length,
-    filter,
-    joined_regexp;
+    filter;
 
   for (; i < len; i++) {
     filter = filters[i];

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -24,16 +24,16 @@ declare module Raven {
         serverName?: string;
 
         /** List of messages to be filtered out before being sent to Sentry. */
-        ignoreErrors?: (RegExp | string)[];
+        ignoreErrors?: (Function | RegExp | string)[];
 
         /** Similar to ignoreErrors, but will ignore errors from whole urls patching a regex pattern. */
-        ignoreUrls?: (RegExp | string)[];
+        ignoreUrls?: (Function | RegExp | string)[];
 
         /** The inverse of ignoreUrls. Only report errors from whole urls matching a regex pattern. */
-        whitelistUrls?: (RegExp | string)[];
+        whitelistUrls?: (Function | RegExp | string)[];
 
         /** An array of regex patterns to indicate which urls are a part of your app. */
-        includePaths?: (RegExp | string)[];
+        includePaths?: (Function | RegExp | string)[];
 
         /** Additional data to be tagged onto the error. */
         tags?: {


### PR DESCRIPTION
ref #1059.

`ignoreErrors`, `includePaths`, `ignoreUrls`, `whitelistUrls` now accept arrays of RegExp and functions.

The major change is that ignoreErrors now stay as array after `config()`, and the configuration must always be an Array. Which I think makes for even more consistent API.

`joinRegExp` is wrapped by `optimizeFilters`. And the test must be done using using `matchFiltters` function.

The provided test function will be tested before string and RegExp.
Call the check with `matchFilters(ignoreUrls, typeString, type, message, fileurl,...)`, then test function will be called as `function(typeString, type, message, fileurl, ...)` (I keep typeString as first parameter for convenient).

Noted that I didn't pass any extra parameter to `includePaths`, `ignoreUrls`, `whitelistUrls` but I made them accept function anyway, for consistency.