### PR TITLE
fix: Check parseUrl for correct input type

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -185,8 +185,8 @@ function urlencode(o) {
 // intentionally using regex and not <a/> href parsing trick because React Native and other
 // environments where DOM might not be available
 function parseUrl(url) {
+  if (typeof url !== 'string') return {};
   var match = url.match(/^(([^:\/?#]+):)?(\/\/([^\/?#]*))?([^?#]*)(\?([^#]*))?(#(.*))?$/);
-  if (!match) return {};
 
   // coerce to undefined values to empty string so we don't get 'undefined'
   var query = match[6] || '';

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -353,6 +353,15 @@ describe('utils', function() {
         // from example.com => example.com/example.com/foo (valid url).
       });
     });
+
+    it('should return an empty object for invalid input', function() {
+      assert.deepEqual(parseUrl(), {});
+      assert.deepEqual(parseUrl(42), {});
+      assert.deepEqual(parseUrl([]), {});
+      assert.deepEqual(parseUrl({}), {});
+      assert.deepEqual(parseUrl(null), {});
+      assert.deepEqual(parseUrl(undefined), {});
+    });
   });
 
   describe('wrappedCallback', function() {


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-js/issues/1189

The second check can be removed, as all groups are optional and we'll always match even on an empty string.