### PR TITLE
Fix default fingerprinting when using synthetic traces

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -514,12 +514,14 @@ Raven.prototype = {
 
     options = options || {};
 
+    var strMsg = msg + ''; // Make sure it's actually a string
     var data = objectMerge(
       {
-        message: msg + '' // Make sure it's actually a string
+        message: strMsg
       },
       options
     );
+    var isFingerprint = isArray(data.fingerprint) && data.fingerprint.length;
 
     var ex;
     // Generate a "synthetic" stack trace from this point.
@@ -555,11 +557,13 @@ Raven.prototype = {
     }
 
     if (this._globalOptions.stacktrace || (options && options.stacktrace)) {
+      if (!isFingerprint) {
+        // fingerprint on msg, not stack trace (legacy behavior, could be
+        // revisited)
+        data.fingerprint = [strMsg];
+      }
       options = objectMerge(
         {
-          // fingerprint on msg, not stack trace (legacy behavior, could be
-          // revisited)
-          fingerprint: msg,
           trimHeadFrames: 0
         },
         options

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -3044,6 +3044,23 @@ describe('Raven (public API)', function() {
         var frames = Raven._send.lastCall.args[0].stacktrace.frames;
         assertSynthetic(frames);
       });
+
+      it('should send a default fingerprint if stacktrace:true is set via globalOptions', function() {
+        this.sinon.stub(Raven, 'isSetup').returns(true);
+        this.sinon.stub(Raven, '_send');
+
+        Raven._globalOptions.stacktrace = true;
+        function foo() {
+          Raven.captureMessage('foo');
+        }
+
+        foo();
+        var fingerprint = Raven._send.lastCall.args[0].fingerprint;
+
+        // the fingerprint should be the same as the message
+        // but wrapped in an array
+        assert.deepEqual(fingerprint, ['foo']);
+      });
     });
   });
 


### PR DESCRIPTION
I think I've found a bug w/ fingerprinting and synthetic traces.

When using synthetic traces via the globalOption `stracktrace: true`,  there is an attempt to maintain the legacy grouping behavior and [`fingerprint on msg, not stack trace`](https://github.com/getsentry/raven-js/blob/3.23.1/src/raven.js#L560).


Looks like when this was implemented, there was a few oversights. Here is the breaking [code](https://github.com/getsentry/raven-js/blob/3.23.1/src/raven.js#L562)
1. The default `fingerprint` is dropped and never gets to sentry
2. The `fingerprint` value is of the wrong type

First, there is an attempt to create a default `fingerprint` from the `msg` param passed to `captureMessage`. The `fingerprint` property is added to the `options` variable but the values from `options` are not merged back to `data` after the `fingerprint` property is set. The end-result is that `fingerprint` ends up getting dropped and it never makes it to sentry.

The other issue w/ the existing code is that `fingerprint` is set to a string value. Sentry does not like raw strings and it will ignore the `fingerprint` unless its an array of strings. I've modified the `fingerprint` value to be an array of strings.

Here is my setup and some of the JSON payloads to make things a little clearer.

Sentry 8.22.0
Raven 3.23.1
Config: `{stacktrace: true}`

before the fixes: (notice the `["{{ default }}"]` fingerprint)
<img width="591" alt="screen shot 2018-03-05 at 1 05 22 pm" src="https://user-images.githubusercontent.com/1317941/37012078-aab2d174-20a7-11e8-90c1-5c381044b188.png">

after including the `fingerprint` as a string: (note the `fingerprint` and the `errors`)
<img width="698" alt="screen shot 2018-03-05 at 4 44 44 pm" src="https://user-images.githubusercontent.com/1317941/37012096-c1b0081a-20a7-11e8-998f-ff82b8283ac5.png">


after including the `fingerprint` as an array:
<img width="704" alt="screen shot 2018-03-05 at 4 44 14 pm" src="https://user-images.githubusercontent.com/1317941/37012113-dd8e3372-20a7-11e8-9d77-454f0291e4f8.png">


