### PR TITLE
build(browser): Include raven-js in the dist build

### DIFF
--- a/packages/browser/package.json
+++ b/packages/browser/package.json
@@ -15,8 +15,7 @@
   },
   "dependencies": {
     "@sentry/core": "0.5.0-beta.4",
-    "@sentry/shim": "0.5.0-beta.4",
-    "raven-js": "^3.24.0"
+    "@sentry/shim": "0.5.0-beta.4"
   },
   "devDependencies": {
     "chai": "^4.1.2",
@@ -30,6 +29,7 @@
     "npm-run-all": "^4.1.2",
     "prettier": "^1.11.1",
     "prettier-check": "^2.0.0",
+    "raven-js": "^3.24.0",
     "rimraf": "^2.6.2",
     "rollup": "^0.57.1",
     "rollup-plugin-commonjs": "^9.1.0",

--- a/packages/browser/rollup.config.js
+++ b/packages/browser/rollup.config.js
@@ -13,10 +13,15 @@ export default [
       exports: 'named',
       interop: false,
     },
-    external: ['raven-js', '@sentry/core', '@sentry/shim'],
+    external: ['@sentry/core', '@sentry/shim'],
     plugins: [
       typescript({
         tsconfig: 'tsconfig.build.json',
+      }),
+      resolve({
+        jsnext: true,
+        main: true,
+        browser: true,
       }),
       commonjs(),
     ],


### PR DESCRIPTION
This always bundles raven-js into the `dist` build of `@sentry/browser` and removes it from production dependencies. This should help to make the installation size smaller, since `raven-js` is quite a heavy package.