### PR TITLE
Added skipSampleRate option to Raven.captureMessage and Raven.captureException

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -94,6 +94,23 @@ Capturing Messages
 
     Raven.captureMessage('Broken!')
 
+Passing options
+-----------------------
+
+The ``captureMessage`` and ``captureException`` both allow options to be passed for them
+
+.. describe:: skipSampleRate
+
+    Skips sampling rate checking this message and always sends it. Default: ``false``
+
+    .. code-block:: javascript
+
+        Raven.captureMessage('Something happened', {
+          options: {
+            skipSampleRate: true
+          }
+        });
+
 .. _raven-js-additional-context:
 
 Passing Additional Data

--- a/src/raven.js
+++ b/src/raven.js
@@ -1635,6 +1635,9 @@ Raven.prototype = {
 
   _send: function(data) {
     var globalOptions = this._globalOptions;
+    var options = data.options || {};
+    // delete `options` from data to so it doesn't get send with the outbound payload
+    delete data.options;
 
     var baseData = {
         project: this._globalProject,
@@ -1708,7 +1711,7 @@ Raven.prototype = {
       return;
     }
 
-    if (typeof globalOptions.sampleRate === 'number') {
+    if (typeof globalOptions.sampleRate === 'number' && !options.skipSampleRate) {
       if (Math.random() < globalOptions.sampleRate) {
         this._sendProcessedPayload(data);
       }

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2627,6 +2627,18 @@ describe('Raven (public API)', function() {
       assert.isTrue(Raven._send.calledOnce);
     });
 
+    it('should respect `skipSampleRate` option', function() {
+      this.sinon.stub(Raven, '_makeRequest');
+      setupRaven();
+      Raven._globalOptions.sampleRate = 0.0;
+      Raven.captureMessage('This message should be sent', {
+        options: {
+          skipSampleRate: true
+        }
+      });
+      assert.equal(Raven._makeRequest.callCount, 1);
+    });
+
     it('should not throw an error if not configured', function() {
       this.sinon.stub(Raven, 'isSetup').returns(false);
       this.sinon.stub(Raven, '_send');
@@ -2749,6 +2761,18 @@ describe('Raven (public API)', function() {
       assert.doesNotThrow(function() {
         Raven.captureException(new Error('err'));
       });
+    });
+
+    it('should respect `skipSampleRate`', function() {
+      this.sinon.stub(Raven, '_makeRequest');
+      setupRaven();
+      Raven._globalOptions.sampleRate = 0.0;
+      Raven.captureException(new Error('This error should be sent'), {
+        options: {
+          skipSampleRate: true
+        }
+      });
+      assert.equal(Raven._makeRequest.callCount, 1);
     });
   });
 


### PR DESCRIPTION
Both of these methods now accept an option to skip global sampling rate. I added tests but documentation is missing because i'm not sure how I should document it and where.

This solves #1011 
