### PR TITLE
ref: Rename Sentry.create to Sentry.init in all layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Setup and usage of these SDKs always follows the same principle. In Node, for
 example (on another platform simply substitute the import):
 
 ```javascript
-const { create, captureMessage } = require('@sentry/node');
+const { init, captureMessage } = require('@sentry/node');
 
-create({
+init({
   dsn: '__DSN__',
   // ...
 });

--- a/packages/browser/README.md
+++ b/packages/browser/README.md
@@ -19,14 +19,14 @@ compatibility from time to time. We absolutely recommend
 
 ## Usage
 
-To use this SDK, call `create(options)` as early as possible after loading the
+To use this SDK, call `init(options)` as early as possible after loading the
 page. This will initialize the SDK and hook into the environment. Note that you
 can turn off almost all side effects using the respective options.
 
 ```javascript
-import { create } from '@sentry/browser';
+import { init } from '@sentry/browser';
 
-create({
+init({
   dsn: '__DSN__',
   // ...
 });
@@ -34,7 +34,7 @@ create({
 
 To set context information or send manual events, use the exported functions of
 `@sentry/browser`. Note that these functions will not perform any action before
-you have called `create()`:
+you have called `init()`:
 
 ```javascript
 import * as Sentry from '@sentry/browser';

--- a/packages/browser/src/index.ts
+++ b/packages/browser/src/index.ts
@@ -28,4 +28,4 @@ export {
 
 export { BrowserBackend, BrowserOptions } from './backend';
 export { BrowserFrontend } from './frontend';
-export { create, getCurrentFrontend } from './sdk';
+export { init, getCurrentFrontend } from './sdk';

--- a/packages/browser/src/sdk.ts
+++ b/packages/browser/src/sdk.ts
@@ -1,4 +1,4 @@
-import { createAndBind } from '@sentry/core';
+import { initAndBind } from '@sentry/core';
 import { getCurrentClient } from '@sentry/shim';
 import { BrowserOptions } from './backend';
 import { BrowserFrontend } from './frontend';
@@ -6,14 +6,14 @@ import { BrowserFrontend } from './frontend';
 /**
  * The Sentry Browser SDK Client.
  *
- * To use this SDK, call the {@link create} function as early as possible when
+ * To use this SDK, call the {@link init} function as early as possible when
  * loading the web page. To set context information or send manual events, use
  * the provided methods.
  *
  * @example
- * import { create } from '@sentry/browser';
+ * import { init } from '@sentry/browser';
  *
- * create({
+ * init({
  *   dsn: '__DSN__',
  *   // ...
  * });
@@ -46,8 +46,8 @@ import { BrowserFrontend } from './frontend';
  *
  * @see BrowserOptions for documentation on configuration options.
  */
-export function create(options: BrowserOptions): void {
-  createAndBind(BrowserFrontend, options);
+export function init(options: BrowserOptions): void {
+  initAndBind(BrowserFrontend, options);
 }
 
 /** Returns the current BrowserFrontend, if any. */

--- a/packages/browser/test/index.test.ts
+++ b/packages/browser/test/index.test.ts
@@ -9,7 +9,7 @@ import {
   captureException,
   captureMessage,
   Context,
-  create,
+  init,
   popScope,
   pushScope,
   SentryEvent,
@@ -22,7 +22,7 @@ const dsn = 'https://53039209a22b4ec1bcc296a3c9fdecd6@sentry.io/4291';
 
 describe('SentryBrowser', () => {
   before(() => {
-    create({ dsn });
+    init({ dsn });
   });
 
   describe('getContext() / setContext()', () => {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -2,4 +2,4 @@ export { BackendClass, FrontendBase } from './base';
 export { DSN, DSNComponents, DSNLike, DSNProtocol } from './dsn';
 export { SentryError } from './error';
 export { Backend, Frontend, LogLevel, Options, Scope } from './interfaces';
-export { createAndBind, FrontendClass } from './sdk';
+export { initAndBind, FrontendClass } from './sdk';

--- a/packages/core/src/sdk.ts
+++ b/packages/core/src/sdk.ts
@@ -24,7 +24,7 @@ export interface FrontendClass<F extends Frontend, O extends Options> {
  * @param options Options to pass to the frontend.
  * @returns The installed and bound frontend instance.
  */
-export function createAndBind<F extends Frontend, O extends Options>(
+export function initAndBind<F extends Frontend, O extends Options>(
   frontendClass: FrontendClass<F, O>,
   options: O,
 ): void {

--- a/packages/core/test/mocks/frontend.ts
+++ b/packages/core/test/mocks/frontend.ts
@@ -1,6 +1,6 @@
 import { SdkInfo } from '@sentry/shim';
 import { FrontendBase } from '../../src/base';
-import { createAndBind } from '../../src/sdk';
+import { initAndBind } from '../../src/sdk';
 import { TestBackend, TestOptions } from './backend';
 
 export const TEST_SDK = {
@@ -21,6 +21,6 @@ export class TestFrontend extends FrontendBase<TestBackend, TestOptions> {
   }
 }
 
-export function create(options: TestOptions): void {
-  createAndBind(TestFrontend, options);
+export function init(options: TestOptions): void {
+  initAndBind(TestFrontend, options);
 }

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -19,14 +19,14 @@ compatibility from time to time. We absolutely recommend
 
 ## Usage
 
-To use this SDK, call `create(options)` as early as possible in the main entry
+To use this SDK, call `init(options)` as early as possible in the main entry
 module. This will initialize the SDK and hook into the environment. Note that
 you can turn off almost all side effects using the respective options.
 
 ```javascript
 const Sentry = require('@sentry/node');
 
-Sentry.create({
+Sentry.init({
   dsn: '__DSN__',
   // ...
 });
@@ -34,7 +34,7 @@ Sentry.create({
 
 To set context information or send manual events, use the exported functions of
 `@sentry/node`. Note that these functions will not perform any action before you
-have called `create()`:
+have called `init()`:
 
 ```javascript
 // Set user information, as well as tags and further extras

--- a/packages/node/src/index.ts
+++ b/packages/node/src/index.ts
@@ -28,4 +28,4 @@ export {
 
 export { NodeBackend, NodeOptions } from './backend';
 export { NodeFrontend } from './frontend';
-export { create, getCurrentFrontend } from './sdk';
+export { init, getCurrentFrontend } from './sdk';

--- a/packages/node/src/sdk.ts
+++ b/packages/node/src/sdk.ts
@@ -1,4 +1,4 @@
-import { createAndBind } from '@sentry/core';
+import { initAndBind } from '@sentry/core';
 import { getCurrentClient } from '@sentry/shim';
 import { NodeOptions } from './backend';
 import { NodeFrontend } from './frontend';
@@ -6,14 +6,14 @@ import { NodeFrontend } from './frontend';
 /**
  * The Sentry Node SDK Client.
  *
- * To use this SDK, call the {@link create} function as early as possible in the
+ * To use this SDK, call the {@link init} function as early as possible in the
  * main entry module. To set context information or send manual events, use the
  * provided methods.
  *
  * @example
- * const { create } = require('@sentry/node');
+ * const { init } = require('@sentry/node');
  *
- * create({
+ * init({
  *   dsn: '__DSN__',
  *   // ...
  * });
@@ -46,8 +46,8 @@ import { NodeFrontend } from './frontend';
  *
  * @see NodeOptions for documentation on configuration options.
  */
-export function create(options: NodeOptions): void {
-  createAndBind(NodeFrontend, options);
+export function init(options: NodeOptions): void {
+  initAndBind(NodeFrontend, options);
 }
 
 /** Returns the current NodeFrontend, if any. */

--- a/packages/node/test/index.test.ts
+++ b/packages/node/test/index.test.ts
@@ -16,7 +16,7 @@ import {
   captureException,
   captureMessage,
   Context,
-  create,
+  init,
   NodeBackend,
   NodeFrontend,
   popScope,
@@ -31,7 +31,7 @@ const dsn = 'https://53039209a22b4ec1bcc296a3c9fdecd6@sentry.io/4291';
 
 describe('SentryNode', () => {
   beforeEach(() => {
-    create({ dsn });
+    init({ dsn });
   });
 
   describe('getContext() / setContext()', () => {

--- a/packages/shim/test/lib/shim.test.ts
+++ b/packages/shim/test/lib/shim.test.ts
@@ -15,7 +15,7 @@ import {
   setUserContext,
   withScope,
 } from '../../src';
-import { create, TestClient, TestClient2 } from '../mocks/client';
+import { init, TestClient, TestClient2 } from '../mocks/client';
 
 declare var global: any;
 
@@ -134,7 +134,7 @@ describe('Shim', () => {
   });
 
   it('returns the bound client', () => {
-    create({});
+    init({});
     expect(getCurrentClient()).to.equal(TestClient.instance);
   });
 
@@ -149,7 +149,7 @@ describe('Shim', () => {
   });
 
   it('does not throw an error when pushing different clients', () => {
-    create({});
+    init({});
     expect(() => {
       withScope(new TestClient2(), () => {
         //
@@ -158,7 +158,7 @@ describe('Shim', () => {
   });
 
   it('does not throw an error when pushing same clients', () => {
-    create({});
+    init({});
     expect(() => {
       withScope(new TestClient({}), () => {
         //

--- a/packages/shim/test/mocks/client.ts
+++ b/packages/shim/test/mocks/client.ts
@@ -14,6 +14,6 @@ export class TestClient {
 
 export class TestClient2 {}
 
-export function create(options: object): void {
+export function init(options: object): void {
   bindClient(new TestClient(options));
 }


### PR DESCRIPTION
This name better reflects what this function is actually doing. Coordinated with work in sentry-rust.