### PR TITLE
raven - add flag for unhandled promise rejections

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -426,7 +426,7 @@ Raven.prototype = {
    */
   _promiseRejectionHandler: function(event) {
     this._logDebug('debug', 'Raven caught unhandled promise rejection:', event);
-    this.captureException(event.reason);
+    this.captureException(event.reason, { unhandledPromiseRejection: true });
   },
 
   /**


### PR DESCRIPTION
It would be nice to maintain the context that an error was submitted by an unhandled promise rejection. This PR intends to be one possible solution. 

First time contributor to Raven-js, looking for feedback. Happy to try another approach or add tests.