### PR TITLE
ref: Access window.location instead of document.location

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1636,14 +1636,14 @@ Raven.prototype = {
       };
     }
 
-    if (this._hasDocument) {
-      if (_document.location && _document.location.href) {
-        httpData.url = _document.location.href;
-      }
-      if (_document.referrer) {
-        if (!httpData.headers) httpData.headers = {};
-        httpData.headers.Referer = _document.referrer;
-      }
+    // Check in `window` instead of `document`, as we may be in ServiceWorker environment
+    if (_window.location && _window.location.href) {
+      httpData.url = _window.location.href;
+    }
+
+    if (this._hasDocument && _document.referrer) {
+      if (!httpData.headers) httpData.headers = {};
+      httpData.headers.Referer = _document.referrer;
     }
 
     return httpData;


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-js/pull/1159 but with less code. `window.location` is always accessible if `document.location` is, but it's not true another way around, eg. in Service Workers