### PR TITLE
Compare ignoreErrors pattern to error message

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1420,13 +1420,13 @@ Raven.prototype = {
   },
 
   _processException: function(type, message, fileurl, lineno, frames, options) {
-    if (!!this._globalOptions.ignoreErrors.test) {
-      if (
-        this._globalOptions.ignoreErrors.test(message) ||
-        (type && this._globalOptions.ignoreErrors.test(type + ': ' + (message || '')))
-      ) {
-        return;
-      }
+    var prefixedMessage = (type ? type + ': ' : '') + (message || '');
+    if (
+      !!this._globalOptions.ignoreErrors.test &&
+      (this._globalOptions.ignoreErrors.test(message) ||
+        this._globalOptions.ignoreErrors.test(prefixedMessage))
+    ) {
+      return;
     }
 
     var stacktrace;

--- a/src/raven.js
+++ b/src/raven.js
@@ -1420,7 +1420,7 @@ Raven.prototype = {
   },
 
   _processException: function(type, message, fileurl, lineno, frames, options) {
-    var testString = (type || '') + ': ' + (message || '');
+    var testString = (type ? type + ': ' : '') + (message || '');
 
     if (
       !!this._globalOptions.ignoreErrors.test && (

--- a/src/raven.js
+++ b/src/raven.js
@@ -1422,7 +1422,7 @@ Raven.prototype = {
   _processException: function(type, message, fileurl, lineno, frames, options) {
     if (!!this._globalOptions.ignoreErrors.test) {
       var testStrings = [message, type ? type + ': ' + (message || '') : ''];
-      for (var ix in testStrings) {
+      for (var ix = 0, len = testStrings.length; ix < len; ix++) {
         if (testStrings[ix] && this._globalOptions.ignoreErrors.test(testStrings[ix])) {
           return;
         }

--- a/src/raven.js
+++ b/src/raven.js
@@ -1420,14 +1420,14 @@ Raven.prototype = {
   },
 
   _processException: function(type, message, fileurl, lineno, frames, options) {
-    var testString = (type ? type + ': ' : '') + (message || '');
-
-    if (
-      !!this._globalOptions.ignoreErrors.test && (
-        this._globalOptions.ignoreErrors.test(message) ||
-        this._globalOptions.ignoreErrors.test(testString))
-    )
-      return;
+    if (!!this._globalOptions.ignoreErrors.test) {
+      var testStrings = [message, type ? type + ': ' + (message || '') : ''];
+      for (var ix in testStrings) {
+        if (testStrings[ix] && this._globalOptions.ignoreErrors.test(testStrings[ix])) {
+          return;
+        }
+      }
+    }
 
     var stacktrace;
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -1421,11 +1421,13 @@ Raven.prototype = {
 
   _processException: function(type, message, fileurl, lineno, frames, options) {
     if (!!this._globalOptions.ignoreErrors.test) {
-      var testStrings = [message, type ? type + ': ' + (message || '') : ''];
-      for (var ix = 0, len = testStrings.length; ix < len; ix++) {
-        if (testStrings[ix] && this._globalOptions.ignoreErrors.test(testStrings[ix])) {
-          return;
-        }
+      if (this._globalOptions.ignoreErrors.test(message)) {
+        return;
+      } else if (
+        type &&
+        this._globalOptions.ignoreErrors.test(type + ': ' + (message || ''))
+      ) {
+        return;
       }
     }
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -1421,11 +1421,9 @@ Raven.prototype = {
 
   _processException: function(type, message, fileurl, lineno, frames, options) {
     if (!!this._globalOptions.ignoreErrors.test) {
-      if (this._globalOptions.ignoreErrors.test(message)) {
-        return;
-      } else if (
-        type &&
-        this._globalOptions.ignoreErrors.test(type + ': ' + (message || ''))
+      if (
+        this._globalOptions.ignoreErrors.test(message) ||
+        (type && this._globalOptions.ignoreErrors.test(type + ': ' + (message || '')))
       ) {
         return;
       }

--- a/src/raven.js
+++ b/src/raven.js
@@ -1423,8 +1423,9 @@ Raven.prototype = {
     var testString = (type || '') + ': ' + (message || '');
 
     if (
-      !!this._globalOptions.ignoreErrors.test &&
-      this._globalOptions.ignoreErrors.test(testString)
+      !!this._globalOptions.ignoreErrors.test && (
+        this._globalOptions.ignoreErrors.test(message) ||
+        this._globalOptions.ignoreErrors.test(testString))
     )
       return;
 

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -478,27 +478,37 @@ describe('globals', function() {
     it('should respect `ignoreErrors`', function() {
       this.sinon.stub(Raven, '_send');
       Raven._globalOptions.ignoreErrors = joinRegExp([
-        'CustomError1: e1',
-        'e1',
-        'e2',
-        'CustomError2',
-        /^CustomError1: e1$/,
-        /^e1$/,
-        /^e2$/,
-        /^CustomError2/
+        'msg1',
+        'CustomError1',
+        'CustomError2: msg2',
+        /^msg3/,
+        /^RegexError1/,
+        /^RegexError2: msg4/
       ]);
-      Raven._processException('Error', 'e1', 'http://example.com', []);
+      Raven._processException('Error', 'msg1', 'http://example.com', []);
       assert.isFalse(Raven._send.called);
-      Raven._processException('Error', 'e2', 'http://example.com', []);
+      Raven._processException(undefined, 'msg1', 'http://example.com', []);
       assert.isFalse(Raven._send.called);
-      Raven._processException('CustomError1', 'e1', 'http://example.com', []);
+      Raven._processException('CustomError1', 'error', 'http://example.com', []);
       assert.isFalse(Raven._send.called);
-      Raven._processException('CustomError2', 'error', 'http://example.com', []);
+      Raven._processException('CustomError2', 'msg2', 'http://example.com', []);
       assert.isFalse(Raven._send.called);
-      Raven._processException(undefined, 'e1', 'http://example.com', []);
+
+      Raven._processException('Error', 'msg3', 'http://example.com', []);
       assert.isFalse(Raven._send.called);
+      Raven._processException(undefined, 'msg3', 'http://example.com', []);
+      assert.isFalse(Raven._send.called);
+      Raven._processException('RegexError1', 'error', 'http://example.com', []);
+      assert.isFalse(Raven._send.called);
+      Raven._processException('RegexError2', 'msg4', 'http://example.com', []);
+      assert.isFalse(Raven._send.called);
+
       Raven._processException('Error', 'error', 'http://example.com', []);
       assert.isTrue(Raven._send.calledOnce);
+      Raven._processException('CustomError2', 'error', 'http://example.com', []);
+      assert.isTrue(Raven._send.calledTwice);
+      Raven._processException('RegexError2', 'error', 'http://example.com', []);
+      assert.isTrue(Raven._send.calledThrice);
     });
 
     it('should handle empty `ignoreErrors`', function() {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -477,13 +477,25 @@ describe('globals', function() {
   describe('processException', function() {
     it('should respect `ignoreErrors`', function() {
       this.sinon.stub(Raven, '_send');
-
-      Raven._globalOptions.ignoreErrors = joinRegExp(['e1', 'e2', 'CustomError']);
+      Raven._globalOptions.ignoreErrors = joinRegExp([
+        'CustomError1: e1',
+        'e1',
+        'e2',
+        'CustomError2',
+        /^CustomError1: e1$/,
+        /^e1$/,
+        /^e2$/,
+        /^CustomError2/
+      ]);
       Raven._processException('Error', 'e1', 'http://example.com', []);
       assert.isFalse(Raven._send.called);
       Raven._processException('Error', 'e2', 'http://example.com', []);
       assert.isFalse(Raven._send.called);
-      Raven._processException('CustomError', 'e3', 'http://example.com', []);
+      Raven._processException('CustomError1', 'e1', 'http://example.com', []);
+      assert.isFalse(Raven._send.called);
+      Raven._processException('CustomError2', 'error', 'http://example.com', []);
+      assert.isFalse(Raven._send.called);
+      Raven._processException(undefined, 'e1', 'http://example.com', []);
       assert.isFalse(Raven._send.called);
       Raven._processException('Error', 'error', 'http://example.com', []);
       assert.isTrue(Raven._send.calledOnce);


### PR DESCRIPTION
This resumes filtering opaque "Script error" messages caused by [errors in cross-origin scripts](https://blog.sentry.io/2016/05/17/what-is-script-error.html).

Fixes #1075.