### PR TITLE
feat: Check for SENTRY_RELEASE during config phase

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -70,7 +70,10 @@ function Raven() {
   this._globalContext = {};
   this._globalOptions = {
     // SENTRY_RELEASE can be injected by https://github.com/getsentry/sentry-webpack-plugin
-    release: _window.SENTRY_RELEASE,
+    release:
+      _window.SENTRY_RELEASE && _window.SENTRY_RELEASE.id
+        ? _window.SENTRY_RELEASE.id
+        : null,
     logger: 'javascript',
     ignoreErrors: [],
     ignoreUrls: [],

--- a/src/raven.js
+++ b/src/raven.js
@@ -69,6 +69,8 @@ function Raven() {
   this._globalProject = null;
   this._globalContext = {};
   this._globalOptions = {
+    // SENTRY_RELEASE can be injected by https://github.com/getsentry/sentry-webpack-plugin
+    release: _window.SENTRY_RELEASE,
     logger: 'javascript',
     ignoreErrors: [],
     ignoreUrls: [],

--- a/src/raven.js
+++ b/src/raven.js
@@ -70,10 +70,7 @@ function Raven() {
   this._globalContext = {};
   this._globalOptions = {
     // SENTRY_RELEASE can be injected by https://github.com/getsentry/sentry-webpack-plugin
-    release:
-      _window.SENTRY_RELEASE && _window.SENTRY_RELEASE.id
-        ? _window.SENTRY_RELEASE.id
-        : null,
+    release: _window.SENTRY_RELEASE && _window.SENTRY_RELEASE.id,
     logger: 'javascript',
     ignoreErrors: [],
     ignoreUrls: [],


### PR DESCRIPTION
Ref: https://github.com/getsentry/sentry-webpack-plugin/pull/20

If `_window.SENTRY_RELEASE` is not set, it'll just fall back to `undefined`, and will be skipped in `_send` method.