### PR TITLE
[don't merge] fix: Don't blow-up when transport itself throws an error

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -110,6 +110,7 @@ function Raven() {
   // before the console plugin has a chance to monkey patch
   this._originalConsole = _window.console || {};
   this._originalConsoleMethods = {};
+  this._originalSetTimeout = _window.setTimeout.bind(_window);
   this._plugins = [];
   this._startTime = now();
   this._wrappedBuiltIns = [];
@@ -466,6 +467,9 @@ Raven.prototype = {
   captureException: function(ex, options) {
     options = objectMerge({trimHeadFrames: 0}, options ? options : {});
 
+    // Store the raw exception object for potential debugging and introspection
+    this._lastCapturedException = ex;
+
     if (isErrorEvent(ex) && ex.error) {
       // If it is an ErrorEvent with `error` property, extract it to get actual Error
       ex = ex.error;
@@ -492,9 +496,6 @@ Raven.prototype = {
         })
       );
     }
-
-    // Store the raw exception object for potential debugging and introspection
-    this._lastCapturedException = ex;
 
     // TraceKit.report will re-raise any exception passed to it,
     // which means you have to wrap it in try/catch. Instead, we
@@ -881,7 +882,7 @@ Raven.prototype = {
   _ignoreNextOnError: function() {
     var self = this;
     this._ignoreOnError += 1;
-    setTimeout(function() {
+    this._originalSetTimeout(function() {
       // onerror should trigger before setTimeout
       self._ignoreOnError -= 1;
     });
@@ -1002,7 +1003,7 @@ Raven.prototype = {
         self._breadcrumbEventHandler('input')(evt);
       }
       clearTimeout(timeout);
-      self._keypressTimeout = setTimeout(function() {
+      self._keypressTimeout = self._originalSetTimeout(function() {
         self._keypressTimeout = null;
       }, debounceDuration);
     };
@@ -1174,6 +1175,7 @@ Raven.prototype = {
 
     fill(_window, 'setTimeout', wrapTimeFn, wrappedBuiltIns);
     fill(_window, 'setInterval', wrapTimeFn, wrappedBuiltIns);
+
     if (_window.requestAnimationFrame) {
       fill(
         _window,
@@ -1988,35 +1990,59 @@ Raven.prototype = {
     }
 
     var url = this._globalEndpoint;
-    (globalOptions.transport || this._makeRequest).call(this, {
-      url: url,
-      auth: auth,
-      data: data,
-      options: globalOptions,
-      onSuccess: function success() {
-        self._resetBackoff();
 
-        self._triggerEvent('success', {
-          data: data,
-          src: url
-        });
-        callback && callback();
-      },
-      onError: function failure(error) {
-        self._logDebug('error', 'Raven transport failed to send: ', error);
+    try {
+      (globalOptions.transport || this._makeRequest).call(this, {
+        url: url,
+        auth: auth,
+        data: data,
+        options: globalOptions,
+        onSuccess: function success() {
+          self._resetBackoff();
 
-        if (error.request) {
-          self._setBackoffState(error.request);
+          self._triggerEvent('success', {
+            data: data,
+            src: url
+          });
+          callback && callback();
+        },
+        onError: function failure(error) {
+          self._logDebug('error', 'Raven transport failed to send: ', error);
+
+          if (error.request) {
+            self._setBackoffState(error.request);
+          }
+
+          self._triggerEvent('failure', {
+            data: data,
+            src: url
+          });
+          error =
+            error || new Error('Raven send failed (no additional details provided)');
+          callback && callback(error);
         }
+      });
+    } catch (e) {
+      // Something went wrong while invoking either default or user-provided transport function
+      // that should send previously caught exception
+      //
+      // We catch this error, try to send it to Sentry so that user knows what went wrong
+      // and then rethrow original exception so it's not magically swallowed,
+      // while making sure it's not caught again by our code
 
-        self._triggerEvent('failure', {
-          data: data,
-          src: url
-        });
-        error = error || new Error('Raven send failed (no additional details provided)');
-        callback && callback(error);
-      }
-    });
+      // `setTimeout` is required in order for `captureException` below not accidentally trigger
+      // this exact block again and fall into infinite loop.
+      // `e !== lastException` check will only work, once first exception
+      // is actually assigned to our private variable
+      self._originalSetTimeout(function() {
+        var lastException = self.lastException();
+        if (e !== lastException) {
+          self.captureException(e);
+          self._ignoreNextOnError();
+          throw lastException;
+        }
+      });
+    }
   },
 
   _makeRequest: function(opts) {


### PR DESCRIPTION
Resolves https://github.com/getsentry/raven-js/issues/1287

This one was tough to tackle, but I think it should be good enough.

`setTimeout` has to be cached, as we wrap it ourselves later on for instrumentation purposes.
And because it's, well, `wrapped`, it calls `_ignoreNextOnError` internally, which was making a quite large mess with this patch.