### PR TITLE
fix(node): Correctly handle onFatalError

### DIFF
--- a/packages/browser/src/backend.ts
+++ b/packages/browser/src/backend.ts
@@ -10,11 +10,7 @@ import { Raven, SendMethod } from './raven';
 /** Original raven send function. */
 const sendRavenEvent = Raven._sendProcessedPayload.bind(Raven) as SendMethod;
 
-/**
- * Normalizes the event so it is consistent with our domain interface.
- * @param event
- * @returns
- */
+/** Normalizes the event so it is consistent with our domain interface. */
 function normalizeRavenEvent(event: SentryEvent): SentryEvent {
   const ex = (event.exception || {}) as { values?: SentryException[] };
   if (ex && ex.values) {
@@ -24,11 +20,7 @@ function normalizeRavenEvent(event: SentryEvent): SentryEvent {
   return event;
 }
 
-/**
- * Prepares an event so it can be send with raven-js.
- * @param event
- * @returns
- */
+/** Prepares an event so it can be send with raven-js. */
 function prepareEventForRaven(event: SentryEvent): SentryEvent {
   const ravenEvent = event as any;
   if (event.exception) {
@@ -44,29 +36,29 @@ function prepareEventForRaven(event: SentryEvent): SentryEvent {
  */
 export interface BrowserOptions extends Options {
   /**
-   * A pattern for error messages which should not be sent to Sentry.
-   * By default, all errors will be sent.
+   * A pattern for error messages which should not be sent to Sentry. By
+   * default, all errors will be sent.
    */
   ignoreErrors?: Array<string | RegExp>;
 
   /**
-   * A pattern for error URLs which should not be sent to Sentry.
-   * To whitelist certain errors instead, use {@link Options.whitelistUrls}.
-   * By default, all errors will be sent.
+   * A pattern for error URLs which should not be sent to Sentry. To whitelist
+   * certain errors instead, use {@link Options.whitelistUrls}. By default, all
+   * errors will be sent.
    */
   ignoreUrls?: Array<string | RegExp>;
 
   /**
-   * A pattern for error URLs which should exclusively be sent to Sentry.
-   * This is the opposite of {@link Options.ignoreUrls}.
-   * By default, all errors will be sent.
+   * A pattern for error URLs which should exclusively be sent to Sentry. This
+   * is the opposite of {@link Options.ignoreUrls}. By default, all errors will
+   * be sent.
    */
   whitelistUrls?: Array<string | RegExp>;
 
   /**
    * Defines a list source code file paths. Only errors including these paths in
-   * their stack traces will be sent to Sentry.
-   * By default, all errors will be sent.
+   * their stack traces will be sent to Sentry. By default, all errors will be
+   * sent.
    */
   includePaths?: Array<string | RegExp>;
 }
@@ -97,9 +89,9 @@ export class BrowserBackend implements Backend {
 
     Raven.config(dsn.toString(), this.frontend.getOptions()).install();
 
-    // Hook into Raven's breadcrumb mechanism. This allows us to intercept
-    // both breadcrumbs created internally by Raven and pass them to the
-    // Frontend first, before actually capturing them.
+    // Hook into Raven's breadcrumb mechanism. This allows us to intercept both
+    // breadcrumbs created internally by Raven and pass them to the Frontend
+    // first, before actually capturing them.
     Raven.setBreadcrumbCallback(breadcrumb => {
       addBreadcrumb(breadcrumb);
       return false;

--- a/packages/browser/src/frontend.ts
+++ b/packages/browser/src/frontend.ts
@@ -15,6 +15,7 @@ export class BrowserFrontend extends FrontendBase<
 > {
   /**
    * Creates a new Browser SDK instance.
+   *
    * @param options Configuration options for this SDK.
    */
   public constructor(options: BrowserOptions) {

--- a/packages/core/src/status.ts
+++ b/packages/core/src/status.ts
@@ -14,8 +14,7 @@ export enum SendStatus {
   Failed = 'failed',
 }
 
-// tslint:disable:no-unnecessary-qualifier
-// tslint:disable-next-line:no-namespace
+// tslint:disable:no-unnecessary-qualifier no-namespace
 export namespace SendStatus {
   /**
    * Converts a HTTP status code into a {@link SendStatus}.

--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -19,10 +19,11 @@ export interface NodeOptions extends Options {
 
   /**
    * Enables/disables automatic collection of breadcrumbs. Possible values are:
-   * false - all automatic breadcrumb collection disabled (default)
-   * true - all automatic breadcrumb collection enabled
-   * A dictionary of individual breadcrumb types that can be enabled/disabled:
-   * e.g.: { console: true, http: false }
+   *
+   *  - `false`: all automatic breadcrumb collection disabled (default)
+   *  - `true`: all automatic breadcrumb collection enabled
+   *  - A dictionary of individual breadcrumb types that can be
+   *    enabled/disabled: e.g.: `{ console: true, http: false }`
    */
   autoBreadcrumbs?: { [key: string]: boolean } | boolean;
 
@@ -56,16 +57,16 @@ export class NodeBackend implements Backend {
 
     Raven.config(dsn.toString(true), this.frontend.getOptions()).install();
 
-    // There is no option for this so we have to overwrite it like this.
-    // We need this in SentryElectron.
+    // There is no option for this so we have to overwrite it like this. We need
+    // this in SentryElectron.
     const { onFatalError } = this.frontend.getOptions();
     if (onFatalError) {
       Raven.onFatalError = onFatalError;
     }
 
-    // Hook into Raven's breadcrumb mechanism. This allows us to intercept
-    // both breadcrumbs created internally by Raven and pass them to the
-    // Frontend first, before actually capturing them.
+    // Hook into Raven's breadcrumb mechanism. This allows us to intercept both
+    // breadcrumbs created internally by Raven and pass them to the Frontend
+    // first, before actually capturing them.
     Raven.captureBreadcrumb = breadcrumb => {
       addBreadcrumb(breadcrumb);
     };

--- a/packages/node/src/raven.ts
+++ b/packages/node/src/raven.ts
@@ -9,8 +9,7 @@ export interface RavenInternal {
   captureException(exception: any, cb?: (event: SentryEvent) => void): void;
   captureMessage(message: string, cb?: (event: SentryEvent) => void): void;
   config(dsn: string, options: object): RavenInternal;
-  onFatalError(error: Error): void;
-  install(): void;
+  install(onFatalError?: (error: Error) => void): void;
   send: SendMethod;
   version: string;
 }

--- a/packages/node/src/raven.ts
+++ b/packages/node/src/raven.ts
@@ -1,7 +1,7 @@
 import { Breadcrumb, SentryEvent } from '@sentry/shim';
 import * as RavenNode from 'raven';
 
-export type SendMethod = (event: SentryEvent, cb: (err: any) => void) => void;
+export type SendMethod = (event: SentryEvent, cb?: (err: any) => void) => void;
 
 /** Provides access to internal raven functionality. */
 export interface RavenInternal {

--- a/packages/shim/src/shim.ts
+++ b/packages/shim/src/shim.ts
@@ -5,8 +5,8 @@ import { ScopeLayer } from './interfaces';
 /**
  * API compatibility version of this shim.
  *
- * WARNING: This number should only be incresed when the global interface changes a
- * and new methods are introduced.
+ * WARNING: This number should only be incresed when the global interface
+ * changes a and new methods are introduced.
  */
 export const API_VERSION = 1;
 

--- a/packages/shim/test/lib/shim.test.ts
+++ b/packages/shim/test/lib/shim.test.ts
@@ -29,7 +29,7 @@ describe('Shim', () => {
 
   it('captures an exception', () => {
     const client = {
-      captureException: spy(),
+      captureException: spy(async () => Promise.resolve()),
     };
     withScope(client, () => {
       const e = new Error('test exception');
@@ -40,7 +40,7 @@ describe('Shim', () => {
 
   it('captures a message', () => {
     const client = {
-      captureMessage: spy(),
+      captureMessage: spy(async () => Promise.resolve()),
     };
     withScope(client, () => {
       const message = 'yo';
@@ -51,7 +51,7 @@ describe('Shim', () => {
 
   it('captures an event', () => {
     const client = {
-      captureEvent: spy(),
+      captureEvent: spy(async () => Promise.resolve()),
     };
     withScope(client, () => {
       const e = { message: 'test' };

--- a/packages/utils/src/fs.ts
+++ b/packages/utils/src/fs.ts
@@ -11,8 +11,8 @@ const _0777 = parseInt('0777', 8);
  * @returns A Promise that resolves when the path has been created.
  */
 async function mkdirAsync(path: string, mode: number): Promise<void> {
-  // We cannot use util.promisify here because that was only introduced
-  // in Node 8 and we need to support older Node versions.
+  // We cannot use util.promisify here because that was only introduced in Node
+  // 8 and we need to support older Node versions.
   return new Promise<void>((res, reject) => {
     mkdir(path, mode, err => {
       if (err) {

--- a/packages/utils/src/store.ts
+++ b/packages/utils/src/store.ts
@@ -3,8 +3,8 @@ import { dirname, join } from 'path';
 import { mkdirpSync } from './fs';
 
 /**
- * Lazily serializes data to a JSON file to persist.
- * When created, it loads data from that file if it already exists.
+ * Lazily serializes data to a JSON file to persist. When created, it loads data
+ * from that file if it already exists.
  */
 export class Store<T> {
   /** Internal path for JSON file. */


### PR DESCRIPTION
`Raven.send` wasn't overridden correctly, which caused globally unhandled exceptions not to be captured. 

**Explanation**

`Raven.send` is called in three situations:
1. When the user calls `captureException` or `captureMessage` on the new SDK wrapper. Those methods must return the generated event instead of sending them.
2. When intercepting an error from a wrapped function. In that case, the shim's `captureEvent` has to be called to redirect to the proper scope/frontend.
3. When catching globally unhandled exceptions. This has to go to the shim's `captureEvent`, again.

**Solution**

For case (1), we inject a callback function that has `__SENTRY_CAPTURE__` set to true. In that case, we simply call the callback, which will resolve a promise inside `eventFromException` to return that value as expected. 

For all other cases, we capture the event using `this.frontend.captureEvent` and then resolve the callback. There is two caveats, though:
 - It should actually call `captureEvent` from `@sentry/shim`, but that does not support a callback yet. However, we need to wait until the event has been sent before issuing the callback. 
 - The callback *should* receive the event ID as second parameter, but we don't generate that yet in the core.