### PR TITLE
Move sourcemap active release docs further up

### DIFF
--- a/docs/sourcemaps.rst
+++ b/docs/sourcemaps.rst
@@ -8,6 +8,19 @@ Sentry supports un-minifying JavaScript via `Source Maps
 view source code context obtained from stack traces in their original untransformed form, which is particularly useful for debugging minified code (e.g. UglifyJS), or transpiled code from a higher-level
 language (e.g. TypeScript, ES6).
 
+Specify the active release in raven
+-----------------------------------
+
+For sourcemaps to work you must ensure you have specified the active release in your Raven.js client configuration:
+
+.. code-block:: javascript
+
+  Raven.config('your-dsn', {
+    release: '1.2.3-beta'
+  }).install();
+
+Sentry needs this to associate ingested event data with the release and artifacts you've created via the API.
+
 Generating a Source Map
 -----------------------
 
@@ -339,19 +352,6 @@ Troubleshooting
 ---------------
 
 Source maps can sometimes be tricky to get going. If you're having trouble, try the following tips.
-
-Verify you have specified the release in your client config
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-You must specify the active release in your Raven.js client configuration:
-
-.. code-block:: javascript
-
-  Raven.config('your-dsn', {
-    release: '1.2.3-beta'
-  }).install();
-
-Sentry needs this to associate ingested event data with the release and artifacts you've created via the API.
 
 Verify your source maps are built correctly
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/sourcemaps.rst
+++ b/docs/sourcemaps.rst
@@ -11,7 +11,7 @@ language (e.g. TypeScript, ES6).
 Specify the active release in raven
 -----------------------------------
 
-For sourcemaps to work you must ensure you have specified the active release in your Raven.js client configuration:
+If you are uploading your own sourcemap artifacts, you must have specified the active release in your Raven.js client configuration. If your sourcemaps are on your remote server (with your running code) then this step is not needed.
 
 .. code-block:: javascript
 
@@ -19,7 +19,7 @@ For sourcemaps to work you must ensure you have specified the active release in 
     release: '1.2.3-beta'
   }).install();
 
-Sentry needs this to associate ingested event data with the release and artifacts you've created via the API.
+Sentry needs this to associate ingested event data with the release and artifacts you've created via the API. 
 
 Generating a Source Map
 -----------------------


### PR DESCRIPTION
It took myself and another developer around a week of on and off attempts to get sourcemaps working correctly with Sentry. It turned out the reason was that we hadn't marked an active release in the raven configuration.

We struggled to find this information as it was in the troubleshooting section. We should have looked in that section much sooner, but since we had to errors coming back from the sentry CLI when uploading sourcemaps, we assumed it would not be something from the troubleshooting guide.

Since this release option is *required* if you want to use sourcemaps, I thought it would make sense for it to be moved it into the main guide section and out of the troubleshooting section. This way folks will see it as the first required step and not think of it as an optional step.

Please let me know if you'd prefer it in another section, or feel it is right to be in the troubleshooting area. For us this caused problems though we may be a minority, however I do think this could make the journey easier for others.

## Checklist

_This is only a doc update_

* [x] If you've added code that should be tested, please add tests.
* [x] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [x] Ensure your code lints and the test suite passes (npm test).

Thanks for considering my docs change :smile: