### PR TITLE
fix(core): Initialize internal scope when the frontend is ready

### DIFF
--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -72,7 +72,7 @@ export abstract class FrontendBase<B extends Backend, O extends Options>
    * specified to the public methods. This is specifically used in standalone
    * mode, when the Frontend is directly instanciated by the user.
    */
-  private readonly internalScope: Scope = this.getInitialScope();
+  private readonly internalScope: Scope;
 
   /**
    * Stores whether installation has been performed and was successful. Before
@@ -93,6 +93,9 @@ export abstract class FrontendBase<B extends Backend, O extends Options>
     if (options.dsn) {
       this.dsn = new DSN(options.dsn);
     }
+
+    // The initial scope must have access to backend, options and DSN
+    this.internalScope = this.getInitialScope();
   }
 
   /**

--- a/packages/core/test/lib/base.test.ts
+++ b/packages/core/test/lib/base.test.ts
@@ -2,7 +2,8 @@ import { Breadcrumb, SentryEvent } from '@sentry/shim';
 import { expect } from 'chai';
 import { spy } from 'sinon';
 import { SentryError } from '../../src/error';
-import { TestBackend } from '../mocks/backend';
+import { Scope } from '../../src/interfaces';
+import { TestBackend, TestOptions } from '../mocks/backend';
 import { TEST_SDK, TestFrontend } from '../mocks/frontend';
 
 const PUBLIC_DSN = 'https://username@domain/path';
@@ -21,6 +22,27 @@ describe('FrontendBase', () => {
 
     it('throws with invalid DSN', () => {
       expect(() => new TestFrontend({ dsn: 'abc' })).to.throw(SentryError);
+    });
+
+    it('initializes the internal scope', () => {
+      const options = { dsn: PUBLIC_DSN };
+      const scope = { breadcrumbs: [], context: { extra: { custom: true } } };
+
+      class TempFrontend extends TestFrontend {
+        public constructor(opts: TestOptions) {
+          super(opts);
+          expect(this.getInternalScope()).to.equal(scope);
+        }
+
+        public getInitialScope(): Scope {
+          expect(this.getBackend()).to.equal(TestBackend.instance);
+          expect(this.getOptions()).to.equal(options);
+          expect(this.getDSN()!.toString()).to.equal(PUBLIC_DSN);
+          return scope;
+        }
+      }
+
+      new TempFrontend(options);
     });
   });
 


### PR DESCRIPTION
The `internalScope` was initialized directly in the field and not in its constructor. Thus, `backend` and `options` were not available to `getInitialScope()`. This PR fixes this.