### PR TITLE
feat(node): Add a dirty version of transports

### DIFF
--- a/packages/node/src/backend.ts
+++ b/packages/node/src/backend.ts
@@ -1,6 +1,12 @@
 import { Backend, Frontend, Options, SentryError } from '@sentry/core';
 import { addBreadcrumb, captureEvent, SentryEvent } from '@sentry/shim';
-import { Raven, SendMethod } from './raven';
+import {
+  HTTPSTransport,
+  HTTPTransport,
+  Raven,
+  SendMethod,
+  Transport,
+} from './raven';
 
 /** Original Raven send function. */
 const sendRavenEvent = Raven.send.bind(Raven) as SendMethod;
@@ -130,5 +136,25 @@ export class NodeBackend implements Backend {
    */
   public storeContext(): boolean {
     return true;
+  }
+
+  /**
+   * Set the transport module used for submitting events.
+   *
+   * This can be set to modules like "http" or "https" or any other object that
+   * provides a `request` method with options.
+   *
+   * @param transport The transport to use for submitting events.
+   */
+  public setTransport(transport: Transport): void {
+    const dsn = this.frontend.getDSN();
+    if (!dsn) {
+      return;
+    }
+
+    Raven.transport =
+      dsn.protocol === 'http'
+        ? new HTTPTransport({ transport })
+        : new HTTPSTransport({ transport });
   }
 }

--- a/packages/node/src/raven.ts
+++ b/packages/node/src/raven.ts
@@ -3,6 +3,21 @@ import * as RavenNode from 'raven';
 
 export type SendMethod = (event: SentryEvent, cb?: (err: any) => void) => void;
 
+/** A HTTP transport module. */
+export interface Transport {
+  request(options: object | string): void;
+}
+
+/** A Raven transport wrapper. */
+export interface RavenTransport {
+  send(): void;
+}
+
+/** A constructor class that creates a RavenTransport. */
+export interface TransportClass {
+  new (options: { transport: Transport }): RavenTransport;
+}
+
 /** Provides access to internal raven functionality. */
 export interface RavenInternal {
   captureBreadcrumb(breadcrumb: Breadcrumb): void;
@@ -11,9 +26,19 @@ export interface RavenInternal {
   config(dsn: string, options: object): RavenInternal;
   install(onFatalError?: (error: Error) => void): void;
   send: SendMethod;
+  transport: RavenTransport;
   version: string;
 }
 
 /** Casted raven instance with access to internal functions. */
 // tslint:disable-next-line:variable-name
 export const Raven: RavenInternal = RavenNode as any;
+
+/** Interface for transports exported by RavenNode. */
+interface Transports {
+  HTTPSTransport: TransportClass;
+  HTTPTransport: TransportClass;
+}
+
+export const { HTTPSTransport, HTTPTransport } = (RavenNode as any)
+  .transports as Transports;


### PR DESCRIPTION
This adds an internal method `NodeBackend.setTransport` that can take any module or object that looks like the `http` object. This is actually required by https://github.com/getsentry/sentry-electron/issues/73 to use the `electron.net` module instead of node's own http implementation. 

Since we do not have a clear design specification for transports yet, this API should be considered internal for now.

**Details**

Usually, we would add a `transport` option to the SDKs, just like raven-node and raven-js already have it. However, this approach would have two significant drawbacks:

 1. There is no way we can set an option in the Electron frontend which will **only** be used by the Node backend and not by the Browser backend (actually, there is one, but it is super dirty).
 2. I do not want to export Raven's transport interface to the "user" just now. The interface seems like the wrong layer of abstraction.

Instead, we can now manually set a transport to the backend instance directly using the `setTransport` setter. It needs to implement the exact signature of [http.request](https://nodejs.org/api/http.html#http_http_request_options_callback). 

For an example, have a look at [ElectronBackend](https://github.com/getsentry/sentry-electron/blob/d1778b135b0ee2215d565eb1b7eab0ec710864e0/src/backend.ts#L394-L400).