### PR TITLE
docs: Fix document reference for electron

### DIFF
--- a/docs/integrations/electron.rst
+++ b/docs/integrations/electron.rst
@@ -37,7 +37,7 @@ And now ``renderer process``, which uses the Browser SDK:
     });
 
 This configuration will also take care of unhandled Promise rejections, which can be handled in various ways. By default, Electron uses standard JS API.
-To learn more about handling promises, refer to :doc:`Promises <../usage#promises>` documentation.
+To learn more about handling promises, refer to :doc:`Promises <raven-js-promises>` documentation.
 
 Sending environment information
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -303,6 +303,8 @@ And set an ``Access-Control-Allow-Origin`` HTTP header on that file.
 .. note:: both of these steps need to be done or your scripts might not
    even get executed
 
+.. _raven-js-promises:
+
 Promises
 --------
 


### PR DESCRIPTION
Per: http://udig.refractions.net/files/docs/latest/user/docguide/sphinxSyntax.html