### PR TITLE
fix: Attempt to provide some information for <unlabeled event>

### DIFF
--- a/packages/raven-js/package-lock.json
+++ b/packages/raven-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "raven-js",
-  "version": "3.26.0",
+  "version": "3.26.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/packages/raven-js/src/raven.js
+++ b/packages/raven-js/src/raven.js
@@ -616,7 +616,9 @@ Raven.prototype = {
       return;
     }
 
-    if (this._globalOptions.stacktrace || (options && options.stacktrace)) {
+    // Always attempt to get stacktrace if message is empty.
+    // It's the only way to provide any helpful information to the user.
+    if (this._globalOptions.stacktrace || options.stacktrace || data.message === '') {
       // fingerprint on msg, not stack trace (legacy behavior, could be revisited)
       data.fingerprint = data.fingerprint == null ? msg : data.fingerprint;
 
@@ -1772,6 +1774,11 @@ Raven.prototype = {
       },
       options
     );
+
+    var ex = data.exception.values[0];
+    if (ex.type == null && ex.value === '') {
+      ex.value = 'Unrecoverable error caught';
+    }
 
     // Move mechanism from options to exception interface
     // We do this, as requiring user to pass `{exception:{mechanism:{ ... }}}` would be


### PR DESCRIPTION
This one was very tricky to debug and fix. Some details and reasoning behind the fix.

First, there are 3 ways to trigger this issue, so let's go one by one:

```js
captureException('');
captureMessage('');
throw '';
```

## Before

### `captureException('')`

![screen shot 2018-06-15 at 11 55 27](https://user-images.githubusercontent.com/1523305/41462417-14db280e-7093-11e8-90c6-6c3e4a82a275.png)

There's no type and no message, as when a string is passed, it'll fallback to `captureException`. The thing why it's special is that we default to `stracktrace: true` and there's synthetic stack trace created by `new Error('')` which should help a user to debug the issue.

---

### `captureMessage('')`

![screen shot 2018-06-15 at 11 59 07](https://user-images.githubusercontent.com/1523305/41462578-97115b5e-7093-11e8-9fea-a17d1db5b09b.png)

No type, no message, and no stack trace, as we default to `false` when using `captureMessage` directly :(

---

### `throw ''`

![screen shot 2018-06-15 at 12 00 27](https://user-images.githubusercontent.com/1523305/41462642-ca47b39c-7093-11e8-8f33-7f891142139a.png)

No type, no message, no stack trace, and parse error on top of that :(

## After

### `captureException('')`

No changes.

---

### `captureMessage('')`

![screen shot 2018-06-15 at 12 08 31](https://user-images.githubusercontent.com/1523305/41462925-d8cd53bc-7094-11e8-8136-02c3b6b1b8cb.png)

We have a stack trace now \o/

---

### `throw ''`

![screen shot 2018-06-15 at 12 09 43](https://user-images.githubusercontent.com/1523305/41462969-0661ce7a-7095-11e8-8b58-102423ea5054.png)

Overriden type. More reasonable message. No processing error and file, line and column of the main call \o/

## FAQ

- Why it only affects `''`?
Because `null` and `undefined` coerce to their string representation and are valid labels

- Why can we not fix it using synthetic stack traces in TraceKit?
Because by the time `throw ''` reaches global error handler, you cannot `new Error('')` it anymore. It has no data that can be fed to the constructor.

- Are there other ways around if once I find the culprit?
Yes, you can use

```js
Raven.wrap(function () {
   ...your code...
})

// or 

try {
  ...your code...
} catch (e) {
  // Synthetic stack traces are possible in `try/catch` clauses, even with `throw ''` calls
  const ex = new Error(e);
  Raven.captureException(ex);
}
```

Ref: https://github.com/getsentry/raven-js/issues/1271