### PR TITLE
Breadcrumbs replace state #588

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1285,26 +1285,23 @@ Raven.prototype = {
         }
       };
 
-      fill(
-        history,
-        'pushState',
-        function(origPushState) {
-          // note history.pushState.length is 0; intentionally not declaring
-          // params to preserve 0 arity
-          return function(/* state, title, url */) {
-            var url = arguments.length > 2 ? arguments[2] : undefined;
+      var historyReplacementFunction = function(origHistFunction) {
+        // note history.pushState.length is 0; intentionally not declaring
+        // params to preserve 0 arity
+        return function(/* state, title, url */) {
+          var url = arguments.length > 2 ? arguments[2] : undefined;
 
-            // url argument is optional
-            if (url) {
-              // coerce to string (this is what pushState does)
-              self._captureUrlChange(self._lastHref, url + '');
-            }
+          // url argument is optional
+          if (url) {
+            // coerce to string (this is what pushState does)
+            self._captureUrlChange(self._lastHref, url + '');
+          }
 
-            return origPushState.apply(this, arguments);
-          };
-        },
-        wrappedBuiltIns
-      );
+          return origHistFunction.apply(this, arguments);
+        };
+      };
+
+      fill(history, 'pushState', historyReplacementFunction, wrappedBuiltIns);
     }
 
     if (autoBreadcrumbs.console && 'console' in _window && console.log) {

--- a/src/raven.js
+++ b/src/raven.js
@@ -1272,8 +1272,12 @@ Raven.prototype = {
     // borrowed from: https://github.com/angular/angular.js/pull/13945/files
     var chrome = _window.chrome;
     var isChromePackagedApp = chrome && chrome.app && chrome.app.runtime;
-    var hasPushState = !isChromePackagedApp && _window.history && history.pushState;
-    if (autoBreadcrumbs.location && hasPushState) {
+    var hasPushAndReplaceState =
+      !isChromePackagedApp &&
+      _window.history &&
+      history.pushState &&
+      history.replaceState;
+    if (autoBreadcrumbs.location && hasPushAndReplaceState) {
       // TODO: remove onpopstate handler on uninstall()
       var oldOnPopState = _window.onpopstate;
       _window.onpopstate = function() {
@@ -1302,6 +1306,7 @@ Raven.prototype = {
       };
 
       fill(history, 'pushState', historyReplacementFunction, wrappedBuiltIns);
+      fill(history, 'replaceState', historyReplacementFunction, wrappedBuiltIns);
     }
 
     if (autoBreadcrumbs.console && 'console' in _window && console.log) {

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -1205,9 +1205,9 @@ describe('integration', function() {
 
           // can't call history.back() because it will change url of parent document
           // (e.g. document running mocha) ... instead just "emulate" a back button
-          // press by calling replaceState + onpopstate manually
+          // press by calling replaceState
           history.replaceState({}, '', '/bar?a=1#fragment');
-          window.onpopstate();
+
           done();
         },
         function() {

--- a/test/integration/test.js
+++ b/test/integration/test.js
@@ -1186,7 +1186,7 @@ describe('integration', function() {
       );
     });
 
-    it('should record history.[pushState|back] changes as navigation breadcrumbs', function(
+    it('should record history.[pushState|replaceState] changes as navigation breadcrumbs', function(
       done
     ) {
       var iframe = this.iframe;


### PR DESCRIPTION
resolves #588

- Pulled out logic to fill a history function so it could be reused with `replaceState`
- Updated test, by removing the `window.onpopstate();` line it tests both filled history functions. Is that test sufficient?
