### PR TITLE
docs: async loader

### DIFF
--- a/loader.js
+++ b/loader.js
@@ -1,0 +1,99 @@
+(function(
+  _window,
+  _document,
+  _script,
+  _onerror,
+  _onunhandledrejection,
+  _url,
+  _dsn,
+  _config
+) {
+  // Create a namespace and attach function that will store captured exception
+  // Because functions are also objects, we can attach the queue itself straight to it and save some bytes
+  var queue = function(exception) {
+    (queue.data = queue.data || []).push(exception);
+  };
+
+  // Store reference to the old `onerror` handler and override it with our own function
+  // that will just push exceptions to the queue and call through old handler if we found one
+  var _oldOnerror = _window[_onerror];
+  _window[_onerror] = function(message, source, lineno, colno, exception) {
+    // Use keys as "data type" to save some characters"
+    queue({
+      e: [].slice.call(arguments)
+    });
+
+    if (_oldOnerror) _oldOnerror.apply(_window, arguments);
+  };
+
+  // Do the same store/queue/call operations for `onunhandledrejection` event
+  var _oldOnunhandledrejection = _window[_onunhandledrejection];
+  _window[_onunhandledrejection] = function(exception) {
+    queue({
+      p: exception.reason
+    });
+    if (_oldOnunhandledrejection)
+      _oldOnunhandledrejection.apply(_window, arguments);
+  };
+
+  // Create a `script` tag with provided SDK `url` and attach it just before the first, already existing `script` tag
+  // Scripts that are dynamically created and added to the document are async by default,
+  // they don't block rendering and execute as soon as they download, meaning they could
+  // come out in the wrong order. Because of that we don't need async=1 as GA does.
+  // it was probably(?) a legacy behavior that they left to not modify few years old snippet
+  // https://www.html5rocks.com/en/tutorials/speed/script-loading/
+  var _currentScriptTag = _document.getElementsByTagName(_script)[0];
+  var _newScriptTag = _document.createElement(_script);
+  _newScriptTag.src = _url;
+  _newScriptTag.crossorigin = "anonymous";
+
+  // Once our SDK is loaded
+  _newScriptTag.addEventListener("load", function() {
+    try {
+      // Restore onerror/onunhandledrejection handlers
+      _window[_onerror] = _oldOnerror;
+      _window[_onunhandledrejection] = _oldOnunhandledrejection;
+
+      var data = queue.data;
+      var SDK = _window.Raven;
+      // Configure it using provided DSN and config object
+      SDK.config(_dsn, _config).install();
+      // Because we installed the SDK, at this point we have an access to TraceKit's handler,
+      // which can take care of browser differences (eg. missing exception argument in onerror)
+      var tracekitErrorHandler = _window[_onerror];
+
+      // And capture all previously caught exceptions
+      if (data.length) {
+        for (var i = 0; i < data.length; i++) {
+          if (data[i].e) {
+            tracekitErrorHandler.apply(SDK.TraceKit, data[i].e);
+          } else if (data[i].p) {
+            SDK.captureException(data[i].p);
+          }
+        }
+      }
+    } catch (o_O) {
+      console.log(o_O);
+    }
+  });
+
+  _currentScriptTag.parentNode.insertBefore(_newScriptTag, _currentScriptTag);
+})(
+  // predefined references, that should never be changed
+  window,
+  document,
+  "script",
+  "onerror",
+  "onunhandledrejection",
+  // URL to the SDK
+  "https://cdn.ravenjs.com/3.23.2/raven.js",
+  // DSN
+  "https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378",
+  // SDK Options
+  {
+    dataCallback: function(data) {
+      console.log(data);
+      return data;
+    }
+  }
+);


### PR DESCRIPTION
I'm still not sure how we should approach passing CDN/DSN url and Raven configs.

As last arguments to the snippet?

```js
<script>
(function () { ...snippet code... }(
  'http://sdk.url',
  'http://cdn.url',
  { options }
))
</script>
```

As global variables with predefined names?

```js
<script>
var RAVEN_CDN = 'http://sdk.url';
var RAVEN_DSN = 'http://cdn.url';
var RAVEN_OPTIONS = { options };
(function () { ...snippet code... }())
</script>
```

Also, it looks kinda big, even when compiled with closure compiler.

```js
function(a,b,g,e,h,n,p,q){function f(a){(f.data=f.data||[]).push(a)}var k=a[e];a[e]=function(c,b,e,d,h){f({e:[].slice.call(arguments)});k&&k.apply(a,arguments)};var l=a[h];a[h]=function(c){f({p:c.reason});l&&l.apply(a,arguments)};var m=b.getElementsByTagName(g)[0];b=b.createElement(g);b.src=n;b.g="anonymous";b.addEventListener("load",function(){try{a[e]=k;a[h]=l;var c=f.data,b=a.a;b.f(p,q).install();var g=a[e];if(c.length)for(var d=0;d<c.length;d++)c[d].e?g.apply(b.b,c[d].e):c[d].p&&b.c(c[d].p)}catch(r){console.log(r)}});
m.parentNode.insertBefore(b,m)})(window,document,"script","onerror","onunhandledrejection","https://cdn.ravenjs.com/3.23.2/raven.js","https://363a337c11a64611be4845ad6e24f3ac@sentry.io/297378",{h:function(a){console.log(a);return a}});
```

It's also hard to predict whether I covered all the edge cases (eg. I found out that I had to do things like on L63, as some browsers doesn't provide last argument to onerror functions).