### PR TITLE
fix: Do not include credentials by default

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -313,7 +313,6 @@ Those configuration options are documented below:
 
         {
             method: 'POST',
-            credentials: 'include',
             keepalive: true,
             referrerPolicy: 'origin'
         }

--- a/src/raven.js
+++ b/src/raven.js
@@ -87,7 +87,6 @@ function Raven() {
   };
   this._fetchDefaults = {
     method: 'POST',
-    credentials: 'include',
     keepalive: true,
     referrerPolicy: 'origin'
   };

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -1783,7 +1783,6 @@ describe('globals', function() {
           assert.deepEqual(window.fetch.lastCall.args, [
             'http://localhost/?a=1&b=2',
             {
-              credentials: 'include',
               keepalive: true,
               referrerPolicy: 'origin',
               method: 'POST',


### PR DESCRIPTION
Reverts a default `credentials: 'include'` for fetch that was set in #1177. This default was primarily added for self-hosted Sentry installations and should therefore require explicit configuration with `fetchOptions`.

Most importantly, this breaks when a user with Sentry account (and therefore an active sentry.io cookie) visits any webpage using the Raven SDK. The cookie will be rejected by CORS protection because Sentry does not send a `Access-Control-Allow-Credentials`. This is expected behavior, see getsentry/sentry#6970 for more information.

Also, this is not usual browser behavior and should therefore not be default. And, it is inconsistent with the `XMLHttpRequest` implementation which does not include credentials by default. 

Fixes getsentry/sentry#6970