### PR TITLE
fix: Fix toString usage for function wrapped using wrap method

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -364,10 +364,10 @@ Raven.prototype = {
     wrapped.prototype = func.prototype;
 
     func.__raven_wrapper__ = wrapped;
-    // Signal that this function has been wrapped already
-    // for both debugging and to prevent it to being wrapped twice
+    // Signal that this function has been wrapped/filled already
+    // for both debugging and to prevent it to being wrapped/filled twice
     wrapped.__raven__ = true;
-    wrapped.__inner__ = func;
+    wrapped.__orig__ = func;
 
     return wrapped;
   },
@@ -949,7 +949,7 @@ Raven.prototype = {
     // eslint-disable-next-line no-extend-native
     Function.prototype.toString = function() {
       if (typeof this === 'function' && this.__raven__) {
-        return self._originalFunctionToString.apply(this.__orig_method__, arguments);
+        return self._originalFunctionToString.apply(this.__orig__, arguments);
       }
       return self._originalFunctionToString.apply(this, arguments);
     };

--- a/src/utils.js
+++ b/src/utils.js
@@ -358,7 +358,7 @@ function fill(obj, name, replacement, track) {
   var orig = obj[name];
   obj[name] = replacement(orig);
   obj[name].__raven__ = true;
-  obj[name].__orig_method__ = orig;
+  obj[name].__orig__ = orig;
   if (track) {
     track.push([obj, name, orig]);
   }


### PR DESCRIPTION
Fixes: https://github.com/getsentry/raven-js/issues/1132#issuecomment-344626168

It broke, because `zone.js` has some code that's triggered for IE/Edge only, and it modified calls context – https://github.com/angular/zone.js/blob/dcc285aab37bdd90b6d7133fc73045100861c61c/lib/browser/event-target.ts#L67-L97

This caused all `wrap` calls to be passed through it, and called `toString` on them – https://github.com/angular/zone.js/blob/dcc285aab37bdd90b6d7133fc73045100861c61c/lib/browser/event-target.ts#L82 Because of that, `function wrapped`, which we return from `wrap` calls was given as a context to `Function.prototype.toString.apply`, as it also contains `__raven__` flag set to `true`.`

The problem was, that all functions wrapped with either `wrap` and `fill` had mentioned `__raven__` flags, but original function on one of them was called `__inner__` and one `__orig_method__`. This was untraceable with tests, as it's just an odd edge case, where `zone.js` overrides all API methods and then `core.js` polyfills some of them.

Oh well... ¯\_(ツ)_/¯