### PR TITLE
Added error console logging outside of production

### DIFF
--- a/docs/integrations/angular.rst
+++ b/docs/integrations/angular.rst
@@ -62,6 +62,7 @@ Then, in your main module file (where ``@NgModule`` is called, e.g. app.module.t
     import { BrowserModule } from '@angular/platform-browser';
     import { NgModule, ErrorHandler } from '@angular/core';
     import { AppComponent } from './app.component';
+    import { environment } from '../environments/environment';
 
     Raven
       .config('___PUBLIC_DSN___')
@@ -70,6 +71,9 @@ Then, in your main module file (where ``@NgModule`` is called, e.g. app.module.t
     export class RavenErrorHandler implements ErrorHandler {
       handleError(err:any) : void {
         Raven.captureException(err.originalError || err);
+        if(!environment.production) {
+          super.handleError(err);
+        }
       }
     }
 


### PR DESCRIPTION
Without calling `super.handleError(err)`, Raven swallows the error without any indication for debugging in development environments


Before submitting a pull request, please verify the following:

* [X] If you've added code that should be tested, please add tests.
* [X] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [X] Ensure your code lints and the test suite passes (npm test).
