### PR TITLE
fix(core): Limit maxBreadcrumbs to [0; 100] and default to 30

### DIFF
--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -7,7 +7,13 @@ import { SendStatus } from './status';
  * Default maximum number of breadcrumbs added to an event. Can be overwritten
  * with {@link Options.maxBreadcrumbs}.
  */
-const MAX_BREADCRUMBS = 30;
+const DEFAULT_BREADCRUMBS = 30;
+
+/**
+ * Absolute maximum number of breadcrumbs added to an event. The
+ * `maxBreadcrumbs` option cannot be higher than this value.
+ */
+const MAX_BREADCRUMBS = 100;
 
 /** A class object that can instanciate Backend objects. */
 export interface BackendClass<B extends Backend, O extends Options> {
@@ -156,7 +162,7 @@ export abstract class FrontendBase<B extends Backend, O extends Options>
       shouldAddBreadcrumb,
       beforeBreadcrumb,
       afterBreadcrumb,
-      maxBreadcrumbs = MAX_BREADCRUMBS,
+      maxBreadcrumbs = DEFAULT_BREADCRUMBS,
     } = this.getOptions();
 
     if (maxBreadcrumbs <= 0) {
@@ -175,7 +181,7 @@ export abstract class FrontendBase<B extends Backend, O extends Options>
 
     if (await this.getBackend().storeBreadcrumb(finalBreadcrumb, scope)) {
       scope.breadcrumbs = [...scope.breadcrumbs, finalBreadcrumb].slice(
-        -Math.max(0, Math.min(maxBreadcrumbs, 100)),
+        -Math.max(0, Math.min(maxBreadcrumbs, MAX_BREADCRUMBS)),
       );
     }
 
@@ -267,7 +273,7 @@ export abstract class FrontendBase<B extends Backend, O extends Options>
   ): Promise<SentryEvent> {
     const {
       environment,
-      maxBreadcrumbs = MAX_BREADCRUMBS,
+      maxBreadcrumbs = DEFAULT_BREADCRUMBS,
       release,
     } = this.getOptions();
 
@@ -282,7 +288,7 @@ export abstract class FrontendBase<B extends Backend, O extends Options>
     const breadcrumbs = scope.breadcrumbs;
     if (breadcrumbs.length > 0 && maxBreadcrumbs > 0) {
       prepared.breadcrumbs = breadcrumbs.slice(
-        -Math.max(0, Math.min(maxBreadcrumbs, 100)),
+        -Math.max(0, Math.min(maxBreadcrumbs, MAX_BREADCRUMBS)),
       );
     }
 

--- a/packages/core/src/base.ts
+++ b/packages/core/src/base.ts
@@ -7,7 +7,7 @@ import { SendStatus } from './status';
  * Default maximum number of breadcrumbs added to an event. Can be overwritten
  * with {@link Options.maxBreadcrumbs}.
  */
-const MAX_BREADCRUMBS = 100;
+const MAX_BREADCRUMBS = 30;
 
 /** A class object that can instanciate Backend objects. */
 export interface BackendClass<B extends Backend, O extends Options> {
@@ -159,7 +159,7 @@ export abstract class FrontendBase<B extends Backend, O extends Options>
       maxBreadcrumbs = MAX_BREADCRUMBS,
     } = this.getOptions();
 
-    if (maxBreadcrumbs === 0) {
+    if (maxBreadcrumbs <= 0) {
       return;
     }
 
@@ -175,7 +175,7 @@ export abstract class FrontendBase<B extends Backend, O extends Options>
 
     if (await this.getBackend().storeBreadcrumb(finalBreadcrumb, scope)) {
       scope.breadcrumbs = [...scope.breadcrumbs, finalBreadcrumb].slice(
-        -maxBreadcrumbs,
+        -Math.max(0, Math.min(maxBreadcrumbs, 100)),
       );
     }
 
@@ -281,7 +281,9 @@ export abstract class FrontendBase<B extends Backend, O extends Options>
 
     const breadcrumbs = scope.breadcrumbs;
     if (breadcrumbs.length > 0 && maxBreadcrumbs > 0) {
-      prepared.breadcrumbs = breadcrumbs.slice(-maxBreadcrumbs);
+      prepared.breadcrumbs = breadcrumbs.slice(
+        -Math.max(0, Math.min(maxBreadcrumbs, 100)),
+      );
     }
 
     const context = scope.context;


### PR DESCRIPTION
The default for `maxBreadcrumbs` was incorrectly set to `100`. However, documentation says `30`, with a maximum possible value of `100`. This PR fixes this and adds an additional check for negative numbers.