### PR TITLE
null check stacks in isSameStacktrace

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,11 @@ var stringify = require('../vendor/json-stringify-safe/stringify');
 var _window =
   typeof window !== 'undefined'
     ? window
-    : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+    : typeof global !== 'undefined'
+      ? global
+      : typeof self !== 'undefined'
+        ? self
+        : {};
 
 function isObject(what) {
   return typeof what === 'object' && what !== null;
@@ -416,6 +420,9 @@ function isSameStacktrace(stack1, stack2) {
 
   var frames1 = stack1.frames;
   var frames2 = stack2.frames;
+
+  // Exit early if stacktrace is malformed
+  if (frames1 === undefined || frames2 === undefined) return false;
 
   // Exit early if frame count differs
   if (frames1.length !== frames2.length) return false;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -26,6 +26,7 @@ var truncate = utils.truncate;
 var urlencode = utils.urlencode;
 var htmlTreeAsString = utils.htmlTreeAsString;
 var htmlElementAsString = utils.htmlElementAsString;
+var isSameStacktrace = utils.isSameStacktrace;
 var parseUrl = utils.parseUrl;
 var safeJoin = utils.safeJoin;
 var serializeException = utils.serializeException;
@@ -370,6 +371,17 @@ describe('utils', function() {
         }),
         'input#the-username[name="username"]'
       );
+    });
+  });
+
+  describe('isSameStacktrace', function() {
+    it('does not fail if frames are not present', function() {
+      var validStack = {frames: []};
+      var invalidStack = {};
+      var invalidResult = isSameStacktrace(validStack, invalidStack);
+      assert.equal(invalidResult, false);
+      invalidResult = isSameStacktrace(invalidStack, validStack);
+      assert.equal(invalidResult, false);
     });
   });
 


### PR DESCRIPTION
# Description
Some libraries, such as Mapbox, throw errors that are malformed. They don't have the frames variable, which get used in "_isRepeatData".

This causes Raven.captureException to fail on the second call, on _isRepeatData when deduping errors. This is particularly nasty because it's occurring in the catch part of a try / catch.

Sample code:
```
    try {
      const attemptedMap = new mapboxgl.Map({
        container: this.mapRef.current,
        style: this.getMapStyle(),
        center: initialCenter,
        zoom: initialZoom,
      });
 } catch (e) {
      // error thrown here
      Raven.captureException(e, {
        level: "warning",
        stacktrace: true});
}
```

Exception seen in FullStory:
```
TypeError: Cannot read property 'length' of undefined at d (vendor.bd501d31eb3dbf1fd2b5.js:23:30798) at s._isRepeatData (vendor.bd501d31eb3dbf1fd2b5.js:23:25059) at s._sendProcessedPayload (vendor.bd501d31eb3dbf1fd2b5.js:23:26662) at s._send (vendor.bd501d31eb3dbf1fd2b5.js:23:26417) at s._processException 
```

I'm not sure what the preferred behavior is here (returning true or false), but it strikes me that returning false is safer.

Appreciate any feedback, thanks!