### PR TITLE
fix: Update RegExp to work with updated CodePush paths

### DIFF
--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -24,7 +24,7 @@ var wrappedCallback = require('../src/utils').wrappedCallback;
 // Example React Native path format (iOS):
 // /var/containers/Bundle/Application/{DEVICE_ID}/HelloWorld.app/main.jsbundle
 
-var PATH_STRIP_RE = /^.*\/[^\.]+(\.app|CodePush)/;
+var PATH_STRIP_RE = /^.*\/[^\.]+(\.app|CodePush|.*(?=\/))/;
 var stringify = require('../vendor/json-stringify-safe/stringify');
 var FATAL_ERROR_KEY = '--rn-fatal--';
 var ASYNC_STORAGE_KEY = '--raven-js-global-error-payload--';

--- a/test/plugins/react-native.test.js
+++ b/test/plugins/react-native.test.js
@@ -122,6 +122,12 @@ describe('React Native plugin', function() {
                     lineno: 12,
                     colno: 13,
                     function: 'lol'
+                  },
+                  {
+                      filename: 'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/5c5f606315aa4ab04ac04068b3149b785e5e487e9081bfc25b6e44a353182a5e/file3.js',
+                      lineno: 12,
+                      colno: 13,
+                      'function': 'lol'
                   }
                 ]
               }
@@ -135,6 +141,7 @@ describe('React Native plugin', function() {
       var frames = data.exception.values[0].stacktrace.frames;
       assert.equal(frames[0].filename, '/file1.js');
       assert.equal(frames[1].filename, '/file2.js');
+      assert.equal(frames[2].filename, '/file3.js');
     });
   });
 


### PR DESCRIPTION
ignoreErrors, includePaths, ignoreUrls, whitelistUrls now accept arrays of RegExp and functions.

The major change is that ignoreErrors now stay as array after config(), and the configuration must always be an Array. Which I think makes for even more consistent API.

joinRegExp is wrapped by optimizeFilters. And the test must be done using using matchFiltters function.

The provided test function will be tested before string and RegExp.
Call the check with matchFilters(ignoreUrls, typeString, type, message, fileurl,...), then test function will be called as function(typeString, type, message, fileurl, ...) (I keep typeString as first parameter for convenient).

Noted that I didn't pass any extra parameter to includePaths, ignoreUrls, whitelistUrls but I made them accept function anyway, for consistency.