### PR TITLE
ref: Restructure exports to prefer default exports [WIP]

### DIFF
--- a/packages/browser/src/bundle.ts
+++ b/packages/browser/src/bundle.ts
@@ -1,2 +1,2 @@
 export * from '@sentry/core';
-export { SentryBrowser, BrowserOptions as SentryBrowserOptions } from './lib/browser';
+export { default as SentryBrowser, BrowserOptions } from './lib/browser';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -1,1 +1,1 @@
-export { SentryBrowser, BrowserOptions as SentryBrowserOptions } from './lib/browser';
+export { default, BrowserOptions } from './lib/browser';

--- a/packages/browser/src/lib/browser.ts
+++ b/packages/browser/src/lib/browser.ts
@@ -15,7 +15,7 @@ const sendRavenEvent = Raven._sendProcessedPayload;
 // tslint:disable-next-line:no-empty-interface
 export interface BrowserOptions extends Options {}
 
-export class SentryBrowser implements Adapter {
+export default class SentryBrowser implements Adapter {
   private capturing: boolean = false;
   private captured: any;
 

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
 import * as Sentry from '@sentry/core';
-import { SentryBrowser, SentryBrowserOptions } from '../src/index';
+import SentryBrowser, { BrowserOptions } from '../src/index';
 
 describe('Test', () => {
   beforeEach(async () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,4 +1,7 @@
+import * as Sentry from './lib/sentry';
+
+export default Sentry;
+export { default as Client, Adapter, Options } from './lib/client';
 export { default as DSN } from './lib/dsn';
-export { default as Client } from './lib/client';
-export * from './lib/sentry';
+export { default as SentryError } from './lib/error';
 export * from './lib/interfaces';

--- a/packages/core/src/lib/client.ts
+++ b/packages/core/src/lib/client.ts
@@ -1,16 +1,37 @@
-import {
-  Adapter,
-  Breadcrumb,
-  Context,
-  LogLevel,
-  Options,
-  SentryEvent,
-  User,
-} from './interfaces';
-import { SentryError } from './sentry';
-
 import ContextManager from './context';
 import DSN from './dsn';
+import SentryError from './error';
+import { Breadcrumb, Context, LogLevel, SentryEvent, User } from './interfaces';
+
+// TODO: Rework options
+export interface Options {
+  release?: string;
+  environment?: string;
+  logLevel?: LogLevel;
+  maxBreadcrumbs?: number;
+  ignoreErrors?: Array<string | RegExp>;
+  ignoreUrls?: Array<string | RegExp>;
+  whitelistUrls?: Array<string | RegExp>;
+  includePaths?: Array<string | RegExp>;
+  shouldSend?: (e: SentryEvent) => boolean;
+  beforeSend?: (e: SentryEvent) => SentryEvent;
+  afterSend?: (e: SentryEvent) => void;
+  shouldAddBreadcrumb?: (b: Breadcrumb) => boolean;
+  beforeBreadcrumb?: (b: Breadcrumb) => Breadcrumb;
+  afterBreadcrumb?: (b: Breadcrumb) => Breadcrumb;
+}
+
+export interface Adapter {
+  readonly options: {};
+  install(): Promise<boolean>;
+  captureException(exception: any): Promise<SentryEvent>;
+  captureMessage(message: string): Promise<SentryEvent>;
+  captureBreadcrumb(breadcrumb: Breadcrumb): Promise<Breadcrumb>;
+  send(event: SentryEvent): Promise<void>;
+  setOptions(options: Options): Promise<void>;
+  getContext(): Promise<Context>;
+  setContext(context: Context): Promise<void>;
+}
 
 export default class Client {
   public readonly dsn: DSN;

--- a/packages/core/src/lib/dsn.ts
+++ b/packages/core/src/lib/dsn.ts
@@ -1,4 +1,4 @@
-import { SentryError } from './sentry';
+import SentryError from './error';
 
 const DSN_REGEX = /^(?:(\w+):)\/\/(?:(\w+)(:\w+)?@)([\w\.-]+)(?::(\d+))?\/(.+)/;
 

--- a/packages/core/src/lib/error.ts
+++ b/packages/core/src/lib/error.ts
@@ -1,0 +1,9 @@
+export default class SentryError extends Error {
+  public name: string;
+
+  constructor(public message: string) {
+    super(message);
+    this.name = new.target.prototype.constructor.name;
+    Object.setPrototypeOf(this, new.target.prototype);
+  }
+}

--- a/packages/core/src/lib/interfaces.ts
+++ b/packages/core/src/lib/interfaces.ts
@@ -1,3 +1,10 @@
+export enum LogLevel {
+  None = 0,
+  Error = 1,
+  Debug = 2,
+  Verbose = 3,
+}
+
 export enum Severity {
   Fatal = 'fatal',
   Error = 'error',
@@ -81,7 +88,6 @@ export interface Request {
   env?: { [key: string]: string };
 }
 
-// TODO: Add missing fields
 export interface SentryEvent extends Context {
   event_id?: string;
   message?: string;
@@ -100,41 +106,4 @@ export interface SentryEvent extends Context {
   exception?: SentryException[];
   stacktrace?: Stacktrace;
   breadcrumbs?: Breadcrumb[];
-}
-
-export enum LogLevel {
-  None = 0,
-  Error = 1,
-  Debug = 2,
-  Verbose = 3,
-}
-
-// TODO: Rework options
-export interface Options {
-  release?: string;
-  environment?: string;
-  logLevel?: LogLevel;
-  maxBreadcrumbs?: number;
-  ignoreErrors?: Array<string | RegExp>;
-  ignoreUrls?: Array<string | RegExp>;
-  whitelistUrls?: Array<string | RegExp>;
-  includePaths?: Array<string | RegExp>;
-  shouldSend?: (e: SentryEvent) => boolean;
-  beforeSend?: (e: SentryEvent) => SentryEvent;
-  afterSend?: (e: SentryEvent) => void;
-  shouldAddBreadcrumb?: (b: Breadcrumb) => boolean;
-  beforeBreadcrumb?: (b: Breadcrumb) => Breadcrumb;
-  afterBreadcrumb?: (b: Breadcrumb) => Breadcrumb;
-}
-
-export interface Adapter {
-  readonly options: {};
-  install(): Promise<boolean>;
-  captureException(exception: any): Promise<SentryEvent>;
-  captureMessage(message: string): Promise<SentryEvent>;
-  captureBreadcrumb(breadcrumb: Breadcrumb): Promise<Breadcrumb>;
-  send(event: SentryEvent): Promise<void>;
-  setOptions(options: Options): Promise<void>;
-  getContext(): Promise<Context>;
-  setContext(context: Context): Promise<void>;
 }

--- a/packages/core/src/lib/sentry.ts
+++ b/packages/core/src/lib/sentry.ts
@@ -1,5 +1,4 @@
-import Client from './client';
-import { Options } from './interfaces';
+import Client, { Options } from './client';
 
 let sharedClient: Client;
 
@@ -14,14 +13,4 @@ export function setSharedClient(client: Client): Client {
 
 export function getSharedClient(): Client {
   return sharedClient;
-}
-
-export class SentryError extends Error {
-  public name: string;
-
-  constructor(public message: string) {
-    super(message);
-    this.name = new.target.prototype.constructor.name;
-    Object.setPrototypeOf(this, new.target.prototype);
-  }
 }

--- a/packages/core/test/lib/client.test.ts
+++ b/packages/core/test/lib/client.test.ts
@@ -1,19 +1,17 @@
 // tslint:disable
 import { expect } from 'chai';
 import { spy, stub } from 'sinon';
-import * as Sentry from '../../src/index';
+import Sentry, { Client, SentryError, LogLevel } from '../../src';
 import { MockAdapter } from '../mocks/MockAdapter';
 
 const dsn = 'https://username:password@domain/path';
 
 describe('Sentry.Client', () => {
   it('get public/private DSN', () => {
-    const sentry = new Sentry.Client(dsn);
+    const sentry = new Client(dsn);
     expect(sentry.dsn.toString()).to.equal('https://username@domain/path');
     expect(sentry.dsn.toString(true)).to.equal(dsn);
-    const sentry2 = new Sentry.Client(
-      'https://username:password@domain:8888/path',
-    );
+    const sentry2 = new Client('https://username:password@domain:8888/path');
     expect(sentry2.dsn.toString()).to.equal(
       'https://username@domain:8888/path',
     );
@@ -24,24 +22,24 @@ describe('Sentry.Client', () => {
 
   it('invalid DSN', () => {
     expect(() => {
-      new Sentry.Client('abc');
+      new Client('abc');
     }).to.throw();
     expect(() => {
-      new Sentry.Client('https://username:password@domain');
+      new Client('https://username:password@domain');
     }).to.throw();
     expect(() => {
-      new Sentry.Client('//username:password@domain');
+      new Client('//username:password@domain');
     }).to.throw();
     expect(() => {
-      new Sentry.Client('https://username:@domain');
+      new Client('https://username:@domain');
     }).to.throw();
     expect(() => {
-      new Sentry.Client('123');
+      new Client('123');
     }).to.throw();
     try {
-      new Sentry.Client('123');
+      new Client('123');
     } catch (e) {
-      expect(e instanceof Sentry.SentryError).to.be.ok;
+      expect(e instanceof SentryError).to.be.ok;
     }
   });
 
@@ -53,7 +51,7 @@ describe('Sentry.Client', () => {
   });
 
   it('call install on Adapter', async () => {
-    const sentry = new Sentry.Client(dsn);
+    const sentry = new Client(dsn);
     sentry.use(MockAdapter, { testOption: true });
     const spy1 = spy(sentry, 'install');
     const spy2 = spy(sentry.getAdapter(), 'install');
@@ -63,7 +61,7 @@ describe('Sentry.Client', () => {
   });
 
   it('multiple install calls on Adapter should only call once', async () => {
-    const sentry = new Sentry.Client(dsn);
+    const sentry = new Client(dsn);
     sentry.use(MockAdapter, { testOption: true });
     const spy1 = spy(sentry.getAdapter(), 'install');
     await sentry.install();
@@ -72,7 +70,7 @@ describe('Sentry.Client', () => {
   });
 
   it('no registered Adapter', async () => {
-    const sentry = new Sentry.Client(dsn);
+    const sentry = new Client(dsn);
     try {
       await sentry.install();
     } catch (e) {
@@ -83,13 +81,13 @@ describe('Sentry.Client', () => {
   });
 
   it('get Adapter', () => {
-    const sentry = new Sentry.Client(dsn);
+    const sentry = new Client(dsn);
     sentry.use(MockAdapter, { testOption: true });
     expect(sentry.getAdapter()).to.be.an.instanceof(MockAdapter);
   });
 
   it('call captureMessage with reject on Adapter', async () => {
-    const sentry = await new Sentry.Client(dsn).use(MockAdapter).install();
+    const sentry = await new Client(dsn).use(MockAdapter).install();
     try {
       await sentry.captureMessage('fail');
     } catch (e) {
@@ -98,7 +96,7 @@ describe('Sentry.Client', () => {
   });
 
   it('call captureMessage on Adapter', async () => {
-    const sentry = new Sentry.Client(dsn).use(MockAdapter);
+    const sentry = new Client(dsn).use(MockAdapter);
     sentry.install();
     const spy1 = spy(sentry, 'captureMessage');
     const spy2 = spy(sentry.getAdapter(), 'captureMessage');
@@ -112,7 +110,7 @@ describe('Sentry.Client', () => {
   });
 
   it('call captureBreadcrumb on Adapter', async () => {
-    const sentry = new Sentry.Client(dsn).use(MockAdapter);
+    const sentry = new Client(dsn).use(MockAdapter);
     await sentry.install();
     const spy1 = spy(sentry, 'captureBreadcrumb');
     const spy2 = spy(sentry.getAdapter(), 'captureBreadcrumb');
@@ -122,7 +120,7 @@ describe('Sentry.Client', () => {
   });
 
   it('call captureException on Adapter', async () => {
-    const sentry = await new Sentry.Client(dsn).use(MockAdapter).install();
+    const sentry = await new Client(dsn).use(MockAdapter).install();
     const spy1 = spy(sentry, 'captureException');
     const spy2 = spy(sentry.getAdapter(), 'captureException');
     await sentry.captureException(new Error('oops'));
@@ -131,7 +129,7 @@ describe('Sentry.Client', () => {
   });
 
   it('call send only on one Adapter', async () => {
-    const sentry = await new Sentry.Client(dsn).use(MockAdapter).install();
+    const sentry = await new Client(dsn).use(MockAdapter).install();
     const spy1 = spy(sentry, 'captureMessage');
     const spy2 = spy(sentry.getAdapter(), 'captureMessage');
     const spySend = spy(sentry, 'send');
@@ -148,19 +146,19 @@ describe('Sentry.Client', () => {
   });
 
   it('call log only if bigger debug', () => {
-    const sentry = new Sentry.Client(dsn).use(MockAdapter);
+    const sentry = new Client(dsn).use(MockAdapter);
     const spy1 = spy(global.console, 'log');
     sentry.log('Nothing');
     expect(spy1.calledOnce).to.be.false;
-    sentry.options.logLevel = Sentry.LogLevel.Debug;
+    sentry.options.logLevel = LogLevel.Debug;
     sentry.log('This is fine');
     expect(spy1.calledOnce).to.be.true;
   });
 
   it('should throw error without calling install', async () => {
-    const sentry = new Sentry.Client(dsn).use(MockAdapter);
+    const sentry = new Client(dsn).use(MockAdapter);
     return sentry.captureException(new Error('oops')).catch(err => {
-      expect(err).to.be.instanceof(Sentry.SentryError);
+      expect(err).to.be.instanceof(SentryError);
       expect(err.message).to.equal(
         'Please call install() before calling other methods on Sentry',
       );
@@ -168,14 +166,14 @@ describe('Sentry.Client', () => {
   });
 
   it('call setOptions on Adapter', async () => {
-    const sentry = await new Sentry.Client(dsn).use(MockAdapter).install();
+    const sentry = await new Client(dsn).use(MockAdapter).install();
     const spy1 = spy(sentry.getAdapter(), 'setOptions');
     await sentry.setOptions({ release: '#oops' });
     expect(spy1.calledOnce).to.be.true;
   });
 
   it('setContext', async () => {
-    const sentry = await new Sentry.Client(dsn).use(MockAdapter).install();
+    const sentry = await new Client(dsn).use(MockAdapter).install();
     sentry.setContext({
       extra: { some: 'key' },
       tags: { key: 'test1', key2: 'test2' },
@@ -191,7 +189,7 @@ describe('Sentry.Client', () => {
     const beforeBreadcrumb = spy();
     const afterBreadcrumb = spy();
 
-    const sentry = new Sentry.Client(dsn, {
+    const sentry = new Client(dsn, {
       shouldAddBreadcrumb,
       beforeBreadcrumb,
       afterBreadcrumb,
@@ -213,7 +211,7 @@ describe('Sentry.Client', () => {
     const beforeBreadcrumb = spy();
     const afterBreadcrumb = spy();
 
-    const sentry = new Sentry.Client(dsn, {
+    const sentry = new Client(dsn, {
       shouldAddBreadcrumb,
       beforeBreadcrumb,
       afterBreadcrumb,
@@ -235,7 +233,7 @@ describe('Sentry.Client', () => {
     const beforeSend = spy();
     const afterSend = spy();
 
-    const sentry = new Sentry.Client(dsn, {
+    const sentry = new Client(dsn, {
       shouldSend,
       beforeSend,
       afterSend,
@@ -263,7 +261,7 @@ describe('Sentry.Client', () => {
     const beforeSend = spy();
     const afterSend = spy();
 
-    const sentry = new Sentry.Client(dsn, {
+    const sentry = new Client(dsn, {
       shouldSend,
       beforeSend,
       afterSend,

--- a/packages/core/test/lib/dsn.test.ts
+++ b/packages/core/test/lib/dsn.test.ts
@@ -1,7 +1,7 @@
 // tslint:disable
 import { expect } from 'chai';
 import DSN from '../../src/lib/dsn';
-import { SentryError } from '../../src/lib/sentry';
+import SentryError from '../../src/lib/error';
 
 describe('DSN', () => {
   it('should throw SentryError when provided invalid DSN', () => {

--- a/packages/core/test/mocks/MockAdapter.ts
+++ b/packages/core/test/mocks/MockAdapter.ts
@@ -1,11 +1,5 @@
-import {
-  Adapter,
-  Breadcrumb,
-  Client,
-  Context,
-  Options,
-  SentryEvent,
-} from '../../src/index';
+import Client, { Adapter, Options } from '../../src/lib/client';
+import { Breadcrumb, Context, SentryEvent } from '../../src/lib/interfaces';
 
 export interface MockAdapterOptions extends Options {
   testOption?: boolean;

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -1,3 +1,3 @@
-export { SentryNode, NodeOptions as SentryNodeOptions } from './lib/node';
+export { default, NodeOptions } from './lib/node';
 export { default as Store } from './lib/store';
 export { mkdirp, mkdirpSync } from './lib/utils';

--- a/packages/node/src/lib/node.ts
+++ b/packages/node/src/lib/node.ts
@@ -16,7 +16,7 @@ const captureRavenBreadcrumb = Raven.captureBreadcrumb;
 // tslint:disable-next-line:no-empty-interface
 export interface NodeOptions extends Options {}
 
-export class SentryNode implements Adapter {
+export default class SentryNode implements Adapter {
   private capturing: boolean = false;
   private captured: any;
 

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 
-import * as Sentry from '@sentry/core';
-import { SentryNode } from '../src/index';
+import Sentry from '@sentry/core';
+import SentryNode from '../src/index';
 
 describe('Test', () => {
   beforeEach(async () => {


### PR DESCRIPTION
Doesn't fully compile yet (something is broken in browser tests), but this is how we **could** structure our names and export them from the libraries.