### PR TITLE
Capture message respects ignoreUrls/whitelistUrls #774

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -90,9 +90,6 @@ Those configuration options are documented below:
     tags. Not setting this value is equivalent to a catch-all and will not
     filter out any values.
 
-    Does not affect when non-error object is passed in
-    as argument to captureException.
-
     .. code-block:: javascript
 
         {
@@ -106,9 +103,6 @@ Those configuration options are documented below:
     completely not interested in. `ignoreErrors` is a list of these
     messages to be filtered out before being sent to Sentry as either
     regular expressions or strings.
-
-    Does not affect when non-error object is passed in
-    as argument to captureException.
 
     .. code-block:: javascript
 
@@ -127,9 +121,6 @@ Those configuration options are documented below:
         {
           ignoreUrls: [/graph\.facebook\.com/, 'http://example.com/script2.js']
         }
-
-    Does not affect when non-error object is passed in
-    as argument to ``captureException``.
 
 .. describe:: includePaths
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -90,7 +90,7 @@ Those configuration options are documented below:
     tags. Not setting this value is equivalent to a catch-all and will not
     filter out any values.
 
-    Does not affect ``captureMessage`` or when non-error object is passed in
+    Does not affect when non-error object is passed in
     as argument to captureException.
 
     .. code-block:: javascript
@@ -107,7 +107,7 @@ Those configuration options are documented below:
     messages to be filtered out before being sent to Sentry as either
     regular expressions or strings.
 
-    Does not affect captureMessage or when non-error object is passed in
+    Does not affect when non-error object is passed in
     as argument to captureException.
 
     .. code-block:: javascript
@@ -128,7 +128,7 @@ Those configuration options are documented below:
           ignoreUrls: [/graph\.facebook\.com/, 'http://example.com/script2.js']
         }
 
-    Does not affect captureMessage or when non-error object is passed in
+    Does not affect when non-error object is passed in
     as argument to ``captureException``.
 
 .. describe:: includePaths

--- a/src/raven.js
+++ b/src/raven.js
@@ -450,20 +450,24 @@ Raven.prototype = {
     ex.name = null;
     var stack = TraceKit.computeStackTrace(ex);
 
-    var prvCall = stack.stack[1];
+    // stack[0] is `throw new Error(msg)` call itself, we are interested in the frame that was just before that, stack[1]
+    var initialCall = stack.stack[1];
 
-    var fileurl = prvCall.url || '';
+    var fileurl = initialCall.url || '';
 
     if (
       !!this._globalOptions.ignoreUrls.test &&
       this._globalOptions.ignoreUrls.test(fileurl)
-    )
+    ) {
       return;
+    }
+
     if (
       !!this._globalOptions.whitelistUrls.test &&
       !this._globalOptions.whitelistUrls.test(fileurl)
-    )
+    ) {
       return;
+    }
 
     if (this._globalOptions.stacktrace || (options && options.stacktrace)) {
       options = objectMerge(

--- a/src/raven.js
+++ b/src/raven.js
@@ -454,6 +454,17 @@ Raven.prototype = {
 
     var fileurl = prvCall.url || '';
 
+    if (
+      !!this._globalOptions.ignoreUrls.test &&
+      this._globalOptions.ignoreUrls.test(fileurl)
+    )
+      return;
+    if (
+      !!this._globalOptions.whitelistUrls.test &&
+      !this._globalOptions.whitelistUrls.test(fileurl)
+    )
+      return;
+
     if (this._globalOptions.stacktrace || (options && options.stacktrace)) {
       options = objectMerge(
         {

--- a/src/raven.js
+++ b/src/raven.js
@@ -1470,13 +1470,16 @@ Raven.prototype = {
     if (
       !!this._globalOptions.ignoreUrls.test &&
       this._globalOptions.ignoreUrls.test(fileurl)
-    )
+    ) {
       return;
+    }
+
     if (
       !!this._globalOptions.whitelistUrls.test &&
       !this._globalOptions.whitelistUrls.test(fileurl)
-    )
+    ) {
       return;
+    }
 
     var data = objectMerge(
       {

--- a/src/raven.js
+++ b/src/raven.js
@@ -450,6 +450,10 @@ Raven.prototype = {
     ex.name = null;
     var stack = TraceKit.computeStackTrace(ex);
 
+    var prvCall = stack.stack[1];
+
+    var fileurl = prvCall.url || '';
+
     if (this._globalOptions.stacktrace || (options && options.stacktrace)) {
       options = objectMerge(
         {

--- a/src/raven.js
+++ b/src/raven.js
@@ -435,21 +435,22 @@ Raven.prototype = {
       options
     );
 
+    var ex;
+    // Generate a "synthetic" stack trace from this point.
+    // NOTE: If you are a Sentry user, and you are seeing this stack frame, it is NOT indicative
+    //       of a bug with Raven.js. Sentry generates synthetic traces either by configuration,
+    //       or if it catches a thrown object without a "stack" property.
+    try {
+      throw new Error(msg);
+    } catch (ex1) {
+      ex = ex1;
+    }
+
+    // null exception name so `Error` isn't prefixed to msg
+    ex.name = null;
+    var stack = TraceKit.computeStackTrace(ex);
+
     if (this._globalOptions.stacktrace || (options && options.stacktrace)) {
-      var ex;
-      // Generate a "synthetic" stack trace from this point.
-      // NOTE: If you are a Sentry user, and you are seeing this stack frame, it is NOT indicative
-      //       of a bug with Raven.js. Sentry generates synthetic traces either by configuration,
-      //       or if it catches a thrown object without a "stack" property.
-      try {
-        throw new Error(msg);
-      } catch (ex1) {
-        ex = ex1;
-      }
-
-      // null exception name so `Error` isn't prefixed to msg
-      ex.name = null;
-
       options = objectMerge(
         {
           // fingerprint on msg, not stack trace (legacy behavior, could be
@@ -463,7 +464,6 @@ Raven.prototype = {
         options
       );
 
-      var stack = TraceKit.computeStackTrace(ex);
       var frames = this._prepareFrames(stack, options);
       data.stacktrace = {
         // Sentry expects frames oldest to newest

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2635,6 +2635,34 @@ describe('Raven (public API)', function() {
       });
     });
 
+    it('should respect `ignoreUrls`', function() {
+      this.sinon.stub(Raven, '_send');
+      var TraceKitStub = this.sinon.stub(TraceKit, 'computeStackTrace');
+
+      Raven._globalOptions.ignoreUrls = joinRegExp([/.+?host1.+/, /.+?host2.+/]);
+      TraceKitStub.returns({stack: [{url: 'http://host1/'}, {url: 'http://host1/'}]});
+      Raven.captureMessage('Do not capture');
+      assert.isFalse(Raven._send.called);
+      TraceKitStub.returns({stack: [{url: 'http://host2/'}, {url: 'http://host2/'}]});
+      Raven.captureMessage('Also do not capture');
+      assert.isFalse(Raven._send.called);
+      TraceKitStub.returns({stack: [{url: 'http://host3/'}, {url: 'http://host3/'}]});
+      Raven.captureMessage('Capture!');
+      assert.isTrue(Raven._send.calledOnce);
+    });
+
+    it('should handle empty `ignoreUrls`', function() {
+      this.sinon.stub(Raven, '_send');
+      var TraceKitStub = this.sinon.stub(TraceKit, 'computeStackTrace');
+
+      Raven._globalOptions.ignoreUrls = [];
+      TraceKitStub.returns({
+        stack: [{url: 'http://example.com'}, {url: 'http://example.com'}]
+      });
+      Raven.captureMessage('Capture!');
+      assert.isTrue(Raven._send.calledOnce);
+    });
+
     describe('synthetic traces', function() {
       function assertSynthetic(frames) {
         // Raven.captureMessage

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2670,13 +2670,13 @@ describe('Raven (public API)', function() {
       Raven._globalOptions.whitelistUrls = joinRegExp([/.+?host1.+/, /.+?host2.+/]);
       TraceKitStub.returns({stack: [{url: 'http://host1/'}, {url: 'http://host1/'}]});
       Raven.captureMessage('Capture!');
-      assert.equal(Raven._send.callCount, 1);
+      assert.isTrue(Raven._send.calledOnce);
       TraceKitStub.returns({stack: [{url: 'http://host2/'}, {url: 'http://host2/'}]});
       Raven.captureMessage('Also capture!');
-      assert.equal(Raven._send.callCount, 2);
+      assert.isTrue(Raven._send.calledTwice);
       TraceKitStub.returns({stack: [{url: 'http://host3/'}, {url: 'http://host3/'}]});
       Raven.captureMessage('Do not capture!');
-      assert.equal(Raven._send.callCount, 2);
+      assert.isTrue(Raven._send.calledTwice);
     });
 
     it('should handle empty `whitelistUrls`', function() {


### PR DESCRIPTION
resolves #774

- `captureMessage` will now respect ignoreUrls/whitelistUrls
- An error will always be generated in `captureMessage`. The stack trace of this error will be used to test the file url and see if it matches ignoreUrls/whitelistUrls.
   - The error will still only be added to the payload if the configurations specifies this
- Added tests
- Updated docs to reflect the change
