### PR TITLE
fix: Typescript typings

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -265,8 +265,8 @@ declare module Raven {
             sentry_client: string;
             sentry_key: string;
         };
-        onSuccess: () => void;
-        onError: (error: Error & { request: XMLHttpRequest }) => void;
+        onSuccess(): void;
+        onError(error: Error & { request?: XMLHttpRequest }): void;
     }
 
     interface RavenPlugin {

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -236,13 +236,13 @@ declare module Raven {
         isSetup(): boolean;
 
         /** Specify a function that allows mutation of the data payload right before being sent to Sentry. */
-        setDataCallback(data: any, orig?: any): RavenStatic;
+        setDataCallback(callback: RavenCallback): RavenStatic;
 
         /** Specify a callback function that allows you to mutate or filter breadcrumbs when they are captured. */
-        setBreadcrumbCallback(data: any, orig?: any): RavenStatic;
+        setBreadcrumbCallback(callback: RavenCallback): RavenStatic;
 
         /** Specify a callback function that allows you to apply your own filters to determine if the message should be sent to Sentry. */
-        setShouldSendCallback(data: any, orig?: any): RavenStatic;
+        setShouldSendCallback(callback: RavenCallback): RavenStatic;
 
         /** Show Sentry user feedback dialog */
         showReportDialog(options?: Object): void;
@@ -254,6 +254,8 @@ declare module Raven {
          */
         setDSN(dsn: string): void;
     }
+
+    type RavenCallback = (data: any, orig: (data: any) => any) => any | void;
 
     interface RavenTransportOptions {
         url: string;

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -264,7 +264,7 @@ declare module Raven {
             sentry_key: string;
         };
         onSuccess: () => void;
-        onFailure: () => void;
+        onError: (error: Error & { request: XMLHttpRequest }) => void;
     }
 
     interface RavenPlugin {

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -82,6 +82,13 @@ declare module Raven {
          * A sampling rate to apply to events. A value of 0.0 will send no events, and a value of 1.0 will send all events (default).
          */
         sampleRate?: number;
+
+        /**
+         * By default, Raven.js attempts to suppress duplicate captured errors and messages that occur back-to-back. 
+         * Such events are often triggered by rogue code (e.g. from a `setInterval` callback in a browser extension), 
+         * are not actionable, and eat up your event quota.
+         */
+        allowDuplicates?: boolean
     }
 
     interface RavenInstrumentationOptions {
@@ -236,13 +243,13 @@ declare module Raven {
         isSetup(): boolean;
 
         /** Specify a function that allows mutation of the data payload right before being sent to Sentry. */
-        setDataCallback(callback: RavenCallback): RavenStatic;
+        setDataCallback(callback?: RavenCallback): RavenStatic;
 
         /** Specify a callback function that allows you to mutate or filter breadcrumbs when they are captured. */
-        setBreadcrumbCallback(callback: RavenCallback): RavenStatic;
+        setBreadcrumbCallback(callback?: RavenCallback): RavenStatic;
 
         /** Specify a callback function that allows you to apply your own filters to determine if the message should be sent to Sentry. */
-        setShouldSendCallback(callback: RavenCallback): RavenStatic;
+        setShouldSendCallback(callback?: RavenCallback): RavenStatic;
 
         /** Show Sentry user feedback dialog */
         showReportDialog(options?: Object): void;
@@ -255,7 +262,7 @@ declare module Raven {
         setDSN(dsn: string): void;
     }
 
-    type RavenCallback = (data: any, orig: (data: any) => any) => any | void;
+    type RavenCallback = (data: any, orig?: (data: any) => any) => any | void;
 
     interface RavenTransportOptions {
         url: string;


### PR DESCRIPTION
Before submitting a pull request, please verify the following:

* [x] If you've added code that should be tested, please add tests.
* [x] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [x] Ensure your code lints and the test suite passes (npm test).

I tried applying the hack described here - https://github.com/getsentry/raven-js/issues/339#issuecomment-340134753 - in my angular (typescript) application, when I noticed that some types don't match.

- I changed onFailure to onError and added correct parameter
- I fixed the callback types for setXYZCallback

I went through the implementation and hope that I've renamed / adjusted everything correctly. Would be cool if you could merge and release these fixes soon. Thx