### PR TITLE
fix(utils): Ignore errors during store flush

### DIFF
--- a/packages/utils/src/store.ts
+++ b/packages/utils/src/store.ts
@@ -83,6 +83,10 @@ export class Store<T> {
     try {
       mkdirpSync(dirname(this.path));
       writeFileSync(this.path, JSON.stringify(this.data));
+    } catch (e) {
+      // This usually fails due to anti virus scanners, issues in the file
+      // system, or problems with network drives. We cannot fix or handle this
+      // issue and must resume gracefully. Thus, we have to ignore this error.
     } finally {
       this.flushing = false;
     }


### PR DESCRIPTION
`Store.flush()` might have failed when an anti virus interferes or there is a problem with the file system. However, `flush` is usually executed in a `setImmediate` callback, which cannot throw exceptions. For that reasons, we need to ignore errors ignoring during this flush.

Once we have proper logging set up, we send this error to our log stream.