### PR TITLE
Add `fetchParameters` to configure `fetch`

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -305,9 +305,17 @@ Those configuration options are documented below:
 
 .. describe:: fetchParameters
 
-    ``fetch()`` init parameters.
+    ``fetch()`` init parameters (https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters).
 
-    Reference: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters
+    Defaults:
+
+    .. code-block:: javascript
+        {
+            method: 'POST',
+            credentials: 'include',
+            keepalive: true,
+            referrerPolicy: 'origin'
+        }
 
 
 .. describe:: allowDuplicates

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -303,6 +303,12 @@ Those configuration options are documented below:
             }
         }
 
+.. describe:: fetchParameters
+
+    ``fetch()`` init parameters.
+
+    Reference: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters
+
 
 .. describe:: allowDuplicates
 

--- a/src/raven.js
+++ b/src/raven.js
@@ -88,7 +88,8 @@ function Raven() {
   this._fetchDefaults = {
     method: 'POST',
     credentials: 'include',
-    keepalive: true
+    keepalive: true,
+    referrerPolicy: 'origin'
   };
   this._ignoreOnError = 0;
   this._isRavenInstalled = false;

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1775,6 +1775,8 @@ describe('globals', function() {
           assert.deepEqual(window.fetch.lastCall.args, [
             'http://localhost/?a=1&b=2',
             {
+              credentials: 'include',
+              keepalive: true,
               method: 'POST',
               body: '{"foo":"bar"}'
             }

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1777,6 +1777,7 @@ describe('globals', function() {
             {
               credentials: 'include',
               keepalive: true,
+              referrerPolicy: 'origin',
               method: 'POST',
               body: '{"foo":"bar"}'
             }

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -68,6 +68,11 @@ declare module Raven {
           [key: string]: (string | Function);
         };
 
+        /** `fetch` init parameters */
+        fetchParameters?: {
+          [key: string]: (string | Function);
+        };
+
         /** Allow use of private/secretKey. */
         allowSecretKey?: boolean;
 


### PR DESCRIPTION
This PR adds the ability to configure fetch `parameters`. 

Reference: https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters

By default, we set `keepalive: true` and `credentials: true`. Keepalive should help to send request even on unload and credentials will pass cookies to the request. Passing cookies are essentials for self-hosted solutions if they are behind authorization that requires cookies (our use case).

Added `referrerPolicy: 'origin'` as well, as sentry requires referer header to be passed. Without this option it won't work, so making it default seems like a good idea.

----
* [x] If you've added code that should be tested, please add tests.
* [x] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [x] Ensure your code lints and the test suite passes (npm test).
