### PR TITLE
Use XMLHttpRequest on window

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1244,7 +1244,7 @@ Raven.prototype = {
     }
 
     if (autoBreadcrumbs.xhr && 'XMLHttpRequest' in _window) {
-      var xhrproto = XMLHttpRequest.prototype;
+      var xhrproto = _window.XMLHttpRequest.prototype;
       fill(
         xhrproto,
         'open',


### PR DESCRIPTION
Fixes loading raven in a JS dom environment

