### PR TITLE
Handle ErrorEvent in captureException

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -393,8 +393,11 @@ Raven.prototype = {
      * @return {Raven}
      */
   captureException: function(ex, options) {
-    // If not an Error is passed through, recall as a message instead
-    if (!isError(ex)) {
+    // Cases for sending ex as a message, rather than an exception
+    const isNotError = !isError(ex);
+    const isErrorEventWithoutError = isErrorEvent(ex) && !ex.error;
+
+    if (isNotError || isErrorEventWithoutError) {
       return this.captureMessage(
         ex,
         objectMerge(
@@ -407,10 +410,8 @@ Raven.prototype = {
       );
     }
 
-    // Get actual error out of ErrorEvents
-    if (isErrorEvent(ex)) {
-      ex = ex.error;
-    }
+    // Get actual Error from ErrorEvent
+    if (isErrorEvent(ex)) ex = ex.error;
 
     // Store the raw exception object for potential debugging and introspection
     this._lastCapturedException = ex;

--- a/src/raven.js
+++ b/src/raven.js
@@ -394,8 +394,8 @@ Raven.prototype = {
      */
   captureException: function(ex, options) {
     // Cases for sending ex as a message, rather than an exception
-    const isNotError = !isError(ex);
-    const isErrorEventWithoutError = isErrorEvent(ex) && !ex.error;
+    var isNotError = !isError(ex);
+    var isErrorEventWithoutError = isErrorEvent(ex) && !ex.error;
 
     if (isNotError || isErrorEventWithoutError) {
       return this.captureMessage(

--- a/src/raven.js
+++ b/src/raven.js
@@ -395,9 +395,10 @@ Raven.prototype = {
   captureException: function(ex, options) {
     // Cases for sending ex as a message, rather than an exception
     var isNotError = !isError(ex);
+    var isNotErrorEvent = !isErrorEvent(ex);
     var isErrorEventWithoutError = isErrorEvent(ex) && !ex.error;
 
-    if (isNotError || isErrorEventWithoutError) {
+    if ((isNotError && isNotErrorEvent) || isErrorEventWithoutError) {
       return this.captureMessage(
         ex,
         objectMerge(

--- a/src/raven.js
+++ b/src/raven.js
@@ -8,7 +8,7 @@ var utils = require('./utils');
 var isError = utils.isError;
 var isObject = utils.isObject;
 var isObject = utils.isObject;
-var isError = utils.isError;
+var isErrorEvent = utils.isErrorEvent;
 var isUndefined = utils.isUndefined;
 var isFunction = utils.isFunction;
 var isString = utils.isString;
@@ -405,6 +405,11 @@ Raven.prototype = {
           options
         )
       );
+    }
+
+    // Get actual error out of ErrorEvents
+    if (isErrorEvent(ex)) {
+      ex = ex.error;
     }
 
     // Store the raw exception object for potential debugging and introspection

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,9 +17,15 @@ function isError(value) {
       return true;
     case '[object DOMException]':
       return true;
+    case '[object ErrorEvent]':
+      return true;
     default:
       return value instanceof Error;
   }
+}
+
+function isErrorEvent(value) {
+  return {}.toString.call(value) === '[object ErrorEvent]';
 }
 
 function isUndefined(what) {
@@ -348,6 +354,7 @@ function fill(obj, name, replacement, track) {
 module.exports = {
   isObject: isObject,
   isError: isError,
+  isErrorEvent: isErrorEvent,
   isUndefined: isUndefined,
   isFunction: isFunction,
   isString: isString,

--- a/src/utils.js
+++ b/src/utils.js
@@ -17,8 +17,6 @@ function isError(value) {
       return true;
     case '[object DOMException]':
       return true;
-    case '[object ErrorEvent]':
-      return true;
     default:
       return value instanceof Error;
   }

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2770,7 +2770,7 @@ describe('Raven (public API)', function() {
   });
 
   describe('.captureException', function() {
-    it.only('should treat ErrorEvents similarly to Errors', function() {
+    it('should treat ErrorEvents similarly to Errors', function() {
       var error = new ErrorEvent('crap', {error: new Error('crap')});
       this.sinon.stub(Raven, 'isSetup').returns(true);
       this.sinon.stub(Raven, '_handleStackInfo');
@@ -2778,7 +2778,7 @@ describe('Raven (public API)', function() {
       assert.isTrue(Raven._handleStackInfo.calledOnce);
     });
 
-    it.only('should send ErrorEvents without Errors as messages', function() {
+    it('should send ErrorEvents without Errors as messages', function() {
       var error = new ErrorEvent('crap');
       this.sinon.stub(Raven, 'isSetup').returns(true);
       this.sinon.stub(Raven, 'captureMessage');
@@ -2786,7 +2786,7 @@ describe('Raven (public API)', function() {
       assert.isTrue(Raven.captureMessage.calledOnce);
     });
 
-    it.only('should send non-Errors as messages', function() {
+    it('should send non-Errors as messages', function() {
       this.sinon.stub(Raven, 'isSetup').returns(true);
       this.sinon.stub(Raven, 'captureMessage');
       Raven.captureException({}, {foo: 'bar'});

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2770,6 +2770,29 @@ describe('Raven (public API)', function() {
   });
 
   describe('.captureException', function() {
+    it.only('should treat ErrorEvents similarly to Errors', function() {
+      var error = new ErrorEvent('crap', {error: new Error('crap')});
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_handleStackInfo');
+      Raven.captureException(error, {foo: 'bar'});
+      assert.isTrue(Raven._handleStackInfo.calledOnce);
+    });
+
+    it.only('should send ErrorEvents without Errors as messages', function() {
+      var error = new ErrorEvent('crap');
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, 'captureMessage');
+      Raven.captureException(error, {foo: 'bar'});
+      assert.isTrue(Raven.captureMessage.calledOnce);
+    });
+
+    it.only('should send non-Errors as messages', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, 'captureMessage');
+      Raven.captureException({}, {foo: 'bar'});
+      assert.isTrue(Raven.captureMessage.calledOnce);
+    });
+
     it('should call handleStackInfo', function() {
       var error = new Error('crap');
       this.sinon.stub(Raven, 'isSetup').returns(true);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -11,6 +11,7 @@ var isString = utils.isString;
 var isObject = utils.isObject;
 var isEmptyObject = utils.isEmptyObject;
 var isError = utils.isError;
+var isErrorEvent = utils.isErrorEvent;
 var wrappedCallback = utils.wrappedCallback;
 var joinRegExp = utils.joinRegExp;
 var objectMerge = utils.objectMerge;
@@ -62,6 +63,13 @@ describe('utils', function() {
     it('should work as advertised', function() {
       assert.isTrue(isEmptyObject({}));
       assert.isFalse(isEmptyObject({foo: 1}));
+    });
+  });
+
+  describe('isErrorEvent', function() {
+    it('should work as advertised', function() {
+      assert.isFalse(isErrorEvent(new Error()));
+      assert.isTrue(isErrorEvent(new ErrorEvent('')));
     });
   });
 


### PR DESCRIPTION
This PR makes `captureException` handle `ErrorEvent` objects better. Resolves [1008](https://github.com/getsentry/raven-js/issues/1008).