### PR TITLE
test: Run ErrorEvent tests only when its available

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,12 @@ $ npm run test:karma:integration
 
 Then visit: http://localhost:9876/debug.html
 
+Keep in mind that in order for in-browser tests to work correctly, they need to be bundled first:
+
+```bash
+$ grunt build.test
+```
+
 If you want to make sure that your changes will fit in our 10kB budget:
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "lint": "eslint .",
     "precommit": "lint-staged",
     "publish": "npm run test && grunt publish",
-    "test": "npm run lint && npm run test:size && grunt build.test && npm run test:unit && npm run test:integration && npm run test:typescript",
+    "test": "npm run lint && grunt build.test && npm run test:unit && npm run test:integration && npm run test:typescript",
     "test:karma:unit": "karma start karma.unit.config.js",
     "test:karma:integration": "karma start karma.integration.config.js ",
     "test:karma:sauce": "karma start karma.sauce.config.js ",
@@ -27,7 +27,7 @@
     "test:integration": "npm run test:karma:integration -- --single-run",
     "test:typescript": "tsc --noEmit --noImplicitAny typescript/raven-tests.ts",
     "test:ci": "npm run lint && grunt test:ci && npm run test:karma:sauce",
-    "test:size": "grunt dist && bundlesize"
+    "test:size": "grunt dist && bundlesize && git checkout -- dist/"
   },
   "devDependencies": {
     "bluebird": "^3.4.1",

--- a/src/utils.js
+++ b/src/utils.js
@@ -23,7 +23,7 @@ function isError(value) {
 }
 
 function isErrorEvent(value) {
-  return {}.toString.call(value) === '[object ErrorEvent]';
+  return supportsErrorEvent() && {}.toString.call(value) === '[object ErrorEvent]';
 }
 
 function isUndefined(what) {
@@ -41,6 +41,15 @@ function isString(what) {
 function isEmptyObject(what) {
   for (var _ in what) return false; // eslint-disable-line guard-for-in, no-unused-vars
   return true;
+}
+
+function supportsErrorEvent() {
+  try {
+    new ErrorEvent(''); // eslint-disable-line no-new
+    return true;
+  } catch (e) {
+    return false;
+  }
 }
 
 function wrappedCallback(callback) {
@@ -357,6 +366,7 @@ module.exports = {
   isFunction: isFunction,
   isString: isString,
   isEmptyObject: isEmptyObject,
+  supportsErrorEvent: supportsErrorEvent,
   wrappedCallback: wrappedCallback,
   each: each,
   objectMerge: objectMerge,

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -20,7 +20,9 @@ _Raven.prototype._getUuid = function() {
   return 'abc123';
 };
 
-var joinRegExp = require('../src/utils').joinRegExp;
+var utils = require('../src/utils');
+var joinRegExp = utils.joinRegExp;
+var supportsErrorEvent = utils.supportsErrorEvent;
 
 // window.console must be stubbed in for browsers that don't have it
 if (typeof window.console === 'undefined') {
@@ -2770,21 +2772,23 @@ describe('Raven (public API)', function() {
   });
 
   describe('.captureException', function() {
-    it('should treat ErrorEvents similarly to Errors', function() {
-      var error = new ErrorEvent('pickleRick', {error: new Error('pickleRick')});
-      this.sinon.stub(Raven, 'isSetup').returns(true);
-      this.sinon.stub(Raven, '_handleStackInfo');
-      Raven.captureException(error, {foo: 'bar'});
-      assert.isTrue(Raven._handleStackInfo.calledOnce);
-    });
+    if (supportsErrorEvent()) {
+      it('should treat ErrorEvents similarly to Errors', function() {
+        var error = new ErrorEvent('pickleRick', {error: new Error('pickleRick')});
+        this.sinon.stub(Raven, 'isSetup').returns(true);
+        this.sinon.stub(Raven, '_handleStackInfo');
+        Raven.captureException(error, {foo: 'bar'});
+        assert.isTrue(Raven._handleStackInfo.calledOnce);
+      });
 
-    it('should send ErrorEvents without Errors as messages', function() {
-      var error = new ErrorEvent('pickleRick');
-      this.sinon.stub(Raven, 'isSetup').returns(true);
-      this.sinon.stub(Raven, 'captureMessage');
-      Raven.captureException(error, {foo: 'bar'});
-      assert.isTrue(Raven.captureMessage.calledOnce);
-    });
+      it('should send ErrorEvents without Errors as messages', function() {
+        var error = new ErrorEvent('pickleRick');
+        this.sinon.stub(Raven, 'isSetup').returns(true);
+        this.sinon.stub(Raven, 'captureMessage');
+        Raven.captureException(error, {foo: 'bar'});
+        assert.isTrue(Raven.captureMessage.calledOnce);
+      });
+    }
 
     it('should send non-Errors as messages', function() {
       this.sinon.stub(Raven, 'isSetup').returns(true);

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -12,6 +12,7 @@ var isObject = utils.isObject;
 var isEmptyObject = utils.isEmptyObject;
 var isError = utils.isError;
 var isErrorEvent = utils.isErrorEvent;
+var supportsErrorEvent = utils.supportsErrorEvent;
 var wrappedCallback = utils.wrappedCallback;
 var joinRegExp = utils.joinRegExp;
 var objectMerge = utils.objectMerge;
@@ -66,12 +67,14 @@ describe('utils', function() {
     });
   });
 
-  describe('isErrorEvent', function() {
-    it('should work as advertised', function() {
-      assert.isFalse(isErrorEvent(new Error()));
-      assert.isTrue(isErrorEvent(new ErrorEvent('')));
+  if (supportsErrorEvent()) {
+    describe('isErrorEvent', function() {
+      it('should work as advertised', function() {
+        assert.isFalse(isErrorEvent(new Error()));
+        assert.isTrue(isErrorEvent(new ErrorEvent('')));
+      });
     });
-  });
+  }
 
   describe('isError', function() {
     function testErrorFromDifferentContext(createError) {


### PR DESCRIPTION
Ref: https://github.com/getsentry/raven-js/pull/1094

It wasn't easy to spot this issue without running tests on SauceLabs, which is not possible for PRs coming from forks.

Note: We don't use `ErrorEvent` anywhere in the code, just stringify it to `[object ErrorEvent]`, therefore I believe it's safe to do something like this here. I'll add a note about it to the code after approval to not retrigger Travis build now.

It's the same thing that I had to deal with here: https://github.com/getsentry/raven-js/commit/5bbb0aa5b36052ad5a4924f0824536ac2591bcb0#diff-b95555915e733bd13a149f7161fd9010

ErrorEvent API is sliiightly off on old browsers, and they are not constructors, therefore we cannot call `new` on them – https://developer.mozilla.org/en-US/docs/Web/API/ErrorEvent