### PR TITLE
feat: Handle DOMError and DOMException gracefully

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -12,7 +12,7 @@ function isObject(what) {
 // Yanked from https://git.io/vS8DV re-used under CC0
 // with some tiny modifications
 function isError(value) {
-  switch ({}.toString.call(value)) {
+  switch (Object.prototype.toString.call(value)) {
     case '[object Error]':
       return true;
     case '[object Exception]':
@@ -25,7 +25,15 @@ function isError(value) {
 }
 
 function isErrorEvent(value) {
-  return supportsErrorEvent() && {}.toString.call(value) === '[object ErrorEvent]';
+  return Object.prototype.toString.call(value) === '[object ErrorEvent]';
+}
+
+function isDOMError(value) {
+  return Object.prototype.toString.call(value) === '[object DOMError]';
+}
+
+function isDOMException(value) {
+  return Object.prototype.toString.call(value) === '[object DOMException]';
 }
 
 function isUndefined(what) {
@@ -62,6 +70,24 @@ function isEmptyObject(what) {
 function supportsErrorEvent() {
   try {
     new ErrorEvent(''); // eslint-disable-line no-new
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function supportsDOMError() {
+  try {
+    new DOMError(''); // eslint-disable-line no-new
+    return true;
+  } catch (e) {
+    return false;
+  }
+}
+
+function supportsDOMException() {
+  try {
+    new DOMException(''); // eslint-disable-line no-new
     return true;
   } catch (e) {
     return false;
@@ -583,6 +609,8 @@ module.exports = {
   isObject: isObject,
   isError: isError,
   isErrorEvent: isErrorEvent,
+  isDOMError: isDOMError,
+  isDOMException: isDOMException,
   isUndefined: isUndefined,
   isFunction: isFunction,
   isPlainObject: isPlainObject,
@@ -590,6 +618,8 @@ module.exports = {
   isArray: isArray,
   isEmptyObject: isEmptyObject,
   supportsErrorEvent: supportsErrorEvent,
+  supportsDOMError: supportsDOMError,
+  supportsDOMException: supportsDOMException,
   supportsFetch: supportsFetch,
   supportsReferrerPolicy: supportsReferrerPolicy,
   supportsPromiseRejectionEvent: supportsPromiseRejectionEvent,

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -23,6 +23,8 @@ _Raven.prototype._getUuid = function() {
 var utils = require('../src/utils');
 var joinRegExp = utils.joinRegExp;
 var supportsErrorEvent = utils.supportsErrorEvent;
+var supportsDOMError = utils.supportsDOMError;
+var supportsDOMException = utils.supportsDOMException;
 var supportsFetch = utils.supportsFetch;
 var supportsReferrerPolicy = utils.supportsReferrerPolicy;
 var supportsPromiseRejectionEvent = utils.supportsPromiseRejectionEvent;
@@ -3121,6 +3123,29 @@ describe('Raven (public API)', function() {
         this.sinon.stub(Raven, 'captureMessage');
         Raven.captureException(error, {foo: 'bar'});
         assert.isTrue(Raven.captureMessage.calledOnce);
+      });
+    }
+
+    if (supportsDOMError()) {
+      it('should just pull name and message from DOMError and call captureMessage', function() {
+        var error = new DOMError('pickleRick', 'Morty');
+        this.sinon.stub(Raven, 'isSetup').returns(true);
+        this.sinon.spy(Raven, 'captureMessage');
+        Raven.captureException(error);
+        var call = Raven.captureMessage.getCall(0).args[0];
+        assert.equal(call, 'pickleRick: Morty');
+      });
+    }
+
+    if (supportsDOMException()) {
+      it('should just pull name and message from DOMException and call captureMessage', function() {
+        // Yes, in DOMException order of arguments is reversed...
+        var error = new DOMException('Morty', 'pickleRick');
+        this.sinon.stub(Raven, 'isSetup').returns(true);
+        this.sinon.spy(Raven, 'captureMessage');
+        Raven.captureException(error);
+        var call = Raven.captureMessage.getCall(0).args[0];
+        assert.equal(call, 'pickleRick: Morty');
       });
     }
 

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -12,9 +12,13 @@ var isString = utils.isString;
 var isArray = utils.isArray;
 var isObject = utils.isObject;
 var isEmptyObject = utils.isEmptyObject;
+var isDOMError = utils.isDOMError;
+var isDOMException = utils.isDOMException;
 var isError = utils.isError;
 var isErrorEvent = utils.isErrorEvent;
 var supportsErrorEvent = utils.supportsErrorEvent;
+var supportsDOMError = utils.supportsDOMError;
+var supportsDOMException = utils.supportsDOMException;
 var wrappedCallback = utils.wrappedCallback;
 var joinRegExp = utils.joinRegExp;
 var objectMerge = utils.objectMerge;
@@ -109,6 +113,24 @@ describe('utils', function() {
       it('should work as advertised', function() {
         assert.isFalse(isErrorEvent(new Error()));
         assert.isTrue(isErrorEvent(new ErrorEvent('')));
+      });
+    });
+  }
+
+  if (supportsDOMError()) {
+    describe('isDOMError', function() {
+      it('should work as advertised', function() {
+        assert.isFalse(isDOMError(new Error()));
+        assert.isTrue(isDOMError(new DOMError('')));
+      });
+    });
+  }
+
+  if (supportsDOMException()) {
+    describe('isDOMException', function() {
+      it('should work as advertised', function() {
+        assert.isFalse(isDOMException(new Error()));
+        assert.isTrue(isDOMException(new DOMException('')));
       });
     });
   }


### PR DESCRIPTION
Ref: https://github.com/getsentry/raven-js/issues/939

There's not much we can do here really, as those are legacy APIs that doesn't provide any useful information anyway.

https://developer.mozilla.org/en-US/docs/Web/API/DOMError
https://developer.mozilla.org/en-US/docs/Web/API/DOMException