### PR TITLE
Make user type more flexible

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -205,21 +205,14 @@ declare module Raven {
         /** Log a breadcrumb */
         captureBreadcrumb(crumb: Breadcrumb): RavenStatic;
 
-        /**
-         * Clear the user context, removing the user data that would be sent to Sentry.
-         */
-        setUserContext(): RavenStatic;
-
         /*
-        * Set a user to be sent along with the payload.
+        * Set/Clear a user to be sent along with the payload.
         *
         * @param {object} user An object representing user data [optional]
         * @return {Raven}
         */
-        setUserContext(user: {
-            id?: string;
-            username?: string;
-            email?: string;
+        setUserContext(user?: {
+            [key: string]: string | number | boolean | null | void
         }): RavenStatic;
 
         /** Merge extra attributes to be sent along with the payload. */


### PR DESCRIPTION
The API seems to accept any JSON Object for `setUserContext`.  By making it one method instead of two separate methods, we can also make it more flexible.  Where before a wrapper would need to do:

```typescript
function setUser(user?: User) {
  if (user) {
    Raven.setUserContext(user);
  } else {
    Raven.setUserContext();
  }
}
```

This type definition allows for:


```typescript
function setUser(user?: User) {
  Raven.setUserContext(user);
}
```


Before submitting a pull request, please verify the following:

* [ ] If you've added code that should be tested, please add tests.
* [ ] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [ ] Ensure your code lints and the test suite passes (npm test).
