### PR TITLE
Disable automatic breadcrumbs #782

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -209,7 +209,7 @@ Those configuration options are documented below:
     Enables/disables automatic collection of breadcrumbs. Possible values are:
 
     * `true` (default)
-    * `false` - all automatic breadcrumb collection disabled
+    * `false` - all breadcrumb collection disabled
     * A dictionary of individual breadcrumb types that can be enabled/disabled:
 
     .. code-block:: javascript

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -219,6 +219,7 @@ Those configuration options are documented below:
             'console': false,  // console logging
             'dom': true,       // DOM interactions, i.e. clicks/typing
             'location': false  // url changes, including pushState/popState
+            'sentry': true     // sentry events
         }
 
 .. describe:: maxBreadcrumbs

--- a/src/raven.js
+++ b/src/raven.js
@@ -178,7 +178,8 @@ Raven.prototype = {
       xhr: true,
       console: true,
       dom: true,
-      location: true
+      location: true,
+      sentry: true
     };
 
     var autoBreadcrumbs = globalOptions.autoBreadcrumbs;
@@ -1812,7 +1813,10 @@ Raven.prototype = {
     var exception = data.exception && data.exception.values[0];
 
     // only capture 'sentry' breadcrumb is autoBreadcrumbs is truthy
-    if (this._globalOptions.autoBreadcrumbs) {
+    if (
+      this._globalOptions.autoBreadcrumbs &&
+      this._globalOptions.autoBreadcrumbs.sentry
+    ) {
       this.captureBreadcrumb({
         category: 'sentry',
         message: exception

--- a/src/raven.js
+++ b/src/raven.js
@@ -1810,14 +1810,18 @@ Raven.prototype = {
     }
 
     var exception = data.exception && data.exception.values[0];
-    this.captureBreadcrumb({
-      category: 'sentry',
-      message: exception
-        ? (exception.type ? exception.type + ': ' : '') + exception.value
-        : data.message,
-      event_id: data.event_id,
-      level: data.level || 'error' // presume error unless specified
-    });
+
+    // only capture 'sentry' breadcrumb is autoBreadcrumbs is truthy
+    if (this._globalOptions.autoBreadcrumbs) {
+      this.captureBreadcrumb({
+        category: 'sentry',
+        message: exception
+          ? (exception.type ? exception.type + ': ' : '') + exception.value
+          : data.message,
+        event_id: data.event_id,
+        level: data.level || 'error' // presume error unless specified
+      });
+    }
 
     var url = this._globalEndpoint;
     (globalOptions.transport || this._makeRequest).call(this, {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -802,7 +802,7 @@ describe('globals', function() {
       });
     });
 
-    it("should create and append 'sentry' breadcrumb when `_globalOptions.autoBreadcrumbs` is truthy", function() {
+    it("should create and append 'sentry' breadcrumb when `_globalOptions.autoBreadcrumbs.sentry` is truthy", function() {
       this.sinon.stub(Raven, 'isSetup').returns(true);
       this.sinon.stub(Raven, '_makeRequest');
       this.sinon.stub(Raven, '_getHttpData').returns({
@@ -814,7 +814,9 @@ describe('globals', function() {
       Raven._globalOptions = {
         logger: 'javascript',
         maxMessageLength: 100,
-        autoBreadcrumbs: true
+        autoBreadcrumbs: {
+          sentry: true
+        }
       };
       Raven._breadcrumbs = [
         {
@@ -904,7 +906,7 @@ describe('globals', function() {
       ]);
     });
 
-    it("should not create nor append 'sentry' breadcrumb when `_globalOptions.autoBreadcrumbs` is falsy", function() {
+    it("should not create nor append 'sentry' breadcrumb when `_globalOptions.autoBreadcrumbs.sentry` is falsy", function() {
       this.sinon.stub(Raven, 'isSetup').returns(true);
       this.sinon.stub(Raven, '_makeRequest');
       this.sinon.stub(Raven, '_getHttpData').returns({
@@ -2223,7 +2225,8 @@ describe('Raven (public API)', function() {
           xhr: true,
           console: true,
           dom: true,
-          location: true
+          location: true,
+          sentry: true
         });
       });
 
@@ -2244,6 +2247,7 @@ describe('Raven (public API)', function() {
           xhr: true,
           console: true,
           dom: true,
+          sentry: true,
           location: false /* ! */
         });
       });

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -802,7 +802,7 @@ describe('globals', function() {
       });
     });
 
-    it("should create and append 'sentry' breadcrumb", function() {
+    it("should create and append 'sentry' breadcrumb when `_globalOptions.autoBreadcrumbs` is truthy", function() {
       this.sinon.stub(Raven, 'isSetup').returns(true);
       this.sinon.stub(Raven, '_makeRequest');
       this.sinon.stub(Raven, '_getHttpData').returns({
@@ -813,7 +813,8 @@ describe('globals', function() {
       Raven._globalProject = '2';
       Raven._globalOptions = {
         logger: 'javascript',
-        maxMessageLength: 100
+        maxMessageLength: 100,
+        autoBreadcrumbs: true
       };
       Raven._breadcrumbs = [
         {
@@ -901,6 +902,41 @@ describe('globals', function() {
           level: 'error'
         }
       ]);
+    });
+
+    it("should not create nor append 'sentry' breadcrumb when `_globalOptions.autoBreadcrumbs` is falsy", function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_makeRequest');
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100,
+        autoBreadcrumbs: false
+      };
+
+      Raven._send({message: 'bar'});
+
+      assert.deepEqual(Raven._breadcrumbs, []);
+
+      Raven._send({message: 'foo', level: 'warning'});
+      assert.deepEqual(Raven._breadcrumbs, []);
+
+      Raven._send({
+        exception: {
+          values: [
+            {
+              type: 'ReferenceError',
+              value: 'foo is not defined'
+            }
+          ]
+        }
+      });
+      assert.deepEqual(Raven._breadcrumbs, []);
     });
 
     it('should build a good data payload with a User', function() {


### PR DESCRIPTION
resolves #782 
- wrap `sentry`  breadcrumbs in conditional to respect when `_globalOptions.autoBreadcrumbs` is falsy
- update tests and docs to reflect disabling automatic breadcrumb collection