### PR TITLE
fix: Use JSON.stringify for [object Object]

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -455,12 +455,20 @@ Raven.prototype = {
      * @return {Raven}
      */
   captureMessage: function(msg, options) {
+    // Convert the message into a string
+    var exceptionMessage;
+    if (typeof msg === 'object' && msg !== null) {
+      exceptionMessage = JSON.stringify(msg);
+    } else {
+      exceptionMessage = '' + msg;
+    }
+
     // config() automagically converts ignoreErrors from a list to a RegExp so we need to test for an
     // early call; we'll error on the side of logging anything called before configuration since it's
     // probably something you should see:
     if (
       !!this._globalOptions.ignoreErrors.test &&
-      this._globalOptions.ignoreErrors.test(msg)
+      this._globalOptions.ignoreErrors.test(exceptionMessage)
     ) {
       return;
     }
@@ -469,7 +477,7 @@ Raven.prototype = {
 
     var data = objectMerge(
       {
-        message: msg + '' // Make sure it's actually a string
+        message: exceptionMessage
       },
       options
     );

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -2835,15 +2835,36 @@ describe('Raven (public API)', function() {
         }
       ]);
     });
-
-    it('should coerce message to a string', function() {
+    it('should coerce object message to a json string', function() {
       this.sinon.stub(Raven, 'isSetup').returns(true);
       this.sinon.stub(Raven, '_send');
-      Raven.captureMessage({});
+      Raven.captureMessage({foo: 'bar'});
       assert.isTrue(Raven._send.called);
       assert.deepEqual(Raven._send.lastCall.args, [
         {
-          message: '[object Object]'
+          message: '{"foo":"bar"}'
+        }
+      ]);
+    });
+    it('should coerce array message to a json string', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_send');
+      Raven.captureMessage([1, 2, 3]);
+      assert.isTrue(Raven._send.called);
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          message: '[1,2,3]'
+        }
+      ]);
+    });
+    it('should coerce number to a string', function() {
+      this.sinon.stub(Raven, 'isSetup').returns(true);
+      this.sinon.stub(Raven, '_send');
+      Raven.captureMessage(56);
+      assert.isTrue(Raven._send.called);
+      assert.deepEqual(Raven._send.lastCall.args, [
+        {
+          message: '56'
         }
       ]);
     });


### PR DESCRIPTION
There are several issues about `[object Object]` showing up as the exception message. Obviously people should throw Error instead of a normal JS object. I think it would be way more helpful if the JS object was JSON stringified, so you could see the actual error object.

This PR changes the message -> String logic, so if it's an object, it uses `JSON.stringify` instead.


