### PR TITLE
fix: Fallback to <anonymous> handler name in mechanism

### DIFF
--- a/packages/raven-js/src/raven.js
+++ b/packages/raven-js/src/raven.js
@@ -49,11 +49,7 @@ function now() {
 var _window =
   typeof window !== 'undefined'
     ? window
-    : typeof global !== 'undefined'
-      ? global
-      : typeof self !== 'undefined'
-        ? self
-        : {};
+    : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
 var _document = _window.document;
 var _navigator = _window.navigator;
 
@@ -1116,7 +1112,7 @@ Raven.prototype = {
             {
               mechanism: {
                 type: 'instrument',
-                data: {function: orig.name}
+                data: {function: orig.name || '<anonymous>'}
               }
             },
             originalCallback
@@ -1785,10 +1781,13 @@ Raven.prototype = {
       delete data.mechanism;
     }
 
-    data.exception.mechanism = objectMerge(data.exception.mechanism || {}, {
-      type: 'generic',
-      handled: true
-    });
+    data.exception.mechanism = objectMerge(
+      {
+        type: 'generic',
+        handled: true
+      },
+      data.exception.mechanism || {}
+    );
 
     // Fire away!
     this._send(data);

--- a/packages/raven-js/src/raven.js
+++ b/packages/raven-js/src/raven.js
@@ -49,7 +49,11 @@ function now() {
 var _window =
   typeof window !== 'undefined'
     ? window
-    : typeof global !== 'undefined' ? global : typeof self !== 'undefined' ? self : {};
+    : typeof global !== 'undefined'
+      ? global
+      : typeof self !== 'undefined'
+        ? self
+        : {};
 var _document = _window.document;
 var _navigator = _window.navigator;
 
@@ -1147,7 +1151,11 @@ Raven.prototype = {
                     {
                       mechanism: {
                         type: 'instrument',
-                        data: {target: global, function: 'handleEvent', handler: fn.name}
+                        data: {
+                          target: global,
+                          function: 'handleEvent',
+                          handler: (fn && fn.name) || '<anonymous>'
+                        }
                       }
                     },
                     fn.handleEvent
@@ -1198,7 +1206,7 @@ Raven.prototype = {
                       data: {
                         target: global,
                         function: 'addEventListener',
-                        handler: fn.name
+                        handler: (fn && fn.name) || '<anonymous>'
                       }
                     }
                   },
@@ -1243,7 +1251,10 @@ Raven.prototype = {
                 {
                   mechanism: {
                     type: 'instrument',
-                    data: {function: 'requestAnimationFrame', handler: orig.name}
+                    data: {
+                      function: 'requestAnimationFrame',
+                      handler: (orig && orig.name) || '<anonymous>'
+                    }
                   }
                 },
                 cb
@@ -1315,7 +1326,7 @@ Raven.prototype = {
             {
               mechanism: {
                 type: 'instrument',
-                data: {function: prop, handler: orig.name}
+                data: {function: prop, handler: (orig && orig.name) || '<anonymous>'}
               }
             },
             orig
@@ -1390,7 +1401,7 @@ Raven.prototype = {
                         type: 'instrument',
                         data: {
                           function: 'onreadystatechange',
-                          handler: orig.name
+                          handler: (orig && orig.name) || '<anonymous>'
                         }
                       }
                     },

--- a/packages/raven-js/test/integration/test.js
+++ b/packages/raven-js/test/integration/test.js
@@ -94,9 +94,7 @@ describe('integration', function() {
       );
     });
 
-    it('should generate a synthetic trace for captureException w/ non-errors', function(
-      done
-    ) {
+    it('should generate a synthetic trace for captureException w/ non-errors', function(done) {
       var iframe = this.iframe;
       iframeExecute(
         iframe,
@@ -114,9 +112,7 @@ describe('integration', function() {
       );
     });
 
-    it('should capture an Error object passed to Raven.captureException w/ maxMessageLength set (#647)', function(
-      done
-    ) {
+    it('should capture an Error object passed to Raven.captureException w/ maxMessageLength set (#647)', function(done) {
       var iframe = this.iframe;
       iframeExecute(
         iframe,
@@ -185,9 +181,7 @@ describe('integration', function() {
       );
     });
 
-    it('should not reject back-to-back errors with different stack traces', function(
-      done
-    ) {
+    it('should not reject back-to-back errors with different stack traces', function(done) {
       var iframe = this.iframe;
       iframeExecute(
         iframe,
@@ -236,9 +230,7 @@ describe('integration', function() {
       );
     });
 
-    it('should reject duplicate, back-to-back messages from captureMessage', function(
-      done
-    ) {
+    it('should reject duplicate, back-to-back messages from captureMessage', function(done) {
       var iframe = this.iframe;
       iframeExecute(
         iframe,
@@ -435,9 +427,7 @@ describe('integration', function() {
       );
     });
 
-    it('should catch an exception already caught [but rethrown] via Raven.captureException', function(
-      done
-    ) {
+    it('should catch an exception already caught [but rethrown] via Raven.captureException', function(done) {
       // unlike Raven.wrap which ALWAYS re-throws, we don't know if the user will
       // re-throw an exception passed to Raven.captureException, and so we cannot
       // automatically suppress the next error caught through window.onerror
@@ -493,9 +483,7 @@ describe('integration', function() {
       );
     });
 
-    it('should transparently remove event listeners from wrapped functions', function(
-      done
-    ) {
+    it('should transparently remove event listeners from wrapped functions', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(
@@ -585,9 +573,7 @@ describe('integration', function() {
       );
     });
 
-    it('should capture exceptions from XMLHttpRequest event handlers (e.g. onreadystatechange)', function(
-      done
-    ) {
+    it('should capture exceptions from XMLHttpRequest event handlers (e.g. onreadystatechange)', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(
@@ -615,6 +601,103 @@ describe('integration', function() {
           // # of frames alter significantly between chrome/firefox & safari
           assert.isAtLeast(ravenData.exception.values[0].stacktrace.frames.length, 3);
           assert.isAtMost(ravenData.exception.values[0].stacktrace.frames.length, 4);
+        }
+      );
+    });
+
+    it("should capture built-in's mechanism type as instrument", function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(function() {
+            setTimeout(done);
+            foo();
+          }, 10);
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.deepEqual(ravenData.exception.mechanism, {
+            type: 'instrument',
+            handled: true,
+            data: {function: 'setTimeout'}
+          });
+        }
+      );
+    });
+
+    it("should capture built-in's handlers fn name in mechanism data", function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          var div = document.createElement('div');
+          document.body.appendChild(div);
+          div.addEventListener(
+            'click',
+            function namedFunction() {
+              foo();
+            },
+            false
+          );
+
+          var click = new MouseEvent('click');
+          div.dispatchEvent(click);
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.deepEqual(ravenData.exception.mechanism, {
+            type: 'instrument',
+            handled: true,
+            data: {
+              function: 'addEventListener',
+              handler: 'namedFunction',
+              target: 'EventTarget'
+            }
+          });
+        }
+      );
+    });
+
+    it('should fallback to <anonymous> fn name in mechanism data if one is unavailable', function(done) {
+      var iframe = this.iframe;
+
+      iframeExecute(
+        iframe,
+        done,
+        function() {
+          setTimeout(done);
+
+          var div = document.createElement('div');
+          document.body.appendChild(div);
+          div.addEventListener(
+            'click',
+            function() {
+              foo();
+            },
+            false
+          );
+
+          var click = new MouseEvent('click');
+          div.dispatchEvent(click);
+        },
+        function() {
+          var ravenData = iframe.contentWindow.ravenData[0];
+          assert.deepEqual(ravenData.exception.mechanism, {
+            type: 'instrument',
+            handled: true,
+            data: {
+              function: 'addEventListener',
+              handler: '<anonymous>',
+              target: 'EventTarget'
+            }
+          });
         }
       );
     });
@@ -689,9 +772,7 @@ describe('integration', function() {
       );
     });
 
-    it('should NOT denote XMLHttpRequests to the Sentry store endpoint as requiring breadcrumb capture', function(
-      done
-    ) {
+    it('should NOT denote XMLHttpRequests to the Sentry store endpoint as requiring breadcrumb capture', function(done) {
       var iframe = this.iframe;
       iframeExecute(
         iframe,
@@ -762,9 +843,7 @@ describe('integration', function() {
       );
     });
 
-    it('should record a fetch request with Request obj instead of URL string', function(
-      done
-    ) {
+    it('should record a fetch request with Request obj instead of URL string', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(
@@ -864,9 +943,7 @@ describe('integration', function() {
       );
     });
 
-    it('should record a mouse click on element WITH click handler present', function(
-      done
-    ) {
+    it('should record a mouse click on element WITH click handler present', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(
@@ -906,9 +983,7 @@ describe('integration', function() {
       );
     });
 
-    it('should record a mouse click on element WITHOUT click handler present', function(
-      done
-    ) {
+    it('should record a mouse click on element WITHOUT click handler present', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(
@@ -940,9 +1015,7 @@ describe('integration', function() {
       );
     });
 
-    it('should only record a SINGLE mouse click for a tree of elements with event listeners', function(
-      done
-    ) {
+    it('should only record a SINGLE mouse click for a tree of elements with event listeners', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(
@@ -982,9 +1055,7 @@ describe('integration', function() {
       );
     });
 
-    it('should bail out if accessing the `type` and `target` properties of an event throw an exception', function(
-      done
-    ) {
+    it('should bail out if accessing the `type` and `target` properties of an event throw an exception', function(done) {
       // see: https://github.com/getsentry/raven-js/issues/768
       var iframe = this.iframe;
 
@@ -1019,9 +1090,7 @@ describe('integration', function() {
       );
     });
 
-    it('should record consecutive keypress events into a single "input" breadcrumb', function(
-      done
-    ) {
+    it('should record consecutive keypress events into a single "input" breadcrumb', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(
@@ -1092,9 +1161,7 @@ describe('integration', function() {
       );
     });
 
-    it('should flush keypress breadcrumb when input event occurs immediately after', function(
-      done
-    ) {
+    it('should flush keypress breadcrumb when input event occurs immediately after', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(
@@ -1146,9 +1213,7 @@ describe('integration', function() {
       );
     });
 
-    it('should record consecutive keypress events in a contenteditable into a single "input" breadcrumb', function(
-      done
-    ) {
+    it('should record consecutive keypress events in a contenteditable into a single "input" breadcrumb', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(
@@ -1183,9 +1248,7 @@ describe('integration', function() {
       );
     });
 
-    it('should record history.[pushState|replaceState] changes as navigation breadcrumbs', function(
-      done
-    ) {
+    it('should record history.[pushState|replaceState] changes as navigation breadcrumbs', function(done) {
       var iframe = this.iframe;
 
       iframeExecute(


### PR DESCRIPTION
Fixes: #1358
Fixes: #1361
Completely forgot that anonymous functions have no names... We use `<unknown>` for html elements, so `<anonymous>` sounds like a good name.