### PR TITLE
Handle ErrorEvents in TraceKit

### DIFF
--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -89,7 +89,6 @@ describe('utils', function() {
     describe('isErrorEvent', function() {
       it('should work as advertised', function() {
         assert.isFalse(isErrorEvent(new Error()));
-        assert.isFalse(isError(new ErrorEvent('')));
         assert.isTrue(isErrorEvent(new ErrorEvent('')));
       });
     });
@@ -121,6 +120,11 @@ describe('utils', function() {
     it('should work as advertised', function() {
       assert.isTrue(isError(new Error()));
       assert.isTrue(isError(new ReferenceError()));
+
+      if (supportsErrorEvent()) {
+        assert.isFalse(isError(new ErrorEvent('')));
+      }
+
       assert.isTrue(isError(new RavenConfigError()));
       assert.isTrue(isError(testErrorFromDifferentContext(fromContext)));
       assert.isTrue(isError(testErrorFromDifferentContext(domException)));

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -89,6 +89,7 @@ describe('utils', function() {
     describe('isErrorEvent', function() {
       it('should work as advertised', function() {
         assert.isFalse(isErrorEvent(new Error()));
+        assert.isFalse(isError(new ErrorEvent('')));
         assert.isTrue(isErrorEvent(new ErrorEvent('')));
       });
     });

--- a/test/vendor/tracekit.test.js
+++ b/test/vendor/tracekit.test.js
@@ -2,6 +2,8 @@
 'use strict';
 
 var TraceKit = require('../../vendor/TraceKit/tracekit');
+var utils = require('../../src/utils');
+var supportsErrorEvent = utils.supportsErrorEvent;
 
 describe('TraceKit', function() {
   describe('stacktrace info', function() {
@@ -139,6 +141,20 @@ describe('TraceKit', function() {
       }
     });
 
+    if (supportsErrorEvent()) {
+      it('should handle an error event object', function() {
+        var ex = new ErrorEvent('', {
+          error: new Error('something went wrong')
+        });
+        subscriptionHandler = function(stackInfo, extra) {
+          assert.equal(stackInfo.name, 'Error');
+          assert.equal(stackInfo.message, 'something went wrong');
+        };
+        TraceKit.report.subscribe(subscriptionHandler);
+        window.onerror(undefined, undefined, testLineNo, undefined, ex);
+      });
+    }
+
     describe('with undefined arguments', function() {
       it('should pass undefined:undefined', function() {
         // this is probably not good behavior;  just writing this test to verify
@@ -151,6 +167,7 @@ describe('TraceKit', function() {
         window.onerror(undefined, undefined, testLineNo);
       });
     });
+
     describe('when no 5th argument (error object)', function() {
       it('should seperate name, message for default error types (e.g. ReferenceError)', function(
         done

--- a/test/vendor/tracekit.test.js
+++ b/test/vendor/tracekit.test.js
@@ -142,7 +142,7 @@ describe('TraceKit', function() {
     });
 
     if (supportsErrorEvent()) {
-      it('should handle an error event object', function() {
+      it("should handle error event object as 'ex' param", function() {
         var ex = new ErrorEvent('', {
           error: new Error('something went wrong')
         });
@@ -153,11 +153,23 @@ describe('TraceKit', function() {
         TraceKit.report.subscribe(subscriptionHandler);
         window.onerror(undefined, undefined, testLineNo, undefined, ex);
       });
+
+      it("should handle error event object as 'message' param", function() {
+        var message = new ErrorEvent('', {
+          message: 'something went wrong'
+        });
+        subscriptionHandler = function(stackInfo, extra) {
+          assert.equal(stackInfo.name, undefined);
+          assert.equal(stackInfo.message, 'something went wrong');
+        };
+        TraceKit.report.subscribe(subscriptionHandler);
+        window.onerror(message, undefined, testLineNo, undefined, undefined);
+      });
     }
 
     describe('with undefined arguments', function() {
       it('should pass undefined:undefined', function() {
-        // this is probably not good behavior;  just writing this test to verify
+        // this is probably not good behavior; just writing this test to verify
         // that it doesn't change unintentionally
         subscriptionHandler = function(stackInfo, extra) {
           assert.equal(stackInfo.name, undefined);

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -156,8 +156,13 @@ TraceKit.report = (function reportModuleWrapper() {
         message
       );
       processLastException();
-    } else if (ex && utils.isError(ex)) {
+    } else if (ex && (utils.isError(ex) || utils.isErrorEvent(ex))) {
       // non-string `ex` arg; attempt to extract stack trace
+
+      // If this is an ErrorEvent, get the real error from within
+      if (utils.isErrorEvent(ex)) {
+        ex = ex.error;
+      }
 
       // New chrome and blink send along a real error object
       // Let's just report that like a normal error.

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -149,15 +149,10 @@ TraceKit.report = (function reportModuleWrapper() {
     var stack = null;
 
     // If 'ex' is ErrorEvent, get real Error from inside
-    if (ex && utils.isErrorEvent(ex)) {
-      ex = ex.error;
-    } 
-
+    if (utils.isErrorEvent(ex)) ex = ex.error;
     // If 'message' is ErrorEvent, get real message from inside
-    if (message && utils.isErrorEvent(message)) {
-      message = message.message;
-    }
-
+    if (utils.isErrorEvent(message)) message = message.message;
+   
     if (lastExceptionStack) {
       TraceKit.computeStackTrace.augmentStackTraceWithInitialElement(
         lastExceptionStack,

--- a/vendor/TraceKit/tracekit.js
+++ b/vendor/TraceKit/tracekit.js
@@ -148,6 +148,16 @@ TraceKit.report = (function reportModuleWrapper() {
   function traceKitWindowOnError(message, url, lineNo, colNo, ex) {
     var stack = null;
 
+    // If 'ex' is ErrorEvent, get real Error from inside
+    if (ex && utils.isErrorEvent(ex)) {
+      ex = ex.error;
+    } 
+
+    // If 'message' is ErrorEvent, get real message from inside
+    if (message && utils.isErrorEvent(message)) {
+      message = message.message;
+    }
+
     if (lastExceptionStack) {
       TraceKit.computeStackTrace.augmentStackTraceWithInitialElement(
         lastExceptionStack,
@@ -156,13 +166,8 @@ TraceKit.report = (function reportModuleWrapper() {
         message
       );
       processLastException();
-    } else if (ex && (utils.isError(ex) || utils.isErrorEvent(ex))) {
+    } else if (ex && utils.isError(ex)) {
       // non-string `ex` arg; attempt to extract stack trace
-
-      // If this is an ErrorEvent, get the real error from within
-      if (utils.isErrorEvent(ex)) {
-        ex = ex.error;
-      }
 
       // New chrome and blink send along a real error object
       // Let's just report that like a normal error.
@@ -179,6 +184,7 @@ TraceKit.report = (function reportModuleWrapper() {
       var name = undefined;
       var msg = message; // must be new var or will modify original `arguments`
       var groups;
+
       if ({}.toString.call(message) === '[object String]') {
         var groups = message.match(ERROR_TYPES_RE);
         if (groups) {


### PR DESCRIPTION
This PR resolves #1008 . `traceKitWindowOnError` now handles the case where the `ex` parameter is an `ErrorEvent` object.