### PR TITLE
Tyepscript:  add missing debug option

### DIFF
--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -99,6 +99,11 @@ declare module Raven {
          * are not actionable, and eat up your event quota.
          */
         allowDuplicates?: boolean
+
+        /**
+         * If set to true, Raven.js outputs some light debugging information onto the console.
+         */
+        debug?: boolean;
     }
 
     interface RavenInstrumentationOptions {

--- a/typescript/raven.d.ts
+++ b/typescript/raven.d.ts
@@ -98,7 +98,7 @@ declare module Raven {
          * Such events are often triggered by rogue code (e.g. from a `setInterval` callback in a browser extension), 
          * are not actionable, and eat up your event quota.
          */
-        allowDuplicates?: boolean
+        allowDuplicates?: boolean;
 
         /**
          * If set to true, Raven.js outputs some light debugging information onto the console.


### PR DESCRIPTION
## What does this pull request do?

Found that TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts) `RavenOptions` has no `debug` option listed that is present in [documentatsion](https://docs.sentry.io/clients/javascript/config/). _Also added missing semicolon after RavenOptions.allowDuplicates._

## Checklist

this pull request only updates TypeScript declaration file so it would be sync with docs.

* [x] If you've added code that should be tested, please add tests.
* [x] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [x] Ensure your code lints and the test suite passes (npm test).
