### PR TITLE
add support for injecting response header into error

### DIFF
--- a/src/raven.js
+++ b/src/raven.js
@@ -1314,6 +1314,17 @@ Raven.prototype = {
                   // touching statusCode in some platforms throws
                   // an exception
                   xhr.__raven_xhr.status_code = xhr.status;
+                  // inject response header parameters
+                  if (isFunction(self._globalOptions.injectResponseHeader)) {
+                    var injections = self._globalOptions.injectResponseHeader(xhr.getAllResponseHeaders());
+                    if (injections) {
+                      for (var i in injections) {
+                        if (injections.hasOwnProperty(i)) {
+                          xhr.__raven_xhr[i] = injections[i];
+                        }
+                      }
+                    }
+                  }
                 } catch (e) {
                   /* do nothing */
                 }
@@ -1400,6 +1411,17 @@ Raven.prototype = {
               .apply(this, args)
               .then(function(response) {
                 fetchData.status_code = response.status;
+                // inject response header parameters
+                if (isFunction(self._globalOptions.injectResponseHeader)) {
+                  var injections = self._globalOptions.injectResponseHeader(response.headers);
+                  if (injections) {
+                    for (var i in injections) {
+                      if (injections.hasOwnProperty(i)) {
+                        fetchData[i] = injections[i];
+                      }
+                    }
+                  }
+                }
 
                 self.captureBreadcrumb({
                   type: 'http',


### PR DESCRIPTION
sometimes, we need to track an asynchronous request log based on some parameters, such as `request-id`, and usually `request-id` is attached to the reponse header, if there is a hook can be used will be good, for example, the following usage
**in config**
```javascript
Raven.config('project dsn', {
    injectResponseHeader: headers => {
        // if some paramters exist
        if (headers.has('request-id')) {
        // return paramters that need to be injected
            return {
                'request_id': headers .get('request-id')
            }
        }
    }
})
```
**display**

![image](https://user-images.githubusercontent.com/2277716/40709128-d7b42e98-6427-11e8-8549-6878b339a14d.png)
then we can find out all server logs for this request id soon
