### PR TITLE
fix: #1243 (window defensiveness with addEventListener)

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -431,7 +431,7 @@ Raven.prototype = {
    */
   _attachPromiseRejectionHandler: function() {
     this._promiseRejectionHandler = this._promiseRejectionHandler.bind(this);
-    _window.addEventListener('unhandledrejection', this._promiseRejectionHandler);
+    _window.addEventListener && _window.addEventListener('unhandledrejection', this._promiseRejectionHandler);
     return this;
   },
 
@@ -441,7 +441,7 @@ Raven.prototype = {
    * @return {raven}
    */
   _detachPromiseRejectionHandler: function() {
-    _window.removeEventListener('unhandledrejection', this._promiseRejectionHandler);
+    _window.removeEventListener && _window.removeEventListener('unhandledrejection', this._promiseRejectionHandler);
     return this;
   },
 


### PR DESCRIPTION
this pr fixes a bug introduced in #1242 in non-browser environments

in the future, adding node as a test environment would help prevent this sort of issue.