### PR TITLE
Ability to specify Custom headers

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -275,6 +275,32 @@ Those configuration options are documented below:
     onError
         Callback to be invoked upon a failed request.
 
+.. describe:: headers
+
+    Pass custom headers to server requests for ``fetch`` or ``XMLHttpRequest``.
+
+    .. code-block:: javascript
+
+        {
+            headers: {
+                'CSRF-TOKEN': '12345'
+            }
+        }
+
+    Headers value can be in form of a function, to compute value in time of a request:
+
+    .. code-block:: javascript
+
+        {
+            headers: {
+                'CSRF-TOKEN': function() {
+                    // custom logic that will be computed on every request
+                    return new Date();
+                }
+            }
+        }
+
+
 .. describe:: allowDuplicates
 
     By default, Raven.js attempts to suppress duplicate captured errors and messages that occur back-to-back. Such events are often triggered by rogue code (e.g. from a `setInterval` callback in a browser extension), are not actionable, and eat up your event quota.

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -269,6 +269,9 @@ Those configuration options are documented below:
         sentry_key
             Your public client key (DSN).
 
+    options
+        Include all top-level options described.
+
     onSuccess
         Callback to be invoked upon a successful request.
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -1897,12 +1897,23 @@ Raven.prototype = {
     // Auth is intentionally sent as part of query string (NOT as custom HTTP header) to avoid preflight CORS requests
     var url = opts.url + '?' + urlencode(opts.auth);
 
+    var evaluatedHeaders = null;
+    if (opts.options.headers) {
+      evaluatedHeaders = this._evaluateHeaders(opts.options.headers);
+    }
+
     if (supportsFetch()) {
+      var fetchOptions = {
+        method: 'POST',
+        body: stringify(opts.data)
+      };
+
+      if (evaluatedHeaders) {
+        fetchOptions.headers = evaluatedHeaders;
+      }
+
       return _window
-        .fetch(url, {
-          method: 'POST',
-          body: stringify(opts.data)
-        })
+        .fetch(url, fetchOptions)
         .then(function(response) {
           if (response.ok) {
             opts.onSuccess && opts.onSuccess();
@@ -1960,18 +1971,27 @@ Raven.prototype = {
     }
 
     request.open('POST', url);
-    this._appendHeadersToRequest(request, opts.options.headers);
+
+    if (evaluatedHeaders) {
+      each(evaluatedHeaders, function(key, value) {
+        request.setRequestHeader(key, value);
+      });
+    }
+
     request.send(stringify(opts.data));
   },
 
-  _appendHeadersToRequest: function(request, headers) {
-    if (!headers) {
-      return;
+  _evaluateHeaders: function(headers) {
+    var evaluatedHeaders = {};
+
+    for (var key in headers) {
+      if (headers.hasOwnProperty(key)) {
+        var value = headers[key];
+        evaluatedHeaders[key] = typeof value === 'function' ? value() : value;
+      }
     }
 
-    each(headers, function(key, value) {
-      request.setRequestHeader(key, typeof value === 'function' ? value() : value);
-    });
+    return evaluatedHeaders;
   },
 
   _logDebug: function(level) {

--- a/src/raven.js
+++ b/src/raven.js
@@ -74,6 +74,7 @@ function Raven() {
     ignoreUrls: [],
     whitelistUrls: [],
     includePaths: [],
+    headers: null,
     collectWindowErrors: true,
     maxMessageLength: 0,
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -1960,7 +1960,18 @@ Raven.prototype = {
     }
 
     request.open('POST', url);
+    this._appendHeadersToRequest(request, opts.options.headers);
     request.send(stringify(opts.data));
+  },
+
+  _appendHeadersToRequest: function(request, headers) {
+    if (!headers) {
+      return;
+    }
+
+    each(headers, function(key, value) {
+      request.setRequestHeader(key, typeof value === 'function' ? value() : value);
+    });
   },
 
   _logDebug: function(level) {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1392,6 +1392,87 @@ describe('globals', function() {
       });
     });
 
+    it('should apply globalOptions.headers if specified', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      var globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100,
+        transport: sinon.stub(),
+        options: {
+          headers: {
+            'custom-header': 'value'
+          }
+        }
+      };
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = globalOptions;
+
+      Raven._send({message: 'bar'});
+
+      assert.deepEqual(globalOptions.transport.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost:9876/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser',
+            'custom-header': 'value'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+    });
+
+    it('should apply globalOptions.headers with function value if specified', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_getHttpData').returns({
+        url: 'http://localhost/?a=b',
+        headers: {'User-Agent': 'lolbrowser'}
+      });
+
+      var globalOptions = {
+        logger: 'javascript',
+        maxMessageLength: 100,
+        transport: sinon.stub(),
+        options: {
+          headers: {
+            'custom-header': function() {
+              return 'computed-header-value';
+            }
+          }
+        }
+      };
+
+      Raven._globalProject = '2';
+      Raven._globalOptions = globalOptions;
+
+      Raven._send({message: 'bar'});
+      assert.deepEqual(globalOptions.transport.lastCall.args[0].data, {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+        request: {
+          url: 'http://localhost/?a=b',
+          headers: {
+            'User-Agent': 'lolbrowser',
+            'custom-header': 'computed-header-value'
+          }
+        },
+        event_id: 'abc123',
+        message: 'bar',
+        extra: {'session:duration': 100}
+      });
+    });
+
     it('should check `Raven.isSetup`', function() {
       this.sinon.stub(Raven, 'isSetup').returns(false);
       this.sinon.stub(Raven, '_makeRequest');

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1394,82 +1394,43 @@ describe('globals', function() {
 
     it('should apply globalOptions.headers if specified', function() {
       this.sinon.stub(Raven, 'isSetup').returns(true);
-      this.sinon.stub(Raven, '_getHttpData').returns({
-        url: 'http://localhost/?a=b',
-        headers: {'User-Agent': 'lolbrowser'}
-      });
+      this.sinon.stub(window, 'fetch').resolves(true);
 
-      var globalOptions = {
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
         logger: 'javascript',
         maxMessageLength: 100,
-        transport: sinon.stub(),
-        options: {
-          headers: {
-            'custom-header': 'value'
-          }
+        headers: {
+          'custom-header': 'value'
         }
       };
 
-      Raven._globalProject = '2';
-      Raven._globalOptions = globalOptions;
-
       Raven._send({message: 'bar'});
 
-      assert.deepEqual(globalOptions.transport.lastCall.args[0].data, {
-        project: '2',
-        logger: 'javascript',
-        platform: 'javascript',
-        request: {
-          url: 'http://localhost:9876/?a=b',
-          headers: {
-            'User-Agent': 'lolbrowser',
-            'custom-header': 'value'
-          }
-        },
-        event_id: 'abc123',
-        message: 'bar',
-        extra: {'session:duration': 100}
+      assert.deepEqual(window.fetch.lastCall.args[1].headers, {
+        'custom-header': 'value'
       });
     });
 
     it('should apply globalOptions.headers with function value if specified', function() {
       this.sinon.stub(Raven, 'isSetup').returns(true);
-      this.sinon.stub(Raven, '_getHttpData').returns({
-        url: 'http://localhost/?a=b',
-        headers: {'User-Agent': 'lolbrowser'}
-      });
+      this.sinon.stub(window, 'fetch').resolves(true);
 
-      var globalOptions = {
+      Raven._globalProject = '2';
+      Raven._globalOptions = {
         logger: 'javascript',
         maxMessageLength: 100,
-        transport: sinon.stub(),
-        options: {
-          headers: {
-            'custom-header': function() {
-              return 'computed-header-value';
-            }
+        headers: {
+          'custom-header': function() {
+            return 'computed-header-value';
           }
         }
       };
 
-      Raven._globalProject = '2';
-      Raven._globalOptions = globalOptions;
-
       Raven._send({message: 'bar'});
-      assert.deepEqual(globalOptions.transport.lastCall.args[0].data, {
-        project: '2',
-        logger: 'javascript',
-        platform: 'javascript',
-        request: {
-          url: 'http://localhost/?a=b',
-          headers: {
-            'User-Agent': 'lolbrowser',
-            'custom-header': 'computed-header-value'
-          }
-        },
-        event_id: 'abc123',
-        message: 'bar',
-        extra: {'session:duration': 100}
+
+      assert.deepEqual(window.fetch.lastCall.args[1].headers, {
+        'custom-header': 'computed-header-value'
       });
     });
 

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -63,6 +63,11 @@ declare module Raven {
         /** Override the default HTTP data transport handler. */
         transport?: (options: RavenTransportOptions) => void;
 
+        /** Append headers to the fetch or XMLHttpRequest request. Should be in a form of hash, were value can be string or function */
+        headers?: {
+          [key: string]: (string | Function);
+        };
+
         /** Allow use of private/secretKey. */
         allowSecretKey?: boolean;
 


### PR DESCRIPTION
**Problem**
When using Sentry on premises, Sentry can be behind of authorization or any other service (or both). Part of the verification process comes from the headers passed, for example, `csrf-token`. Currently, there is no simple way how we can pass custom header to every sentry request. And as an additional complication, headers should be computed, as the token is not static.

**Solution**
To avoid any breaking changes, we can pass additional headers as options (via globalOptions), it is already supported by most of the libraries. To solve an issue with computed header value, we can pass function and execute it at a time of the headers evaluation.

**Solution Problem**
As it seems, and the comment in the [raven.js code ](https://github.com/getsentry/raven-js/blob/master/src/raven.js#L1897), as soon as you step into the Headers game, you might have issues with CORS. I am not too worried about it, as it is possible (for on-premises) to solve that, by using the same domain and do routing.
What I am struggling now with, is to make tests to work correctly and test things as they should.

----

* [x] If you've added code that should be tested, please add tests.
* [x] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [x] Ensure your code lints and the test suite passes (npm test).
