### PR TITLE
docs: Release Electron docs

### DIFF
--- a/docs/integrations/electron.rst
+++ b/docs/integrations/electron.rst
@@ -15,6 +15,9 @@ Both packages are available via npm.
 
     $ npm install raven raven-js --save
 
+Configuring the Client
+----------------------
+
 First, let's configure ``main process``, which uses the Node.js SDK:
 
 .. code-block:: javascript

--- a/docs/integrations/index.rst
+++ b/docs/integrations/index.rst
@@ -36,6 +36,7 @@ To install a plugin just include the plugin **after** Raven has been loaded and 
    angularjs
    angular
    backbone
+   electron
    ember
    react
    vue


### PR DESCRIPTION
Fixed `toctree` entry and added the missing header for a wizard (not used right now I believe)