### PR TITLE
check for both stacktraces before calling 'isSameStacktrace'

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -310,6 +310,13 @@ function isOnlyOneTruthy(a, b) {
 }
 
 /**
+ * Returns true if both parameters are undefined
+ */
+function isBothUndefined(a, b) {
+  return isUndefined(a) && isUndefined(b);
+}
+
+/**
  * Returns true if the two input exception interfaces have the same content
  */
 function isSameException(ex1, ex2) {
@@ -319,6 +326,9 @@ function isSameException(ex1, ex2) {
   ex2 = ex2.values[0];
 
   if (ex1.type !== ex2.type || ex1.value !== ex2.value) return false;
+
+  // in case both stacktraces are undefined, we can't decide so default to false
+  if (isBothUndefined(ex1.stacktrace, ex2.stacktrace)) return false;
 
   return isSameStacktrace(ex1.stacktrace, ex2.stacktrace);
 }

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -3431,6 +3431,14 @@ describe('Raven (private methods)', function() {
         data.exception.values[0].stacktrace.frames = [];
         assert.isFalse(Raven._isRepeatData(data));
       });
+
+      it('should not blown if both stacktraces are undefined', function() {
+        Raven._lastData.exception.values[0].stacktrace = undefined;
+        var data1 = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        var data2 = JSON.parse(JSON.stringify(Raven._lastData)); // copy
+        assert.isFalse(Raven._isRepeatData(data1));
+        assert.isFalse(Raven._isRepeatData(data2));
+      });
     });
   });
 });


### PR DESCRIPTION
resolve issue #1125 

1. added function in `utils.js` to check if both given objects are `undefined`. This function will be called from `isSameException` for the Exception interface where stacktrace might be missing.<br>
*Note: I've assumed that in such case, where we don't have stacktrace to check, we should return `false` so Raven will report the exception (even in the price of having duplicates)
2. added test case to simulate the situation 


Further more, after investigating issue #1125, I've found the in the function `_processException`, where the `stacktrace` object is being built, there is
```javascript
    var stacktrace;
    if(frames && frames.length){
        stacktrace = {...}
    } 
    else if(fileurl){
        stacktrace = {...}
    }
``` 
but no final `else`, which means that in this case `stacktrace` resolves to `undefined`.

I can do some change there, but I don't know what is your exact policy regading such case. So for now I did this extra check, but in my opinion, a proper handling the `stacktrace` object is better.