### PR TITLE
fix: Call captureBreadcrumb for fetch after its done

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1278,14 +1278,14 @@ Raven.prototype = {
               status_code: null
             };
 
-            self.captureBreadcrumb({
-              type: 'http',
-              category: 'fetch',
-              data: fetchData
-            });
-
             return origFetch.apply(this, args).then(function(response) {
               fetchData.status_code = response.status;
+
+              self.captureBreadcrumb({
+                type: 'http',
+                category: 'fetch',
+                data: fetchData
+              });
 
               return response;
             });


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-js/issues/1193

Corrects call time and attaches status code as it should.