### PR TITLE
ci: Update Safari to 11.0 (OSX) on SauceLabs

### DIFF
--- a/karma.sauce.config.js
+++ b/karma.sauce.config.js
@@ -35,7 +35,7 @@ var customLaunchers = {
     base: 'SauceLabs',
     browserName: 'safari',
     platform: 'OS X 10.12',
-    version: '10.0'
+    version: '11.0'
   },
   sl_ios: {
     base: 'SauceLabs',


### PR DESCRIPTION
Because I'm too stupid to not forget something and do this in one PR...