### PR TITLE
Fix `config` typings

### DIFF
--- a/packages/raven-js/typescript/raven-tests.ts
+++ b/packages/raven-js/typescript/raven-tests.ts
@@ -22,6 +22,9 @@ var options: Raven.RavenOptions = {
 };
 
 Raven.config('https://public@sentry.io/1', options).install();
+Raven.config(false);
+Raven.config(null);
+Raven.config(undefined);
 
 var throwsError = () => {
   throw new Error('broken');

--- a/packages/raven-js/typescript/raven.d.ts
+++ b/packages/raven-js/typescript/raven.d.ts
@@ -145,7 +145,7 @@ declare namespace Raven {
         * @param {object} options Optional set of global options [optional]
         * @return {Raven}
         */
-    config(dsn: string, options?: RavenOptions): RavenStatic;
+    config(dsn: string | false | null | undefined, options?: RavenOptions): RavenStatic;
 
     /*
         * Installs a global window.onerror error handler


### PR DESCRIPTION
Before submitting a pull request, please verify the following:

* [x] If you've added code that should be tested, please add tests.
* [ ] If you've modified the API (e.g. added a new config or public method), update the [docs](https://github.com/getsentry/raven-js/tree/master/docs) and TypeScript [declaration file](/getsentry/raven-js/blob/master/typescript/raven.d.ts).
* [x] Ensure your code lints and the test suite passes (npm test).

Hey guys 👋 

I thought I'd provide a pull request for the typings covering the fact that `raven-js` can take a falsy dsn and be disabled, as these lines suggest it in the source code.

https://github.com/getsentry/raven-js/blob/5d12cc1bc92842e3b2a49c64f1d20aaa79a06a8f/packages/raven-js/src/raven.js#L155-L162

Thanks!