### PR TITLE
fix: Let Edge to send fetch requests using default config

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -27,6 +27,7 @@ var isSameStacktrace = utils.isSameStacktrace;
 var parseUrl = utils.parseUrl;
 var fill = utils.fill;
 var supportsFetch = utils.supportsFetch;
+var supportsReferrerPolicy = utils.supportsReferrerPolicy;
 
 var wrapConsoleMethod = require('./console').wrapMethod;
 
@@ -90,7 +91,11 @@ function Raven() {
   this._fetchDefaults = {
     method: 'POST',
     keepalive: true,
-    referrerPolicy: 'origin'
+    // Despite all stars in the sky saying that Edge supports old draft syntax, aka 'never', 'always', 'origin' and 'default
+    // https://caniuse.com/#feat=referrer-policy
+    // It doesn't. And it throw exception instead of ignoring this parameter...
+    // REF: https://github.com/getsentry/raven-js/issues/1233
+    referrerPolicy: supportsReferrerPolicy() ? 'origin' : ''
   };
   this._ignoreOnError = 0;
   this._isRavenInstalled = false;

--- a/src/utils.js
+++ b/src/utils.js
@@ -79,6 +79,24 @@ function supportsFetch() {
   }
 }
 
+// Despite all stars in the sky saying that Edge supports old draft syntax, aka 'never', 'always', 'origin' and 'default
+// https://caniuse.com/#feat=referrer-policy
+// It doesn't. And it throw exception instead of ignoring this parameter...
+// REF: https://github.com/getsentry/raven-js/issues/1233
+function supportsReferrerPolicy() {
+  if (!supportsFetch()) return false;
+
+  try {
+    // eslint-disable-next-line no-new
+    new Request('pickleRick', {
+      referrerPolicy: 'origin'
+    });
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
 function wrappedCallback(callback) {
   function dataCallback(data, original) {
     var normalizedData = callback(data) || data;
@@ -431,6 +449,7 @@ module.exports = {
   isEmptyObject: isEmptyObject,
   supportsErrorEvent: supportsErrorEvent,
   supportsFetch: supportsFetch,
+  supportsReferrerPolicy: supportsReferrerPolicy,
   wrappedCallback: wrappedCallback,
   each: each,
   objectMerge: objectMerge,

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -24,6 +24,7 @@ var utils = require('../src/utils');
 var joinRegExp = utils.joinRegExp;
 var supportsErrorEvent = utils.supportsErrorEvent;
 var supportsFetch = utils.supportsFetch;
+var supportsReferrerPolicy = utils.supportsReferrerPolicy;
 
 // window.console must be stubbed in for browsers that don't have it
 if (typeof window.console === 'undefined') {
@@ -1784,7 +1785,7 @@ describe('globals', function() {
             'http://localhost/?a=1&b=2',
             {
               keepalive: true,
-              referrerPolicy: 'origin',
+              referrerPolicy: supportsReferrerPolicy() ? 'origin' : '',
               method: 'POST',
               body: '{"foo":"bar"}'
             }


### PR DESCRIPTION
Fixes https://github.com/getsentry/raven-js/issues/1233

We add `referrer` because this comment https://github.com/getsentry/raven-js/pull/1177#issue-158894122

However, there's no easy way to test this behavior, as:
- mocking `fetch` won't call it's native implementation, therefore not throw an error
- spying on `fetch` won't modify response object, and without it, we'll always jump into `onError` handler because we get no `ok` in resp data

I'm not really convinced if this is a good idea... It just feels odd, but I cannot think of any simple, yet an acceptable solution to this issue.

Thoughts?
