### PR TITLE
bug: Check if stack is available before reading url for ignoreUrl

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -453,7 +453,7 @@ Raven.prototype = {
     // stack[0] is `throw new Error(msg)` call itself, we are interested in the frame that was just before that, stack[1]
     var initialCall = stack.stack[1];
 
-    var fileurl = initialCall.url || '';
+    var fileurl = (initialCall && initialCall.url) || '';
 
     if (
       !!this._globalOptions.ignoreUrls.test &&


### PR DESCRIPTION
This fixes the behavior on Safari/Android, as our tests use eval, which is right now "sliiiiiightly off", per https://github.com/getsentry/raven-js/issues/824

cc @HeroProtagonist just for a good measure :)