### PR TITLE
_document.attachEvent check Condition

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1387,7 +1387,7 @@ Raven.prototype = {
       if (_document.addEventListener) {
         _document.addEventListener('click', self._breadcrumbEventHandler('click'), false);
         _document.addEventListener('keypress', self._keypressEventHandler(), false);
-      } else {
+      } else if(_document.attachEvent){
         // IE8 Compatibility
         _document.attachEvent('onclick', self._breadcrumbEventHandler('click'));
         _document.attachEvent('onkeypress', self._keypressEventHandler());


### PR DESCRIPTION
when  this plugin use  with native Script so get errro _document.attachEvent is not a function


Before submitting a pull request, please verify the following:

* [ ] If you've added code that should be tested, please add tests.
* [ ] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [ ] Ensure your code lints and the test suite passes (npm test).
