### PR TITLE
raven - capture breadcrumb on failed request

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1378,6 +1378,17 @@ Raven.prototype = {
               });
 
               return response;
+            }).catch(function(err) {
+
+              // if there is an error performing the request
+              self.captureBreadcrumb({
+                type: 'http',
+                category: 'fetch',
+                data: fetchData,
+                level: 'error',
+              });
+
+              throw err;
             });
           };
         },

--- a/src/raven.js
+++ b/src/raven.js
@@ -1368,28 +1368,30 @@ Raven.prototype = {
               status_code: null
             };
 
-            return origFetch.apply(this, args).then(function(response) {
-              fetchData.status_code = response.status;
+            return origFetch
+              .apply(this, args)
+              .then(function(response) {
+                fetchData.status_code = response.status;
 
-              self.captureBreadcrumb({
-                type: 'http',
-                category: 'fetch',
-                data: fetchData
+                self.captureBreadcrumb({
+                  type: 'http',
+                  category: 'fetch',
+                  data: fetchData
+                });
+
+                return response;
+              })
+              ['catch'](function(err) {
+                // if there is an error performing the request
+                self.captureBreadcrumb({
+                  type: 'http',
+                  category: 'fetch',
+                  data: fetchData,
+                  level: 'error'
+                });
+
+                throw err;
               });
-
-              return response;
-            }).catch(function(err) {
-
-              // if there is an error performing the request
-              self.captureBreadcrumb({
-                type: 'http',
-                category: 'fetch',
-                data: fetchData,
-                level: 'error',
-              });
-
-              throw err;
-            });
           };
         },
         wrappedBuiltIns
@@ -1402,7 +1404,7 @@ Raven.prototype = {
       if (_document.addEventListener) {
         _document.addEventListener('click', self._breadcrumbEventHandler('click'), false);
         _document.addEventListener('keypress', self._keypressEventHandler(), false);
-      } else if(_document.attachEvent){
+      } else if (_document.attachEvent) {
         // IE8 Compatibility
         _document.attachEvent('onclick', self._breadcrumbEventHandler('click'));
         _document.attachEvent('onkeypress', self._keypressEventHandler());


### PR DESCRIPTION
Fixes #1009 

If there is an issue performing the request (**not** an error response from the server), we don't get any data about what failed, only a `TypeError: Failed to Fetch` with no trace or hint of what was being fetched.

With this change, we capture a breadcrumb indicating that the fetch failed, then re-throw the error.

If there is no additional `catch` in the chain, this will result in an unhandled promise rejection with the original unhelpful error message: `TypeError: Failed to Fetch`.

Question: can you set a log level on a `type: 'http'` breadcrumb? will this be rendered correctly in Sentry?