### PR TITLE
Offline storage plugin

### DIFF
--- a/plugins/offline-storage.js
+++ b/plugins/offline-storage.js
@@ -7,7 +7,7 @@
 
 var offlineStorageKey = 'raven-js-offline-queue';
 
-function offlineStoragelugin(Raven, options) {
+function offlineStoragePlugin(Raven, options) {
   options = options || {};
 
   function processOfflineQueue() {
@@ -21,7 +21,7 @@ function offlineStoragelugin(Raven, options) {
       var queue = JSON.parse(localStorage.getItem(offlineStorageKey)) || [];
 
       // Store an empty queue. If processing these one fails they get back to the queue
-      localStorage.setItem(offlineStorageKey, JSON.stringify([]));
+      localStorage.removeItem(offlineStorageKey);
 
       queue.forEach(function processOfflinePayload(data) {
         // Avoid duplication verification for offline stored
@@ -47,7 +47,7 @@ function offlineStoragelugin(Raven, options) {
 
     try {
       var queue = JSON.parse(localStorage.getItem(offlineStorageKey)) || [];
-      queue.push(event.data || Raven._lastData);
+      queue.push(event.data);
       localStorage.setItem(offlineStorageKey, JSON.stringify(queue));
     } catch (error) {
       Raven._logDebug('error', 'Raven failed to store payload offline: ', error);
@@ -58,4 +58,4 @@ function offlineStoragelugin(Raven, options) {
   window.addEventListener(options.onlineEventName || 'online', processOfflineQueue);
 }
 
-module.exports = offlineStoragelugin;
+module.exports = offlineStoragePlugin;

--- a/plugins/offline-storage.js
+++ b/plugins/offline-storage.js
@@ -1,0 +1,61 @@
+/**
+ * Offline Storage plugin
+ * 
+ * Stores errors failed to get send and try to send them when
+ * Networkf comes back or on init
+ */
+
+var offlineStorageKey = 'raven-js-offline-queue';
+
+function offlineStoragelugin(Raven, options) {
+  options = options || {};
+
+  function processOfflineQueue() {
+    // Let's stop here if there's no connection
+    if (!navigator.onLine) {
+      return;
+    }
+
+    try {
+      // Get the queue
+      var queue = JSON.parse(localStorage.getItem(offlineStorageKey)) || [];
+
+      // Store an empty queue. If processing these one fails they get back to the queue
+      localStorage.setItem(offlineStorageKey, JSON.stringify([]));
+
+      queue.forEach(function processOfflinePayload(data) {
+        // Avoid duplication verification for offline stored
+        // as they may try multiple times to be processed
+        Raven._lastData = null;
+
+        // Try to process it again
+        Raven._sendProcessedPayload(data);
+      });
+    } catch (error) {
+      Raven._logDebug('error', 'Raven transport failed to store offline: ', error);
+    }
+  }
+
+  // Process queue on start
+  processOfflineQueue();
+
+  // Add event listener on onravenFailure and store error on localstorage
+  document.addEventListener('ravenFailure', function(event) {
+    if (!event.data) {
+      return;
+    }
+
+    try {
+      var queue = JSON.parse(localStorage.getItem(offlineStorageKey)) || [];
+      queue.push(event.data || Raven._lastData);
+      localStorage.setItem(offlineStorageKey, JSON.stringify(queue));
+    } catch (error) {
+      Raven._logDebug('error', 'Raven failed to store payload offline: ', error);
+    }
+  });
+
+  // Add event listener on online or custom event to trigger offline queue sending
+  window.addEventListener(options.onlineEventName || 'online', processOfflineQueue);
+}
+
+module.exports = offlineStoragelugin;


### PR DESCRIPTION
This is my proposal to #279. Any thoughts/suggestions to improve or make it different are welcome.
Thanks. 
(https://github.com/getsentry/raven-js/pull/973 continues here.)

# Description
Stores errors failed to get send and try to send them when network comes back or on init

# Options
- onlineEventName: In case you have a custom event fired instead of `online` you can pass it here.

# TODO
If this works for you I'm missing documentation and tests.