### PR TITLE
Make showReportDialog's option paramerter optional

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -234,7 +234,7 @@ declare module Raven {
         setShouldSendCallback(data: any, orig?: any): RavenStatic;
 
         /** Show Sentry user feedback dialog */
-        showReportDialog(options: Object): void;
+        showReportDialog(options?: Object): void;
 
         /*
          * Configure Raven DSN


### PR DESCRIPTION
Typescript complains if you leave the option param empty.

Since the code already checks the `lastEventId` if its not specified, and the parameter is omitted in the docs, it makes sense to update the typings to show that the parameter is optional.