### PR TITLE
Improve support for Windows 10 webview URLs in the stack trace

### DIFF
--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -370,7 +370,7 @@ TraceKit.computeStackTrace = (function computeStackTraceWrapper() {
 
     var chrome = /^\s*at (.*?) ?\(((?:file|https?|blob|chrome-extension|native|eval|webpack|<anonymous>|[a-z]:|\/).*?)(?::(\d+))?(?::(\d+))?\)?\s*$/i,
       gecko = /^\s*(.*?)(?:\((.*?)\))?(?:^|@)((?:file|https?|blob|chrome|webpack|resource|\[native).*?|[^@]*bundle)(?::(\d+))?(?::(\d+))?\s*$/i,
-      winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx|https?|webpack|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
+      winjs = /^\s*at (?:((?:\[object object\])?.+) )?\(?((?:file|ms-appx(?:-web)|https?|webpack|blob):.*?):(\d+)(?::(\d+))?\)?\s*$/i,
       // Used to additionally parse URL/line/column from eval frames
       geckoEval = /(\S+) line (\d+)(?: > eval line \d+)* > eval/i,
       chromeEval = /\((\S*)(?::(\d+))(?::(\d+))\)/,


### PR DESCRIPTION
In Windows 10, webview urls will start with either ms-appx in local mode, or ms-appx-web in remote mode. In Cordova projects targeting Windows 10, the default is ms-appx-web. See the WindowsDefaultUriPrefix section on this page for more info: https://github.com/apache/cordova-windows/blob/master/cordova-windows10.md


Before submitting a pull request, please verify the following:

* [x] If you've added code that should be tested, please add tests.
* [x] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [x] Ensure your code lints and the test suite passes (npm test).
