### PR TITLE
ref: Emit transaction instead of culprit

### DIFF
--- a/plugins/react-native.js
+++ b/plugins/react-native.js
@@ -218,7 +218,7 @@ reactNativePlugin._transport = function(options) {
 };
 
 /**
- * Strip device-specific IDs found in culprit and frame filenames
+ * Strip device-specific IDs found in transaction and frame filenames
  * when running React Native applications on a physical device.
  */
 reactNativePlugin._normalizeData = function(data, pathStripRe) {
@@ -228,6 +228,10 @@ reactNativePlugin._normalizeData = function(data, pathStripRe) {
 
   if (data.culprit) {
     data.culprit = normalizeUrl(data.culprit, pathStripRe);
+  }
+
+  if (data.transaction) {
+    data.transaction = normalizeUrl(data.transaction, pathStripRe);
   }
 
   // NOTE: if data.exception exists, exception.values and exception.values[0] are

--- a/src/raven.js
+++ b/src/raven.js
@@ -49,7 +49,11 @@ function now() {
 var _window =
   typeof window !== 'undefined'
     ? window
-    : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+    : typeof global !== 'undefined'
+      ? global
+      : typeof self !== 'undefined'
+        ? self
+        : {};
 var _document = _window.document;
 var _navigator = _window.navigator;
 
@@ -1695,7 +1699,7 @@ Raven.prototype = {
             }
           ]
         },
-        culprit: fileurl
+        transaction: fileurl
       },
       options
     );
@@ -1810,7 +1814,7 @@ Raven.prototype = {
     if (
       !last ||
       current.message !== last.message || // defined for captureMessage
-      current.culprit !== last.culprit // defined for captureException/onerror
+      current.transaction !== last.transaction // defined for captureException/onerror
     )
       return false;
 

--- a/test/plugins/angular.test.js
+++ b/test/plugins/angular.test.js
@@ -15,7 +15,7 @@ describe('Angular plugin', function() {
         logger: 'javascript',
         platform: 'javascript',
 
-        culprit: 'http://example.org/app.js',
+        transaction: 'http://example.org/app.js',
         message: 'Error: crap',
         exception: {
           type: 'Error',
@@ -50,7 +50,7 @@ describe('Angular plugin', function() {
         logger: 'javascript',
         platform: 'javascript',
 
-        culprit: 'http://example.org/app.js',
+        transaction: 'http://example.org/app.js',
         message: 'Error: crap',
         exception: {
           type: 'Error',

--- a/test/plugins/react-native.test.js
+++ b/test/plugins/react-native.test.js
@@ -136,6 +136,128 @@ describe('React Native plugin', function() {
       assert.equal(frames[0].filename, '/file1.js');
       assert.equal(frames[1].filename, '/file2.js');
     });
+
+    it('should normalize transaction and frame filenames/URLs from .app directory', function() {
+      var data = {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+
+        transaction:
+          'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/app.js',
+        message: 'Error: crap',
+        exception: {
+          type: 'Error',
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'file:///var/containers/Bundle/Application/ABC/123.app/file1.js',
+                    lineno: 10,
+                    colno: 11,
+                    function: 'broken'
+                  },
+                  {
+                    filename:
+                      'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/file2.js',
+                    lineno: 12,
+                    colno: 13,
+                    function: 'lol'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      };
+      reactNativePlugin._normalizeData(data);
+
+      assert.equal(data.transaction, '/app.js');
+      var frames = data.exception.values[0].stacktrace.frames;
+      assert.equal(frames[0].filename, '/file1.js');
+      assert.equal(frames[1].filename, '/file2.js');
+    });
+
+    it('should normalize transaction and frame filenames/URLs from stacktrace interface', function() {
+      var data = {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+
+        transaction:
+          'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/app.js',
+        message: 'Error: crap',
+
+        stacktrace: {
+          frames: [
+            {
+              filename: 'file:///var/containers/Bundle/Application/ABC/123.app/file1.js',
+              lineno: 10,
+              colno: 11,
+              function: 'broken'
+            },
+            {
+              filename:
+                'file:///var/mobile/Containers/Bundle/Application/ABC/123.app/file2.js',
+              lineno: 12,
+              colno: 13,
+              function: 'lol'
+            }
+          ]
+        }
+      };
+      reactNativePlugin._normalizeData(data);
+
+      assert.equal(data.transaction, '/app.js');
+      var frames = data.stacktrace.frames;
+      assert.equal(frames[0].filename, '/file1.js');
+      assert.equal(frames[1].filename, '/file2.js');
+    });
+
+    it('should normalize transaction and frame filenames/URLs from CodePush', function() {
+      var data = {
+        project: '2',
+        logger: 'javascript',
+        platform: 'javascript',
+
+        transaction:
+          'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/app.js',
+        message: 'Error: crap',
+        exception: {
+          type: 'Error',
+          values: [
+            {
+              stacktrace: {
+                frames: [
+                  {
+                    filename:
+                      'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/file1.js',
+                    lineno: 10,
+                    colno: 11,
+                    function: 'broken'
+                  },
+                  {
+                    filename:
+                      'file:///var/mobile/Containers/Data/Application/ABC/Library/Application%20Support/CodePush/CDE/CodePush/file2.js',
+                    lineno: 12,
+                    colno: 13,
+                    function: 'lol'
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      };
+      reactNativePlugin._normalizeData(data);
+
+      assert.equal(data.transaction, '/app.js');
+      var frames = data.exception.values[0].stacktrace.frames;
+      assert.equal(frames[0].filename, '/file1.js');
+      assert.equal(frames[1].filename, '/file2.js');
+    });
   });
 
   describe('_transport()', function() {

--- a/test/raven.test.js
+++ b/test/raven.test.js
@@ -648,7 +648,7 @@ describe('globals', function() {
               }
             ]
           },
-          culprit: 'http://example.com/file1.js'
+          transaction: 'http://example.com/file1.js'
         }
       ]);
 
@@ -666,7 +666,7 @@ describe('globals', function() {
               }
             ]
           },
-          culprit: 'http://example.com/file1.js'
+          transaction: 'http://example.com/file1.js'
         }
       ]);
 
@@ -686,7 +686,7 @@ describe('globals', function() {
               }
             ]
           },
-          culprit: 'http://example.com/file1.js',
+          transaction: 'http://example.com/file1.js',
           extra: 'awesome'
         }
       ]);
@@ -722,7 +722,7 @@ describe('globals', function() {
               }
             ]
           },
-          culprit: 'http://example.com/override.js'
+          transaction: 'http://example.com/override.js'
         }
       ]);
 
@@ -753,7 +753,7 @@ describe('globals', function() {
               }
             ]
           },
-          culprit: 'http://example.com/override.js'
+          transaction: 'http://example.com/override.js'
         }
       ]);
 
@@ -779,7 +779,7 @@ describe('globals', function() {
               }
             ]
           },
-          culprit: 'http://example.com/override.js',
+          transaction: 'http://example.com/override.js',
           extra: 'awesome'
         }
       ]);
@@ -2071,7 +2071,7 @@ describe('globals', function() {
                         pre_context: ['line4']
                     }]
                 },
-                culprit: 'http://example.com',
+                transaction: 'http://example.com',
                 message: 'Error: pickleRick',
                 foo: 'bar'
             }]);
@@ -3805,7 +3805,7 @@ describe('Raven (private methods)', function() {
     describe('from captureException/onerror', function() {
       beforeEach(function() {
         Raven._lastData = {
-          culprit: 'https://example.com/js/foo.js',
+          transaction: 'https://example.com/js/foo.js',
           exception: {
             type: 'TypeError',
             value: 'foo is not defined',
@@ -3834,7 +3834,7 @@ describe('Raven (private methods)', function() {
 
       it('should return false for different exceptions', function() {
         var data = JSON.parse(JSON.stringify(Raven._lastData)); // copy
-        data.culprit = 'https://example.com/js/bar.js';
+        data.transaction = 'https://example.com/js/bar.js';
         assert.isFalse(Raven._isRepeatData(data));
 
         data = JSON.parse(JSON.stringify(Raven._lastData)); // copy


### PR DESCRIPTION
By default, we emit a `transaction` now instead of the culprit. In ReactNative,
we still normalize both, depending on what the user has set.