### PR TITLE
Feature Request | Allow Multiple Raven Instances

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -322,10 +322,7 @@ module.exports = function(grunt) {
     'browserify.core',
     ['_prep', 'browserify:core'].concat(browserifyPluginTaskNames)
   );
-  grunt.registerTask('browserify.plugins-combined', [
-    '_prep',
-    'browserify:plugins-combined'
-  ]);
+
   grunt.registerTask('build.test', ['_prep', 'browserify.core', 'browserify:test']);
   grunt.registerTask('build.core', ['browserify.core', 'uglify', 'sri:dist']);
   grunt.registerTask('build.plugins-combined', [
@@ -334,7 +331,7 @@ module.exports = function(grunt) {
     'sri:dist',
     'sri:build'
   ]);
-  grunt.registerTask('build', ['build.plugins-combined']);
+  grunt.registerTask('build', ['_prep', 'browserify:plugins-combined']);
   grunt.registerTask('dist', ['build.core', 'copy:dist']);
 
   grunt.registerTask('test:ci', ['config:ci', 'build.test']);
@@ -343,5 +340,5 @@ module.exports = function(grunt) {
   grunt.registerTask('run:test', ['build.test', 'connect:test']);
   grunt.registerTask('run:docs', ['connect:docs']);
 
-  grunt.registerTask('publish', ['build.plugins-combined', 's3']);
+  grunt.registerTask('publish', ['build', 's3']);
 };

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -106,6 +106,10 @@ module.exports = function(grunt) {
       src: 'src/singleton.js',
       dest: 'build/raven.js'
     },
+    bloodRaven: {
+      src: 'src/bloodRaven.js',
+      dest: 'build/bloodRaven.js'
+    },
     'plugins-combined': {
       files: pluginConcatFiles,
       options: {
@@ -320,7 +324,7 @@ module.exports = function(grunt) {
   grunt.registerTask('_prep', ['clean', 'gitinfo', 'version']);
   grunt.registerTask(
     'browserify.core',
-    ['_prep', 'browserify:core'].concat(browserifyPluginTaskNames)
+    ['browserify:core'].concat(browserifyPluginTaskNames)
   );
 
   grunt.registerTask('build.test', ['_prep', 'browserify.core', 'browserify:test']);
@@ -331,8 +335,8 @@ module.exports = function(grunt) {
     'sri:dist',
     'sri:build'
   ]);
-  grunt.registerTask('build', ['_prep', 'browserify:plugins-combined']);
-  grunt.registerTask('dist', ['build.core', 'copy:dist']);
+  grunt.registerTask('build', ['_prep', 'browserify:bloodRaven', 'browserify:plugins-combined']);
+  grunt.registerTask('dist', ['_prep', 'browserify:bloodRaven', 'build.core', 'copy:dist']);
 
   grunt.registerTask('test:ci', ['config:ci', 'build.test']);
 

--- a/src/bloodRaven.js
+++ b/src/bloodRaven.js
@@ -1,0 +1,7 @@
+var RavenConstructor = require('./raven');
+var Raven = require('./singleton');
+
+module.exports = {
+  Raven: Raven,
+  RavenConstructor: RavenConstructor
+};


### PR DESCRIPTION
**This PR creates a new bundle exposing both Raven constructor and singleton.**

This functionality has been mentioned [before](https://github.com/getsentry/raven-js/issues/834).

Our web application is constructed as a composite of multiple sub-applications, which run in the same tab or worker. Each sub-application is developed and managed independently by a separate group. Each one of these groups wants to have its own DSN so that it can monitor its sub-application independently. Besides that the main application has its own Raven singleton.
Thus we need both Raven constructor and Raven singleton and we’d like to avoid fetching / bundling Raven twice. Unfortunately, the current API doesn’t allow this.