### PR TITLE
Add allowDuplicates to RavenOptions typescript definition

### DIFF
--- a/typescript/raven-tests.ts
+++ b/typescript/raven-tests.ts
@@ -29,7 +29,8 @@ var options: Raven.RavenOptions = {
     },
     breadcrumbCallback: function (data) {
         return data
-    }
+    },
+    allowDuplicates: true
 };
 
 Raven.config('https://public@sentry.io/1', options).install();

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -87,6 +87,11 @@ declare module Raven {
          * A sampling rate to apply to events. A value of 0.0 will send no events, and a value of 1.0 will send all events (default).
          */
         sampleRate?: number;
+
+        /**
+         * Should raven send duplicate errors. A value of false will not send duplicate errors (default).
+         */
+        allowDuplicates?: boolean;
     }
 
     interface RavenInstrumentationOptions {


### PR DESCRIPTION
Before submitting a pull request, please verify the following:

* [x] If you've added code that should be tested, please add tests.
* [x] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [x] Ensure your code lints and the test suite passes (npm test).

## Problem
We are missing the definition allowing for the `allowDuplicates` option in the configuration for typescript projects.

## Solution
Add the property to the typescript definition.
